### PR TITLE
[search-parts] + [search-extesnbility] Added the ability to choose among multiple search query modifiers

### DIFF
--- a/search-extensibility-library/.vscode/launch.json
+++ b/search-extensibility-library/.vscode/launch.json
@@ -25,7 +25,7 @@
       "name": "Hosted workbench",
       "type": "chrome",
       "request": "launch",
-      "url": "https://enter-your-SharePoint-site/_layouts/workbench.aspx",
+      "url": "https://collaborationcorner.sharepoint.com/teams/PnPIntranet/_layouts/15/workbench.aspx",
       "webRoot": "${workspaceRoot}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {

--- a/search-extensibility-library/src/libraries/myCompanyLibrary/MyCompanyLibraryLibrary.ts
+++ b/search-extensibility-library/src/libraries/myCompanyLibrary/MyCompanyLibraryLibrary.ts
@@ -29,11 +29,23 @@ export class MyCompanyLibraryLibrary implements IExtensibilityLibrary {
     ];
   }
 
-  public getQueryModifier(): IQueryModifierDefinition<any> {
-    return {
-      displayName: CustomQueryModifier.DisplayName,
-      description: CustomQueryModifier.Description,
-      class: CustomQueryModifier
-    };
+  public getCustomQueryModifiers(): IQueryModifierDefinition<any>[] {
+    return [
+      {
+        displayName: CustomQueryModifier.DisplayName,
+        description: CustomQueryModifier.Description,
+        class: CustomQueryModifier
+      },
+      {
+        displayName: 'Test 2',
+        description: 'Test 2',
+        class: CustomQueryModifier
+      },
+      {
+        displayName: 'Test 3',
+        description: 'Test 3',
+        class: CustomQueryModifier
+      }
+    ];
   }
 }

--- a/search-extensibility-library/src/models/IExtensibilityLibrary.ts
+++ b/search-extensibility-library/src/models/IExtensibilityLibrary.ts
@@ -15,7 +15,7 @@ export interface IExtensibilityLibrary {
     getCustomSuggestionProviders(): ISuggestionProviderDefinition<any>[];
 
     /**
-     * Returns query modifier
+     * Returns custom query modifiers
      */
-    getQueryModifier(): IQueryModifierDefinition<any>;
+    getCustomQueryModifiers(): IQueryModifierDefinition<any>[];
 }

--- a/search-parts/src/models/IQueryModifierConfiguration.ts
+++ b/search-parts/src/models/IQueryModifierConfiguration.ts
@@ -1,0 +1,18 @@
+export default interface IQueryModifierConfiguration {
+
+    /**
+     * Indicates if the query modifier is enabled
+     */
+    queryModifierEnabled: boolean;
+
+    /**
+     * The name of the query modifier
+     */
+    queryModifierDisplayName: string;
+
+    /**
+     * The description of the query modifier
+     */
+
+    queryModifierDescription: string;
+}

--- a/search-parts/src/services/ExtensibilityService/IExtensibilityLibrary.ts
+++ b/search-parts/src/services/ExtensibilityService/IExtensibilityLibrary.ts
@@ -15,7 +15,7 @@ export interface IExtensibilityLibrary {
     getCustomSuggestionProviders(): ISuggestionProviderDefinition<any>[];
 
     /**
-     * Returns query modifier
+     * Returns custom query modifiers
      */
-    getQueryModifier(): IQueryModifierDefinition<any>;
+    getCustomQueryModifiers(): IQueryModifierDefinition<any>[];
 }

--- a/search-parts/src/webparts/searchResults/ISearchResultsWebPartProps.ts
+++ b/search-parts/src/webparts/searchResults/ISearchResultsWebPartProps.ts
@@ -5,6 +5,8 @@ import ISortableFieldConfiguration from '../../models/ISortableFieldConfiguratio
 import { ISearchResultType } from '../../models/ISearchResultType';
 import { ICustomTemplateFieldValue } from '../../services/ResultService/ResultService';
 import { ISynonymFieldConfiguration} from '../../models/ISynonymFieldConfiguration';
+import IQueryModifierConfiguration from '../../models/IQueryModifierConfiguration';
+import { IQueryModifierDefinition } from '../../services/ExtensibilityService/IQueryModifierDefinition';
 
 export interface ISearchResultsWebPartProps {
     queryKeywords: DynamicProperty<string>;
@@ -37,5 +39,6 @@ export interface ISearchResultsWebPartProps {
     synonymList: ISynonymFieldConfiguration[];
     searchQueryLanguage: number;
     templateParameters: { [key:string]: any };
-    enableQueryModifier: boolean;
+    queryModifiers: IQueryModifierConfiguration[];
+    selectedQueryModifierDisplayName: string;
 }

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -157,9 +157,14 @@ define([], function () {
     },
     "ManagedPropertiesListPlaceHolder": "Select or add a managed property",
     "QueryModifier": {
-      "NameLabel": "Query Modifier",
-      "OverviewLabel": "A query modifier is available from the extensibility library.",
-      "EnableLabelPrefix": "Enable"
+      "FieldLbl": "Search query modifiers",
+      "ConfigureBtn": "Configure",
+      "PanelHeader": "Configure search query modifiers",
+      "PanelDescription": "You can associate only one query modifier to a search result Web Part",
+      "EnableColumnLbl": "Enabled",
+      "DisplayNameColumnLbl": "Name",
+      "DescriptionColumnLbl": "Description",
+      "SelectedQueryModifierLbl": "Selected query modifier: '{0}'"
     }
   }
 });

--- a/search-parts/src/webparts/searchResults/loc/es-es.js
+++ b/search-parts/src/webparts/searchResults/loc/es-es.js
@@ -157,9 +157,14 @@ define([], function () {
     },
     "ManagedPropertiesListPlaceHolder": "Select or add a managed property",
     "QueryModifier": {
-      "NameLabel": "Modificador de consulta",
-      "OverviewLabel": "Un modificador de consulta está disponible en la biblioteca de extensibilidad.",
-      "EnableLabelPrefix": "Habilitar"
+      "FieldLbl": "Modificador de consulta",
+      "ConfigureBtn": "Configurador",
+      "PanelHeader": "Configurar los modificadores de requisitos",
+      "PanelDescription": "Solo puede asociar un modificador de consulta por elemento web de resultados de búsqueda",
+      "EnableColumnLbl": "Activado",
+      "DisplayNameColumnLbl": "Apellido",
+      "DescriptionColumnLbl": "Descripción",
+      "SelectedQueryModifierLbl": "Selected query modifier: '{0}'"
     }
   }
 });

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -157,9 +157,14 @@ define([], function() {
     },
     "ManagedPropertiesListPlaceHolder": "Sélectionnez ou ajoutez une propriété gérée",
     "QueryModifier": {
-      "NameLabel": "Modificateur de requêtes",
-      "OverviewLabel": "Un modificateur de requête est disponible à la bibliothèque d'extensibilité.",
-      "EnableLabelPrefix": "Activer"
+      "FieldLbl": "Modificateurs de requête",
+      "ConfigureBtn": "Configurer",
+      "PanelHeader": "Configurer les modificateurs de requête",
+      "PanelDescription": "Vous pouvez n'associer qu'un seul modificateur de requête par Web Part de résultats de recherche",
+      "EnableColumnLbl": "Activé",
+      "DisplayNameColumnLbl": "Nom",
+      "DescriptionColumnLbl": "Description",
+      "SelectedQueryModifierLbl": "Modificateur sélectionné: '{0}'"
     }
   }
 });

--- a/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
@@ -158,9 +158,14 @@ declare interface ISearchResultsWebPartStrings {
     }
     ManagedPropertiesListPlaceHolder: string;
     QueryModifier: {
-        NameLabel: string;
-        OverviewLabel: string;
-        EnableLabelPrefix: string;
+        FieldLbl: string;
+        ConfigureBtn: string;
+        PanelHeader: string;
+        PanelDescription: string;
+        EnableColumnLbl: string;
+        DisplayNameColumnLbl: string;
+        DescriptionColumnLbl: string;
+        SelectedQueryModifierLbl: string;
     }
 }
 

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -157,9 +157,14 @@ define([], function () {
     },
     "ManagedPropertiesListPlaceHolder": "Selecteer of voeg een beheerde eigenschap toe",
     "QueryModifier": {
-      "NameLabel": "Endrings spørring",
-      "OverviewLabel": "En spørrings endrings spørring er tilgjengelig fra Utvidelses biblioteket.",
-      "EnableLabelPrefix": "Aktiverer"
+      "FieldLbl": "Modificaties voor zoekopdrachten",
+      "ConfigureBtn": "Configure",
+      "PanelHeader": "Configureer zoekmodificaties",
+      "PanelDescription": "U kunt slechts één zoekopdracht aanpassen aan een webonderdeel met zoekresultaten",
+      "EnableColumnLbl": "Ingeschakeld",
+      "DisplayNameColumnLbl": "Naam",
+      "DescriptionColumnLbl": "Beschrijving",
+      "SelectedQueryModifierLbl": "Geselecteerde query-modifier: '{0}'"
     }
   }
 });


### PR DESCRIPTION
Related to #97 

Added the ability to choose among multiple query modifiers. However, only one can be selected at once per Search Results WP instance.