### PR TITLE
Always render custom result type

### DIFF
--- a/search-parts/src/models/ISearchResult.ts
+++ b/search-parts/src/models/ISearchResult.ts
@@ -1,60 +1,60 @@
 export interface ISearchResults {
-    QueryKeywords: string;
-    PaginationInformation?: IPaginationInformation;
-    RelevantResults: ISearchResult[];
-    RefinementResults: IRefinementResult[];
-    PromotedResults?: IPromotedResult[];
-    SecondaryResults?: ISearchResultBlock[];
-    SpellingSuggestion?: string;
+  QueryKeywords: string;
+  PaginationInformation?: IPaginationInformation;
+  RelevantResults: ISearchResult[];
+  SecondaryResults: ISearchResultBlock[];
+  RefinementResults: IRefinementResult[];
+  PromotedResults?: IPromotedResult[];
+  SpellingSuggestion?: string;
 }
 
 export interface IPaginationInformation {
-    CurrentPage: number;
-    TotalRows: number;
-    MaxResultsPerPage: number;
+  CurrentPage: number;
+  TotalRows: number;
+  MaxResultsPerPage: number;
 }
 
 export interface ISearchVerticalInformation {
-    VerticalKey: string;
-    Count: number;
+  VerticalKey: string;
+  Count: number;
 }
 
 export interface ISearchResult {
-    [key: string]: string;
-    IconSrc?: string;
-    IconExt?: string;
+  [key: string]: string;
+  IconSrc?: string;
+  IconExt?: string;
 }
 
 export interface IRefinementResult {
-    FilterName: string;
-    Values: IRefinementValue[];
+  FilterName: string;
+  Values: IRefinementValue[];
 }
 
 export interface IPromotedResult {
-    Url: string;
-    Title: string;
-    Description: string;
+  Url: string;
+  Title: string;
+  Description: string;
 }
 
 export interface IRefinementValue {
-    RefinementCount: number;
-    RefinementName: string;
-    RefinementToken: string;
-    RefinementValue: string;
+  RefinementCount: number;
+  RefinementName: string;
+  RefinementToken: string;
+  RefinementValue: string;
 }
 
 export interface IRefinementFilter {
-    FilterName: string;
-    Values: IRefinementValue[];
-    Operator: RefinementOperator;
+  FilterName: string;
+  Values: IRefinementValue[];
+  Operator: RefinementOperator;
 }
 
 export enum RefinementOperator {
-    OR = 'or',
-    AND = 'and'
+  OR = 'or',
+  AND = 'and'
 }
 
 export interface ISearchResultBlock {
-  Title: string;
-  Results: ISearchResult[];
+Title: string;
+Results: ISearchResult[];
 }

--- a/search-parts/src/services/SearchService/MockSearchService.ts
+++ b/search-parts/src/services/SearchService/MockSearchService.ts
@@ -51,7 +51,7 @@ class MockSearchService implements ISearchService {
     private _searchResults: ISearchResults;
 
     public constructor() {
-     
+
         this._searchResults = {
             QueryKeywords: "",
             RelevantResults: [
@@ -89,7 +89,7 @@ class MockSearchService implements ISearchService {
                     Author: 'John Doe',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 2',
-                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1"              
+                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1"
                 },
                 {
                     Title: 'Video 1 - Category 1',
@@ -100,7 +100,7 @@ class MockSearchService implements ISearchService {
                     PreviewUrl: 'https://via.placeholder.com/400',
                     Author: 'Aaron Painter',
                     SiteTitle: 'Site 2',
-                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2"                                        
+                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2"
                 },
                 {
                     Title: 'Video 2 - Category 2',
@@ -112,8 +112,8 @@ class MockSearchService implements ISearchService {
                     Author: 'Aaron Painter',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 3',
-                    owstaxidmetadataalltagsinfo: "L0|#01257a103-d2a1-43c4-8c07-6138527a88b7|Tag 3"               
-                },                                   
+                    owstaxidmetadataalltagsinfo: "L0|#01257a103-d2a1-43c4-8c07-6138527a88b7|Tag 3"
+                },
             ],
             RefinementResults: [
                 {
@@ -204,6 +204,7 @@ class MockSearchService implements ISearchService {
                     ]
                 }
             ],
+            SecondaryResults: [],
             PaginationInformation: {
                 TotalRows: 5,
                 CurrentPage: 1,
@@ -225,19 +226,19 @@ class MockSearchService implements ISearchService {
     }
 
     public search(query: string, pageNumber?: number): Promise<ISearchResults> {
-         
+
         const p1 = new Promise<ISearchResults>((resolve) => {
 
             const filters: string[] = [];
             let searchResults = clone(this._searchResults);
             searchResults.QueryKeywords = query;
             const filteredResults: ISearchResult[] = [];
-            
+
             if (this.refinementFilters.length > 0) {
                 this.refinementFilters.map((filter) => {
-                    filters.push(filter.Values[0].RefinementToken);                                                     
+                    filters.push(filter.Values[0].RefinementToken);
                 });
-                
+
                 searchResults.RelevantResults.map((searchResult) => {
                     const filtered = intersection(filters, searchResult.RefinementTokenValues.split(','));
                     if (filtered.length > 0) {
@@ -252,7 +253,7 @@ class MockSearchService implements ISearchService {
             searchResults.PaginationInformation.CurrentPage = pageNumber;
             searchResults.PaginationInformation.TotalRows = searchResults.RelevantResults.length;
             searchResults.PaginationInformation.MaxResultsPerPage = this.resultsCount;
-            
+
             // Return only the specified count
             searchResults.RelevantResults = this._paginate(searchResults.RelevantResults, this.resultsCount, pageNumber);
 
@@ -268,13 +269,13 @@ class MockSearchService implements ISearchService {
     private _paginate (array, pageSize: number, pageNumber: number) {
         let basePage = --pageNumber * pageSize;
 
-        return pageNumber < 0 || pageSize < 1 || basePage >= array.length 
-            ? [] 
+        return pageNumber < 0 || pageSize < 1 || basePage >= array.length
+            ? []
             : array.slice(basePage, basePage + pageSize );
     }
 
     public async suggest(keywords: string): Promise<string[]> {
-       
+
         let proposedSuggestions: string[] = [];
 
         const p1 = new Promise<string[]>((resolve) => {
@@ -290,14 +291,14 @@ class MockSearchService implements ISearchService {
                     proposedSuggestions.push(`${preMatchedText}<B>${matchedText}</B>${postMatchedText}`);
                 }
             });
-            
+
             // Simulate an async call
             setTimeout(() => {
                 resolve(proposedSuggestions);
             }, 100);
 
         });
-        
+
         return p1;
     }
 
@@ -364,14 +365,14 @@ class MockSearchService implements ISearchService {
                 LanguageTag:"en-US",
                 Lcid:1033
             },
-            { 
-                DisplayName: "German", 
-                LanguageTag: "de-DE", 
+            {
+                DisplayName: "German",
+                LanguageTag: "de-DE",
                 Lcid: 1031
             },
             {
-                DisplayName: "French", 
-                LanguageTag: "fr-FR", 
+                DisplayName: "French",
+                LanguageTag: "fr-FR",
                 Lcid: 1036
             },
             {   DisplayName: "Irish",

--- a/search-parts/src/services/SearchService/SearchService.ts
+++ b/search-parts/src/services/SearchService/SearchService.ts
@@ -189,6 +189,7 @@ class SearchService implements ISearchService {
         let results: ISearchResults = {
             QueryKeywords: query,
             RelevantResults: [],
+            SecondaryResults: [],
             RefinementResults: [],
             PaginationInformation: {
                 CurrentPage: pageNumber,

--- a/search-parts/src/templates/layouts/default.html
+++ b/search-parts/src/templates/layouts/default.html
@@ -1,9 +1,15 @@
 <content id="template">
     <style>
         /* Insert your CSS overrides here */
+
+        .noResults {
+            padding: 10px;
+            text-align: center;
+        }
     </style>
 
     <div class="template_root">
+        {{#if items}}
         <ul class="template_defaultList">
             {{#each items as |item|}}
             <li class="template_listItem" tabindex="0">
@@ -30,6 +36,9 @@
             </li>
             {{/each}}
         </ul>
+        {{else}}
+        <div class="noResults">No results to display.</div>
+        {{/if}}
     </div>
 </content>
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -241,6 +241,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
                 webServerRelativeUrl: this.context.pageContext.web.serverRelativeUrl,
                 resultTypes: this.properties.resultTypes,
                 useCodeRenderer: this.codeRendererIsSelected(),
+                isUsingCustomResultTemplate: this.properties.selectedLayout === ResultsLayoutOption.Custom,
                 customTemplateFieldValues: this.properties.customTemplateFieldValues,
                 rendererId: this.properties.selectedLayout as any,
                 enableLocalization: this.properties.enableLocalization,
@@ -359,15 +360,15 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
         // Load extensibility additions
         if (extensibilityLibrary) {
-            
+
             // Add custom web components if any
-            this.availableWebComponentDefinitions = this.availableWebComponentDefinitions.concat(extensibilityLibrary.getCustomWebComponents());          
+            this.availableWebComponentDefinitions = this.availableWebComponentDefinitions.concat(extensibilityLibrary.getCustomWebComponents());
         }
-        
+
         // Set the default search results layout
         this.properties.selectedLayout = (this.properties.selectedLayout !== undefined && this.properties.selectedLayout !== null) ? this.properties.selectedLayout : ResultsLayoutOption.DetailsList;
 
-        // Registers web components 
+        // Registers web components
         this._templateService.registerWebComponents(this.availableWebComponentDefinitions);
 
         this.context.dynamicDataSourceManager.initializeSource(this);
@@ -1546,7 +1547,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
      * @param args The new theme
      */
     private _handleThemeChangedEvent(args: ThemeChangedEventArgs): void {
-        
+
         if (!isEqual(this._themeVariant, args.theme)) {
             this._themeVariant = args.theme;
             this.render();

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/ISearchResultsContainerProps.ts
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/ISearchResultsContainerProps.ts
@@ -50,7 +50,7 @@ interface ISearchResultsContainerProps {
      */
     showBlank: boolean;
 
-    /** 
+    /**
      * The current display mode of Web Part
      */
     displayMode: DisplayMode;
@@ -60,7 +60,7 @@ interface ISearchResultsContainerProps {
      */
     templateService: TemplateService;
 
-    /** 
+    /**
      * The template raw content to display
      */
     templateContent: string;
@@ -85,13 +85,13 @@ interface ISearchResultsContainerProps {
      */
     currentUICultureName: string;
 
-    /** 
-     * The configured result types 
+    /**
+     * The configured result types
      */
     resultTypes: ISearchResultType[];
 
     /**
-     * The name of the CustomAction that should render this data. 
+     * The name of the CustomAction that should render this data.
      */
     rendererId: string;
 
@@ -100,6 +100,11 @@ interface ISearchResultsContainerProps {
      */
     useCodeRenderer: boolean;
     customTemplateFieldValues:  ICustomTemplateFieldValue[];
+
+    /**
+     * Indicate usage of custom result template (inline or external)
+     */
+    isUsingCustomResultTemplate: boolean;
 
     /**
      * Web Parts localized strings
@@ -116,7 +121,7 @@ interface ISearchResultsContainerProps {
      */
     onSearchResultsUpdate: SearchResultsOperationCallback;
 
-    /* 
+    /*
      * The selected page to show for the search results
      */
     selectedPage: number;

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -147,7 +147,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
             let totalPrimaryAndSecondaryResults = this.state.results.RelevantResults.length;
             if (this.state.results.SecondaryResults.length > 0) {
-              totalPrimaryAndSecondaryResults += this.state.results.SecondaryResults.reduce((sum, current) => sum += current.Results.length, 0);
+                totalPrimaryAndSecondaryResults += this.state.results.SecondaryResults.reduce((sum, block) => sum += block.Results.length, 0);
             }
             let templateContext = {
                 items: this.state.results.RelevantResults,
@@ -161,6 +161,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                 maxResultsCount: this.props.searchService.resultsCount,
                 actualResultsCount: items.RelevantResults.length,
                 hasPrimaryOrSecondaryResults: totalPrimaryAndSecondaryResults > 0,
+                totalPrimaryAndSecondaryResults: totalPrimaryAndSecondaryResults,
                 strings: strings,
                 themeVariant: this.props.themeVariant,
                 spellingSuggestion: items.SpellingSuggestion


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | n/a

#### What's in this Pull Request?

Always render the inline or external 'custom' result template. This functionality enables rendering of results which only include secondary results or kick off alternate queries when the original query returned zero results.

@wobba 