### PR TITLE
[search-parts] Fixed #92

### DIFF
--- a/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
@@ -278,6 +278,7 @@ export default class LinkPanel extends React.Component<ILinkPanelProps, ILinkPan
         <TemplateRenderer
           key={i}
           refinementResult={refinementResult}
+          refinerConfiguration={!!configuredFilter[0] ? configuredFilter[0] : null}
           shouldResetFilters={props.shouldResetFilters}
           templateType={configuredFilter[0].template}
           valueToRemove={valueToRemove}

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
@@ -192,6 +192,7 @@ export default class Vertical extends React.Component<IFilterLayoutProps, IVerti
       items.push(
         <TemplateRenderer
           key={i}
+          refinerConfiguration={!!configuredFilter[0] ? configuredFilter[0] : null}
           refinementResult={refinementResult}
           shouldResetFilters={props.shouldResetFilters}
           templateType={!!configuredFilter[0] ? configuredFilter[0].template : null}

--- a/search-parts/src/webparts/searchRefiners/components/Templates/ContainerTree/ContainerTreeTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/ContainerTree/ContainerTreeTemplate.tsx
@@ -8,6 +8,11 @@ import { cloneDeep } from "@microsoft/sp-lodash-subset";
 import { UrlHelper } from '../../../../../helpers/UrlHelper';
 
 export interface IFoldersTemplateProps extends IBaseRefinerTemplateProps {
+
+    /**
+     * Flag indicating if the associated refiner should be displayed as expanded
+     */
+    showExpanded: boolean;
 }
 
 export interface IFoldersTemplateState extends IBaseRefinerTemplateState {
@@ -109,7 +114,7 @@ export default class ContainerTreeTemplate extends React.Component<IFoldersTempl
                             name: `${currPath.substring(currPath.lastIndexOf('/') + 1)} (${value.RefinementCount})`,
                             url: '#',
                             path: currPath,
-                            isExpanded: true,
+                            isExpanded: this.props.showExpanded,
                             refinementValue: url === currPath ? value : null,
                             onClick: (ev, item: INavLink) => {
             

--- a/search-parts/src/webparts/searchRefiners/components/Templates/TemplateRenderer.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/TemplateRenderer.tsx
@@ -10,8 +10,14 @@ import { IRefinementResult, IRefinementValue } from "../../../../models/ISearchR
 import RefinementFilterOperationCallback from '../../../../models/RefinementValueOperationCallback';
 import IUserService from '../../../../services/UserService/IUserService';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
+import IRefinerConfiguration from '../../../../models/IRefinerConfiguration';
 
 export interface ITemplateRendererProps {
+
+  /**
+   * The current configuration for this filter
+   */
+  refinerConfiguration: IRefinerConfiguration;
 
   /**
    * The template type to render
@@ -156,6 +162,7 @@ export default class TemplateRenderer extends React.Component<ITemplateRendererP
 
       case RefinerTemplateOption.ContainerTree:
           renderTemplate = <ContainerTreeTemplate
+            showExpanded={this.props.refinerConfiguration ? this.props.refinerConfiguration.showExpanded : false}
             refinementResult={this.props.refinementResult}
             onFilterValuesUpdated={this.props.onFilterValuesUpdated}
             shouldResetFilters={this.props.shouldResetFilters}


### PR DESCRIPTION
- Fixed #92. Now the container tree refiner template follows the _"Expand filter by default"_ option set in the associated refiner configuration.