### PR TITLE
Thumbnail height is incorrect

### DIFF
--- a/search-parts/src/components/DocumentCardComponent.tsx
+++ b/search-parts/src/components/DocumentCardComponent.tsx
@@ -120,7 +120,7 @@ export class DocumentCardComponent extends React.Component<IDocumentCardComponen
                     imageFit: ImageFit.centerCover,
                     iconSrc: iconSrc,
                     width: this.props.isCompact ? 144 : 318,
-                    height:  this.props.isCompact ? 88 : 196
+                    height:  this.props.isCompact ? 106 : 196
                 }
             ],
         };


### PR DESCRIPTION
Here's a minor update to fix an issue regarding the height in tile views in compact mode.

Before:

![image](https://user-images.githubusercontent.com/184604/70803797-2f6a4080-1db5-11ea-82a9-4939dbf6a68a.png)

After:


![image](https://user-images.githubusercontent.com/184604/70803776-1d889d80-1db5-11ea-96a5-b25a44b2f527.png)
