### PR TITLE
Adding Refiner Default Filters

### DIFF
--- a/search-parts/src/models/IRefinerConfiguration.ts
+++ b/search-parts/src/models/IRefinerConfiguration.ts
@@ -34,6 +34,11 @@ interface IRefinerConfiguration {
      * Allow refiners to be expanded by default
      */
     showExpanded: boolean;
+
+    /** 
+     * Allow refiners to select filters by default
+     */
+    refinerDefaultFilters: string;
 }
 
 export default IRefinerConfiguration;

--- a/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
+++ b/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
@@ -309,6 +309,11 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
             id: 'showExpanded',
             title: strings.Refiners.ShowExpanded,
             type: CustomCollectionFieldType.boolean
+          },
+          {
+            id: 'refinerDefaultFilters',
+            title: strings.Refiners.RefinerDefaultFilters,
+            type: CustomCollectionFieldType.string
           }
         ]
       }),
@@ -450,7 +455,8 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
           template: RefinerTemplateOption.CheckBox,
           refinerSortType: RefinersSortOption.Default,
           refinerSortDirection: RefinersSortDirection.Ascending,
-          showExpanded: false
+          showExpanded: false,
+          refinerDefaultFilters: ""
         },
         {
           refinerName: "Size",
@@ -458,7 +464,8 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
           template: RefinerTemplateOption.CheckBox,
           refinerSortType: RefinersSortOption.ByNumberOfResults,
           refinerSortDirection: RefinersSortDirection.Descending,
-          showExpanded: false
+          showExpanded: false,
+          refinerDefaultFilters: ""
         },
         {
           refinerName: "owstaxidmetadataalltagsinfo",
@@ -466,7 +473,8 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
           template: RefinerTemplateOption.CheckBox,
           refinerSortType: RefinersSortOption.Alphabetical,
           refinerSortDirection: RefinersSortDirection.Ascending,
-          showExpanded: false
+          showExpanded: false,
+          refinerDefaultFilters: ""
         },
         {
           refinerName: "RefinableString06",
@@ -474,7 +482,8 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
           template: RefinerTemplateOption.Persona,
           refinerSortType: RefinersSortOption.Alphabetical,
           refinerSortDirection: RefinersSortDirection.Ascending,
-          showExpanded: false
+          showExpanded: false,
+          refinerDefaultFilters: ""
         }
       ];
     }

--- a/search-parts/src/webparts/searchRefiners/loc/en-us.js
+++ b/search-parts/src/webparts/searchRefiners/loc/en-us.js
@@ -30,6 +30,7 @@ define([], function () {
       "ApplyFiltersLabel": "Apply",
       "ClearFiltersLabel": "Clear",
       "ShowExpanded": "Expand filter by default",
+      "RefinerDefaultFilters": "Initially selected filters",
       "Templates": {
         "RefinementItemTemplateLabel": "Default refinement item",
         "MutliValueRefinementItemTemplateLabel": "Multi-value refinement item",

--- a/search-parts/src/webparts/searchRefiners/loc/es-es.js
+++ b/search-parts/src/webparts/searchRefiners/loc/es-es.js
@@ -30,6 +30,7 @@ define([], function() {
             "ApplyFiltersLabel": "Aplicar",
             "ClearFiltersLabel": "Limpiar",
             "ShowExpanded": "Expandir filtro predeterminado",
+            "RefinerDefaultFilters": "Filtros inicialmente seleccionados",
             "Templates": {
                 "RefinementItemTemplateLabel": "Elemento de refinamiento predeterminado",
                 "MutliValueRefinementItemTemplateLabel": "Elemento de refinamiento multivalor",

--- a/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
@@ -30,6 +30,7 @@ define([], function () {
       "ApplyFiltersLabel": "Appliquer",
       "ClearFiltersLabel": "Effacer",
       "ShowExpanded": "Mode développé par défaut",
+      "RefinerDefaultFilters": "Filtres initialement sélectionnés",
       "Templates": {
         "RefinementItemTemplateLabel": "Filtre par défaut",
         "MutliValueRefinementItemTemplateLabel": "Filtre à valeurs multiples",

--- a/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
@@ -30,6 +30,7 @@ declare interface ISearchRefinersWebPartStrings {
         ApplyFiltersLabel: string;
         ClearFiltersLabel: string;
         ShowExpanded: string;
+        RefinerDefaultFilters: string;
         Templates: {
             RefinementItemTemplateLabel: string;
             MutliValueRefinementItemTemplateLabel: string;

--- a/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
@@ -30,6 +30,7 @@ define([], function() {
             "ApplyFiltersLabel": "Toepassen",
             "ClearFiltersLabel": "Opschonen",
             "ShowExpanded": "Vouw filters standaard uit",
+            "RefinerDefaultFilters": "Aanvankelijk geselecteerde filters",
             "Templates": {
                 "RefinementItemTemplateLabel": "Standaard verfijningsitem",
                 "MutliValueRefinementItemTemplateLabel": "Multi-value verfijningsitem",


### PR DESCRIPTION
This change allows to pre-select refiner values, the refiner filters will be applied when the page loads.  

The refiner will be selected only if they exist in the available refiners.
The new field in the Refiner Configuration is not required, so it can be left empty.

Backlog Item Card Link: https://github.com/microsoft-search/pnp-modern-search/projects/1#card-33171851

These images show the configuration of the refiners and the result:
![RefinersConfig](https://user-images.githubusercontent.com/22582515/75074511-d6f8a300-54c9-11ea-9970-5a520125ed35.PNG)

![Filters](https://user-images.githubusercontent.com/22582515/75074642-1c1cd500-54ca-11ea-8871-8a2edf0b7be3.PNG)

