### PR TITLE
[ModernSearch] Fixed issues #30 and #31

### DIFF
--- a/search-extensibility-library/src/libraries/CustomComponent.tsx
+++ b/search-extensibility-library/src/libraries/CustomComponent.tsx
@@ -83,7 +83,7 @@ export class MyCustomComponentWebComponent extends BaseWebComponent {
     public async connectedCallback() {
  
        let props = this.resolveAttributes();
-       const debugView = <CustomComponent {...props}/>;
-       ReactDOM.render(debugView, this);
+       const customComponent = <CustomComponent {...props}/>;
+       ReactDOM.render(customComponent, this);
     }    
 }

--- a/search-parts/src/services/DynamicDataService/DynamicDataService.ts
+++ b/search-parts/src/services/DynamicDataService/DynamicDataService.ts
@@ -10,47 +10,6 @@ export class DynamicDataService implements IDynamicDataService {
     constructor(dynamicDataProvider: DynamicDataProvider) {
         this._dynamicDataProvider = dynamicDataProvider;
     }
-
-    public getDataSourceValue<TValue>(dynamicProperty: DynamicProperty<TValue>, sourceId: string, propertyId: string, propertyPath: string): TValue {
-        let dataSourceValue: TValue;
-        let source = dynamicProperty.tryGetSource();
-
-        // Try to get the source if a source ID is present
-        // We need to do this check to avoid timing issues regarding data sources reconenction
-        if (!source && sourceId) {
-            source = this._dynamicDataProvider.tryGetSource(sourceId);
-
-            if (source && propertyId) {
-                dataSourceValue = source.getPropertyValue(propertyId)[propertyPath];
-            }
-
-        } else {
-            dataSourceValue = dynamicProperty.tryGetValue();
-        }
-
-        return dataSourceValue;
-    }    
-    
-    public getDataSourceValues<TValue>(dynamicProperty: DynamicProperty<TValue>, sourceId: string, propertyId: string, propertyPath: string): TValue[] {
-        let dataSourceValue: TValue[];
-        let source = dynamicProperty.tryGetSource();
-
-        // Try to get the source if a source ID is present
-        // We need to do this check to avoid timing issues regarding data sources reconenction
-        if (!source && sourceId) {
-            source = this._dynamicDataProvider.tryGetSource(sourceId);
-
-            if (source && propertyId) {
-                dataSourceValue = source.getPropertyValue(propertyId)[propertyPath];
-            }
-
-        } else {
-            dataSourceValue = dynamicProperty.tryGetValues();
-        }
-
-        return dataSourceValue;
-    }
-
     
     /**
      * Get available data sources on the page with specific property Id (i.e. corresponding to the underlying component type)

--- a/search-parts/src/services/DynamicDataService/IDynamicDataService.ts
+++ b/search-parts/src/services/DynamicDataService/IDynamicDataService.ts
@@ -2,7 +2,5 @@ import { DynamicProperty } from "@microsoft/sp-component-base";
 import IDataSourceProperty from "../../models/IDataSourceProperty";
 
 export default interface IDynamicDataService {
-    getDataSourceValue<TValue>(dynamicProperty: DynamicProperty<TValue>, sourceId: string, propertyId: string, propertyPath: string): TValue;
-    getDataSourceValues<TValue>(dynamicProperty: DynamicProperty<TValue>, sourceId: string, propertyId: string, propertyPath: string): TValue[];
     getAvailableDataSourcesByType(propertyId: string): IDataSourceProperty[];
 }

--- a/search-parts/src/services/SearchService/MockSearchService.ts
+++ b/search-parts/src/services/SearchService/MockSearchService.ts
@@ -65,7 +65,8 @@ class MockSearchService implements ISearchService {
                     Author: 'Michele Clark',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 1',
-                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1"
+                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1",
+                    FileType: 'aspx'
                 },
                 {
                     Title: 'Document 2 - Category 2',
@@ -77,7 +78,8 @@ class MockSearchService implements ISearchService {
                     Author: 'John Doe',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 1',
-                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2,L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1"
+                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2,L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1",
+                    FileType: 'pdf'
                 },
                 {
                     Title: 'Form 1',
@@ -87,9 +89,11 @@ class MockSearchService implements ISearchService {
                     ContentCategory: 'Form',
                     PreviewUrl: 'https://via.placeholder.com/400',
                     Author: 'John Doe',
+                    AuthorOWSUSER: '',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 2',
-                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1"
+                    owstaxidmetadataalltagsinfo: "L0|#03f88cf2c-a641-4bca-8861-7e363f5d9a0f|Tag 1",
+                    FileType: 'doc'
                 },
                 {
                     Title: 'Video 1 - Category 1',
@@ -100,7 +104,8 @@ class MockSearchService implements ISearchService {
                     PreviewUrl: 'https://via.placeholder.com/400',
                     Author: 'Aaron Painter',
                     SiteTitle: 'Site 2',
-                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2"
+                    owstaxidmetadataalltagsinfo: "L0|#0ce7eb131-c322-4a46-a398-383b0ec0f3c3|Tag 2",
+                    FileType: 'pptx'
                 },
                 {
                     Title: 'Video 2 - Category 2',
@@ -112,7 +117,8 @@ class MockSearchService implements ISearchService {
                     Author: 'Aaron Painter',
                     SPSiteUrl: 'https://www.microsoft.com',
                     SiteTitle: 'Site 3',
-                    owstaxidmetadataalltagsinfo: "L0|#01257a103-d2a1-43c4-8c07-6138527a88b7|Tag 3"
+                    owstaxidmetadataalltagsinfo: "L0|#01257a103-d2a1-43c4-8c07-6138527a88b7|Tag 3",
+                    FileType: 'doc'
                 },
             ],
             RefinementResults: [

--- a/search-parts/src/services/TemplateService/MockTemplateService.ts
+++ b/search-parts/src/services/TemplateService/MockTemplateService.ts
@@ -5,10 +5,17 @@ import { IComboBoxOption } from 'office-ui-fabric-react/lib/ComboBox';
 import { TemplateService } from './TemplateService';
 import MockSearchService from '../SearchService/MockSearchService';
 import { IPropertyPaneField } from '@microsoft/sp-property-pane';
+import { WebPartContext } from '@microsoft/sp-webpart-base';
 
 class MockTemplateService extends BaseTemplateService {
-    constructor(locale: string) {
-        super();    
+
+    private ctx: WebPartContext;
+
+    constructor(locale: string, ctx : WebPartContext) {
+        super(ctx);    
+
+        this.ctx = ctx;
+
         this.CurrentLocale = locale;
     }
 
@@ -31,7 +38,7 @@ class MockTemplateService extends BaseTemplateService {
 
     public getTemplateParameters(layout: ResultsLayoutOption, properties: ISearchResultsWebPartProps, onUpdateAvailableProperties?: (properties: IComboBoxOption[]) => void, availableProperties?: IComboBoxOption[]): IPropertyPaneField<any>[] {
         
-        const templateService = new TemplateService(null, this.CurrentLocale, new MockSearchService());
+        const templateService = new TemplateService(null, this.CurrentLocale, new MockSearchService(), null, this.ctx);
         return templateService.getTemplateParameters(layout, properties, onUpdateAvailableProperties);
     }
 }

--- a/search-parts/src/templates/layouts/slider.html
+++ b/search-parts/src/templates/layouts/slider.html
@@ -15,20 +15,35 @@
         {{#if @root.hasPrimaryOrSecondaryResults}} 
             {{#>slider items=(JSONstringify @root.items 2) options=(JSONstringify @root.sliderOptions)}}
                 <div class="slide">
-                    \{{#with (split AuthorOWSUSER '|')}}
-                        <pnp-document-card 	title="\{{../Title}}" 
-                                        location="\{{../SiteTitle}}"
-                                        preview-image="\{{getPreviewSrc item}}" 
-                                        preview-url="\{{../ServerRedirectedEmbedURL}}" 
-                                        date="\{{getDate ../Created 'LL'}}" 
-                                        href="\{{getUrl item}}" 
-                                        author="\{{../Author}}" 
-                                        profile-image="/_layouts/15/userphoto.aspx?size=L&username=\{{[0]}}" 
-                                        file-extension="\{{../IconExt}}"
-                                        enable-preview="false" 
-                                        show-file-icon="true">
-                        </pnp-document-card>
-                    \{{/with}}
+                    \{{#if AuthorOWSUSER}}
+                        \{{#with (split AuthorOWSUSER '|')}}
+                            <pnp-document-card 	title="\{{../Title}}" 
+                                            location="\{{../SiteTitle}}"
+                                            preview-image="\{{getPreviewSrc item}}" 
+                                            preview-url="\{{../ServerRedirectedEmbedURL}}" 
+                                            date="\{{getDate ../Created 'LL'}}" 
+                                            href="\{{getUrl item}}" 
+                                            author="\{{../Author}}" 
+                                            profile-image="/_layouts/15/userphoto.aspx?size=L&username=\{{[0]}}" 
+                                            file-extension="\{{../FileType}}"
+                                            enable-preview="false" 
+                                            show-file-icon="true">
+                            </pnp-document-card>
+                        \{{/with}}
+                    \{{else}}
+                            <pnp-document-card 	title="\{{Title}}" 
+                                            location="\{{SiteTitle}}"
+                                            preview-image="\{{getPreviewSrc item}}" 
+                                            preview-url="\{{ServerRedirectedEmbedURL}}" 
+                                            date="\{{getDate Created 'LL'}}" 
+                                            href="\{{getUrl item}}" 
+                                            author="\{{Author}}" 
+                                            profile-image="" 
+                                            file-extension="\{{FileType}}"
+                                            enable-preview="false" 
+                                            show-file-icon="true">
+                            </pnp-document-card>
+                    \{{/if}}                    
                 </div>                
             {{/slider}}
         {{else}}

--- a/search-parts/src/webparts/searchPagination/SearchPaginationWebPart.ts
+++ b/search-parts/src/webparts/searchPagination/SearchPaginationWebPart.ts
@@ -103,12 +103,6 @@ export default class SearchPaginationWebPart extends BaseClientSideWebPart<ISear
 
     this.initThemeVariant();
 
-    if (this.properties.searchResultsDataSourceReference) {
-        // Needed to retrieve manually the value for the dynamic property at render time. See the associated SPFx bug
-        // https://github.com/SharePoint/sp-dev-docs/issues/2985
-        this.context.dynamicDataProvider.registerAvailableSourcesChanged(this.render);
-    }
-
     this.context.dynamicDataSourceManager.initializeSource(this);
 
     return Promise.resolve();

--- a/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
+++ b/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
@@ -156,12 +156,6 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
             this._searchService = new SearchService(this.context.pageContext, this.context.spHttpClient);
         }
 
-        if (this.properties.searchResultsDataSourceReference) {
-            // Needed to retrieve manually the value for the dynamic property at render time. See the associated SPFx bug
-            // https://github.com/SharePoint/sp-dev-docs/issues/2985
-            this.context.dynamicDataProvider.registerAvailableSourcesChanged(this.render);
-        }
-
         this.context.dynamicDataSourceManager.initializeSource(this);
 
         return Promise.resolve();

--- a/search-parts/src/webparts/searchResults/ISearchResultsWebPartProps.ts
+++ b/search-parts/src/webparts/searchResults/ISearchResultsWebPartProps.ts
@@ -26,9 +26,6 @@ export interface ISearchResultsWebPartProps {
     inlineTemplateText: string;
     webPartTitle: string;
     resultTypes: ISearchResultType[];
-    sourceId: string;
-    propertyId: string;
-    propertyPath: string;
     rendererId: string;
     customTemplateFieldValues: ICustomTemplateFieldValue[];
     enableLocalization: boolean;

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -168,16 +168,11 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
         let sourceId: string = this.properties.resultSourceId;
         let getVerticalsCounts: boolean = false;
 
-        let queryDataSourceValue = this._dynamicDataService.getDataSourceValue(this.properties.queryKeywords, this.properties.sourceId, this.properties.propertyId, this.properties.propertyPath);
-        if (typeof (queryDataSourceValue) !== 'string') {
-            queryDataSourceValue = '';
-            this.context.propertyPane.refresh();
-        }
-
-        let queryKeywords = (!queryDataSourceValue) ? this.properties.defaultSearchQuery : queryDataSourceValue;
+        let queryDataSourceValue = this.properties.queryKeywords.tryGetValue();
+        let queryKeywords = queryDataSourceValue ? queryDataSourceValue : this.properties.defaultSearchQuery;
 
         // Get data from connected sources
-        if (this._refinerSourceData) {
+        if (this._refinerSourceData && !this._refinerSourceData.isDisposed) {
             const refinerSourceData: IRefinerSourceData = this._refinerSourceData.tryGetValue();
             if (refinerSourceData) {
                 refinerConfiguration = sortBy(refinerSourceData.refinerConfiguration, 'sortIdx');
@@ -185,7 +180,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
             }
         }
 
-        if (this._searchVerticalSourceData) {
+        if (this._searchVerticalSourceData && !this._searchVerticalSourceData.isDisposed) {
             const searchVerticalSourceData: ISearchVerticalSourceData = this._searchVerticalSourceData.tryGetValue();
             if (searchVerticalSourceData) {
                 if (searchVerticalSourceData.selectedVertical) {
@@ -196,7 +191,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
             }
         }
 
-        if (this._paginationSourceData) {
+        if (this._paginationSourceData && !this._paginationSourceData.isDisposed) {
             const paginationSourceData: IPaginationSourceData = this._paginationSourceData.tryGetValue();
             if (paginationSourceData) {
                 selectedPage = paginationSourceData.selectedPage;
@@ -348,12 +343,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
         this.ensureDataSourceConnection();
 
-        if (this.properties.sourceId) {
-            // Needed to retrieve manually the value for the dynamic property at render time. See the associated SPFx bug
-            // https://github.com/SharePoint/sp-dev-docs/issues/2985
-            this.context.dynamicDataProvider.registerAvailableSourcesChanged(this.render);
-        }
-
         // Load extensibility library if present
         const extensibilityLibrary = await this._extensibilityService.loadExtensibilityLibrary();
 
@@ -371,6 +360,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
         this._templateService.registerWebComponents(this.availableWebComponentDefinitions);
 
         this.context.dynamicDataSourceManager.initializeSource(this);
+
         this._synonymTable = this._convertToSynonymTable(this.properties.synonymList);
 
         this._initComplete = true;
@@ -578,12 +568,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
     protected async onPropertyPaneFieldChanged(propertyPath: string) {
 
-        if (propertyPath.localeCompare('queryKeywords') === 0) {
-
-            // Update data source information
-            this._saveDataSourceInfo();
-        }
-
         if (!this.properties.useDefaultSearchQuery) {
             this.properties.defaultSearchQuery = '';
         }
@@ -669,23 +653,6 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
     protected async onPropertyPaneConfigurationStart() {
         await this.loadPropertyPaneResources();
-    }
-
-    /**
-    * Save the useful information for the connected data source.
-    * They will be used to get the value of the dynamic property if this one fails.
-    */
-    private _saveDataSourceInfo() {
-
-        if (this.properties.queryKeywords.tryGetSource()) {
-            this.properties.sourceId = this.properties.queryKeywords["_reference"]._sourceId;
-            this.properties.propertyId = this.properties.queryKeywords["_reference"]._property;
-            this.properties.propertyPath = this.properties.queryKeywords["_reference"]._propertyPath;
-        } else {
-            this.properties.sourceId = null;
-            this.properties.propertyId = null;
-            this.properties.propertyPath = null;
-        }
     }
 
     /**
@@ -1494,8 +1461,8 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
     public getPropertyValue(propertyId: string): ISearchResultSourceData {
 
         const searchResultSourceData: ISearchResultSourceData = {
-            queryKeywords: this._dynamicDataService.getDataSourceValue(this.properties.queryKeywords, this.properties.sourceId, this.properties.propertyId, this.properties.propertyPath),
-            refinementResults: (this._resultService && this._resultService.results) ? this._resultService.results.RefinementResults : [],
+           queryKeywords: this.properties.queryKeywords.tryGetValue(),
+           refinementResults: (this._resultService && this._resultService.results) ? this._resultService.results.RefinementResults : [],
             paginationInformation: (this._resultService && this._resultService.results) ? this._resultService.results.PaginationInformation : {
                 CurrentPage: 1,
                 MaxResultsPerPage: this.properties.maxResultsCount,

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -319,7 +319,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
         if (Environment.type === EnvironmentType.Local) {
             this._taxonomyService = new MockTaxonomyService();
-            this._templateService = new MockTemplateService(this.context.pageContext.cultureInfo.currentUICultureName);
+            this._templateService = new MockTemplateService(this.context.pageContext.cultureInfo.currentUICultureName, this.context);
             this._searchService = new MockSearchService();
 
         } else {


### PR DESCRIPTION
- Fixed #31. We removed the `            this.context.dynamicDataProvider.registerAvailableSourcesChanged(this.render);` method to avoid multiple renders every time. According to [https://github.com/SharePoint/sp-dev-docs/issues/2985#issuecomment-536055289](https://github.com/SharePoint/sp-dev-docs/issues/2985#issuecomment-536055289), the DynamicProperty should wait for the wired data source and re-render the component when available so no need to to it manually anymore.
- Fixed #30 by adding relevant mock data for local workbench.
