### PR TITLE
Filter Checkbox refiner options by name

### DIFF
--- a/search-parts/src/webparts/searchRefiners/ISearchRefinersWebPartProps.ts
+++ b/search-parts/src/webparts/searchRefiners/ISearchRefinersWebPartProps.ts
@@ -5,6 +5,7 @@ export interface ISearchRefinersWebPartProps {
   webPartTitle: string;
   showBlank: boolean;
   refinersConfiguration: IRefinerConfiguration[];
+  showFilterBoxForRefinerValues: boolean;
   searchResultsDataSourceReference: string;
   selectedLayout: RefinersLayoutOption;
 }

--- a/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
+++ b/search-parts/src/webparts/searchRefiners/SearchRefinersWebPart.ts
@@ -95,6 +95,7 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
           webPartTitle: this.properties.webPartTitle,
           availableRefiners: availableRefiners,
           refinersConfiguration: this.properties.refinersConfiguration,
+          showFilterBoxForRefinerValues: this.properties.showFilterBoxForRefinerValues,
           showBlank: this.properties.showBlank,
           displayMode: this.displayMode,
           onUpdateFilters: (appliedRefiners: IRefinementFilter[]) => {
@@ -317,6 +318,10 @@ export default class SearchRefinersWebPart extends BaseClientSideWebPart<ISearch
             type: CustomCollectionFieldType.boolean
           }
         ]
+      }),
+      PropertyPaneToggle('showFilterBoxForRefinerValues', {
+        label: strings.ShowFilterBoxForRefinerValuesLabel,
+        checked: this.properties.showFilterBoxForRefinerValues,
       }),
       PropertyPaneDropdown('searchResultsDataSourceReference', {
         options: this._dynamicDataService.getAvailableDataSourcesByType(SearchComponentType.SearchResultsWebPart),

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/IFilterLayoutProps.ts
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/IFilterLayoutProps.ts
@@ -16,6 +16,11 @@ interface IFilterLayoutProps {
    */
   refinersConfiguration: IRefinerConfiguration[];
 
+    /**
+   * Display filter box on supported refiner templates (with more than 10 values)
+   */
+  showFilterBoxForRefinerValues: boolean;
+
   /**
    * Indicates if at least a filter value has been selected
    */

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
@@ -286,7 +286,7 @@ export default class LinkPanel extends React.Component<ILinkPanelProps, ILinkPan
           refinerConfiguration={!!configuredFilter[0] ? configuredFilter[0] : null}
           shouldResetFilters={props.shouldResetFilters}
           templateType={configuredFilter[0].template}
-          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
+          showFilterBoxForRefinerValues={props.showFilterBoxForRefinerValues}
           valueToRemove={valueToRemove}
           onFilterValuesUpdated={props.onFilterValuesUpdated}
           language={props.language}

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
@@ -286,6 +286,7 @@ export default class LinkPanel extends React.Component<ILinkPanelProps, ILinkPan
           refinerConfiguration={!!configuredFilter[0] ? configuredFilter[0] : null}
           shouldResetFilters={props.shouldResetFilters}
           templateType={configuredFilter[0].template}
+          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
           valueToRemove={valueToRemove}
           onFilterValuesUpdated={props.onFilterValuesUpdated}
           language={props.language}

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
@@ -198,7 +198,7 @@ export default class Vertical extends React.Component<IFilterLayoutProps, IVerti
           refinementResult={refinementResult}
           shouldResetFilters={props.shouldResetFilters}
           templateType={!!configuredFilter[0] ? configuredFilter[0].template : null}
-          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
+          showFilterBoxForRefinerValues={props.showFilterBoxForRefinerValues}
           onFilterValuesUpdated={props.onFilterValuesUpdated}
           language={props.language}
           themeVariant={props.themeVariant}

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/Vertical/Vertical.tsx
@@ -49,7 +49,7 @@ export default class Vertical extends React.Component<IFilterLayoutProps, IVerti
       groupProps={
         {
           onRenderHeader: this._onRenderHeader,
-          
+
         }
       }
       groups={this.state.groups} /> : noResultsElement;
@@ -69,9 +69,9 @@ export default class Vertical extends React.Component<IFilterLayoutProps, IVerti
         position: 'relative',
         maxHeight: 'inherit'
       }}>
-        <div className={styles.verticalLayout__filterPanel__body} data-is-scrollable={true}>       
+        <div className={styles.verticalLayout__filterPanel__body} data-is-scrollable={true}>
           {renderAvailableFilters}
-          {renderLinkRemoveAll} 
+          {renderLinkRemoveAll}
         </div>
       </div>
     );
@@ -198,6 +198,7 @@ export default class Vertical extends React.Component<IFilterLayoutProps, IVerti
           refinementResult={refinementResult}
           shouldResetFilters={props.shouldResetFilters}
           templateType={!!configuredFilter[0] ? configuredFilter[0].template : null}
+          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
           onFilterValuesUpdated={props.onFilterValuesUpdated}
           language={props.language}
           themeVariant={props.themeVariant}

--- a/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/ISearchRefinersContainerProps.ts
+++ b/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/ISearchRefinersContainerProps.ts
@@ -27,6 +27,11 @@ export interface ISearchRefinersContainerProps {
   refinersConfiguration: IRefinerConfiguration[];
 
   /**
+   * Display filter box on supported refiner templates (with more than 10 values)
+   */
+  showFilterBoxForRefinerValues: boolean;
+
+  /**
    * The selected layout
    */
   selectedLayout: RefinersLayoutOption;

--- a/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/SearchRefinersContainer.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/SearchRefinersContainer.tsx
@@ -61,6 +61,7 @@ export default class SearchRefinersContainer extends React.Component<ISearchRefi
             onFilterValuesUpdated={this.onFilterValuesUpdated}
             refinementResults={this.state.availableRefiners}
             refinersConfiguration={this.props.refinersConfiguration}
+            showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
             shouldResetFilters={this.state.shouldResetFilters}
             onRemoveAllFilters={this.onRemoveAllFilters}
             hasSelectedValues={this.state.selectedRefinementFilters.length > 0 ? true : false}
@@ -83,6 +84,7 @@ export default class SearchRefinersContainer extends React.Component<ISearchRefi
             onFilterValuesUpdated={this.onFilterValuesUpdated}
             refinementResults={this.state.availableRefiners}
             refinersConfiguration={this.props.refinersConfiguration}
+            showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
             shouldResetFilters={this.state.shouldResetFilters}
             onRemoveAllFilters={this.onRemoveAllFilters}
             hasSelectedValues={this.state.selectedRefinementFilters.length > 0 ? true : false}

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.module.scss
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.module.scss
@@ -1,3 +1,3 @@
 .filterBox {
-  max-width: 300px;;
+  max-width: 300px;
 }

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.module.scss
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.module.scss
@@ -1,0 +1,3 @@
+.filterBox {
+  max-width: 300px;;
+}

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -41,7 +41,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
         }
 
         return <div>
-            {this.props.refinementResult.Values.length > 10 && this.state.refinerSelectedFilterValues.length === 0 &&
+            {this.props.refinementResult.Values.length > 10 && (this.state.refinerSelectedFilterValues.length === 0 || this.props.isMultiValue) &&
                 <TextField className={styles.filterBox} placeholder="Filter list of options by name" onChange={this._onChangeFilterText} />
             }
             {
@@ -94,7 +94,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
         // In this case we use the refiners global state to recreate the 'local' state for this component
         this.setState({
             refinerSelectedFilterValues: this.props.selectedValues,
-            refinerFilteredFilterValues: this.props.selectedValues.length > 0 ? this.props.selectedValues : cloneDeep(this.props.refinementResult.Values),
+            refinerFilteredFilterValues: (!this.props.isMultiValue && this.props.selectedValues.length > 0) ? this.props.selectedValues : cloneDeep(this.props.refinementResult.Values),
         });
     }
 
@@ -103,7 +103,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
         if (nextProps.shouldResetFilters) {
             this.setState({
                 refinerSelectedFilterValues: [],
-                refinerFilteredFilterValues: nextProps.selectedValues.length > 0 ? nextProps.selectedValues : cloneDeep(nextProps.refinementResult.Values),
+                refinerFilteredFilterValues: (!this.props.isMultiValue && nextProps.selectedValues.length > 0) ? nextProps.selectedValues : cloneDeep(nextProps.refinementResult.Values),
             });
         }
 
@@ -126,11 +126,17 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
 
     /**
    * Filter list of options based on user input
+   * Also take into account selected options
    * @param filterText - The text to use when filtering the collection
    */
     private _onChangeFilterText = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, filterText: string): void => {
       this.setState({
-        refinerFilteredFilterValues: filterText ? this.props.refinementResult.Values.filter(r => r.RefinementName.toString().toLowerCase().indexOf(filterText.toLowerCase()) > -1) : this.props.refinementResult.Values
+        refinerFilteredFilterValues: filterText
+          ? this.props.refinementResult.Values.filter(
+            r => r.RefinementName.toString().toLowerCase().indexOf(filterText.toLowerCase()) > -1 ||
+            this.state.refinerSelectedFilterValues.some(s => s.RefinementValue === r.RefinementValue)
+          )
+          : this.props.refinementResult.Values
       });
     }
 
@@ -157,7 +163,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
 
         this.setState({
             refinerSelectedFilterValues: newFilterValues,
-            refinerFilteredFilterValues: newFilterValues,
+            refinerFilteredFilterValues: !this.props.isMultiValue ? newFilterValues : this.state.refinerFilteredFilterValues,
         });
 
         if (!this.props.isMultiValue) {

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -133,7 +133,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
       this.setState({
         refinerFilteredFilterValues: filterText
           ? this.props.refinementResult.Values.filter(
-            r => r.RefinementName.toString().toLowerCase().indexOf(filterText.toLowerCase()) > -1 ||
+            r => r.RefinementValue.toString().toLowerCase().indexOf(filterText.toLowerCase()) > -1 ||
             this.state.refinerSelectedFilterValues.some(s => s.RefinementValue === r.RefinementValue)
           )
           : this.props.refinementResult.Values

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -103,7 +103,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
         if (nextProps.shouldResetFilters) {
             this.setState({
                 refinerSelectedFilterValues: [],
-                refinerFilteredFilterValues: [],
+                refinerFilteredFilterValues: nextProps.selectedValues.length > 0 ? nextProps.selectedValues : cloneDeep(nextProps.refinementResult.Values),
             });
         }
 

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -41,7 +41,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
         }
 
         return <div>
-            {this.props.refinementResult.Values.length > 10 && (this.state.refinerSelectedFilterValues.length === 0 || this.props.isMultiValue) &&
+            { this.props.showFilterBoxForRefinerValues && this.props.refinementResult.Values.length > 10 && (this.state.refinerSelectedFilterValues.length === 0 || this.props.isMultiValue) &&
                 <TextField className={styles.filterBox} placeholder={strings.Refiners.FilterBoxPlaceholder} onChange={this._onChangeFilterText} />
             }
             {

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -42,7 +42,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
 
         return <div>
             {this.props.refinementResult.Values.length > 10 && (this.state.refinerSelectedFilterValues.length === 0 || this.props.isMultiValue) &&
-                <TextField className={styles.filterBox} placeholder="Filter list of options by name" onChange={this._onChangeFilterText} />
+                <TextField className={styles.filterBox} placeholder={strings.Refiners.FilterBoxPlaceholder} onChange={this._onChangeFilterText} />
             }
             {
                 this.state.refinerFilteredFilterValues.map((refinementValue: IRefinementValue, j) => {

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/ICheckboxTemplateState.ts
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/ICheckboxTemplateState.ts
@@ -1,0 +1,17 @@
+import IBaseRefinerTemplateState from "../IBaseRefinerTemplateState";
+import { IRefinementValue } from "../../../../../models/ISearchResult";
+
+interface ICheckboxTemplateState extends IBaseRefinerTemplateState {
+
+    /**
+     * The current selected values for the refiner
+     */
+    refinerSelectedFilterValues: IRefinementValue[];
+
+    /**
+     * The current filtered values for the refiner
+     */
+    refinerFilteredFilterValues: IRefinementValue[];
+}
+
+export default ICheckboxTemplateState;

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/ICheckboxTemplateState.ts
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/ICheckboxTemplateState.ts
@@ -4,11 +4,6 @@ import { IRefinementValue } from "../../../../../models/ISearchResult";
 interface ICheckboxTemplateState extends IBaseRefinerTemplateState {
 
     /**
-     * The current selected values for the refiner
-     */
-    refinerSelectedFilterValues: IRefinementValue[];
-
-    /**
      * The current filtered values for the refiner
      */
     refinerFilteredFilterValues: IRefinementValue[];

--- a/search-parts/src/webparts/searchRefiners/components/Templates/IBaseRefinerTemplateProps.ts
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/IBaseRefinerTemplateProps.ts
@@ -37,6 +37,11 @@ interface IBaseRefinerTemplateProps {
   removeFilterValue?: IRefinementValue;
 
   /**
+   * Display filter box on supported refiner templates (with more than 10 values)
+   */
+  showFilterBoxForRefinerValues?: boolean;
+
+  /**
    * UserService
    */
   userService?: IUserService;

--- a/search-parts/src/webparts/searchRefiners/components/Templates/TemplateRenderer.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/TemplateRenderer.tsx
@@ -24,6 +24,11 @@ export interface ITemplateRendererProps {
    */
   templateType: RefinerTemplateOption;
 
+    /**
+   * Display filter box on supported refiner templates (with more than 10 values)
+   */
+  showFilterBoxForRefinerValues: boolean;
+
   /**
    * The current refinement result to display
    */
@@ -90,7 +95,8 @@ export default class TemplateRenderer extends React.Component<ITemplateRendererP
           isMultiValue={false}
           themeVariant={this.props.themeVariant}
           removeFilterValue={this.props.valueToRemove}
-          selectedValues={selectedValues} 
+          selectedValues={selectedValues}
+          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
         />;
         break;
 
@@ -103,6 +109,7 @@ export default class TemplateRenderer extends React.Component<ITemplateRendererP
           isMultiValue={true}
           removeFilterValue={this.props.valueToRemove}
           selectedValues={this.props.selectedValues}
+          showFilterBoxForRefinerValues={this.props.showFilterBoxForRefinerValues}
         />;
         break;
 

--- a/search-parts/src/webparts/searchRefiners/loc/en-us.js
+++ b/search-parts/src/webparts/searchRefiners/loc/en-us.js
@@ -19,6 +19,7 @@ define([], function () {
     "SelectedFiltersLabel": "Selected filters:",
     "RefinerLayoutLabel": "Filters layout",
     "ConnectToSearchResultsLabel": "Connect to search results Web Part",
+    "ShowFilterBoxForRefinerValuesLabel": "Display filter box on supported refiner templates (with more than 10 values)",
     "Refiners": {
       "RefinersFieldLabel": "Refiners",
       "RefinerManagedPropertyField": "Filter managed property",

--- a/search-parts/src/webparts/searchRefiners/loc/en-us.js
+++ b/search-parts/src/webparts/searchRefiners/loc/en-us.js
@@ -30,6 +30,7 @@ define([], function () {
       "ApplyFiltersLabel": "Apply",
       "ClearFiltersLabel": "Clear",
       "ShowExpanded": "Expand filter by default",
+      "FilterBoxPlaceholder": "Filter list of options by name",
       "Templates": {
         "RefinementItemTemplateLabel": "Default refinement item",
         "MutliValueRefinementItemTemplateLabel": "Multi-value refinement item",

--- a/search-parts/src/webparts/searchRefiners/loc/es-es.js
+++ b/search-parts/src/webparts/searchRefiners/loc/es-es.js
@@ -30,6 +30,7 @@ define([], function() {
             "ApplyFiltersLabel": "Aplicar",
             "ClearFiltersLabel": "Limpiar",
             "ShowExpanded": "Expandir filtro predeterminado",
+            "FilterBoxPlaceholder": "Filtrar lista de opciones por nombre",
             "Templates": {
                 "RefinementItemTemplateLabel": "Elemento de refinamiento predeterminado",
                 "MutliValueRefinementItemTemplateLabel": "Elemento de refinamiento multivalor",

--- a/search-parts/src/webparts/searchRefiners/loc/es-es.js
+++ b/search-parts/src/webparts/searchRefiners/loc/es-es.js
@@ -19,6 +19,7 @@ define([], function() {
         "SelectedFiltersLabel": "Filtros seleccionados:",
         "RefinerLayoutLabel": "Diseño de filtros",
         "ConnectToSearchResultsLabel": "Conectar al Web Part de Resultados de Búsqueda",
+        "ShowFilterBoxForRefinerValuesLabel": "Display filter box on supported refiner templates (with more than 10 values)",
         "Refiners": {
             "RefinersFieldLabel": "Refinadores",
             "RefinerManagedPropertyField": "Filtrar la propiedad administrada",

--- a/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
@@ -30,6 +30,7 @@ define([], function () {
       "ApplyFiltersLabel": "Appliquer",
       "ClearFiltersLabel": "Effacer",
       "ShowExpanded": "Mode développé par défaut",
+      "FilterBoxPlaceholder": "Filtrer la liste des options par nom",
       "Templates": {
         "RefinementItemTemplateLabel": "Filtre par défaut",
         "MutliValueRefinementItemTemplateLabel": "Filtre à valeurs multiples",

--- a/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchRefiners/loc/fr-fr.js
@@ -19,6 +19,7 @@ define([], function () {
     "FilterResultsButtonLabel": "Filtrer",
     "RefinerLayoutLabel": "Disposition des filtres",
     "ConnectToSearchResultsLabel": "Se connecter au composant de recherche",
+    "ShowFilterBoxForRefinerValuesLabel": "Display filter box on supported refiner templates (with more than 10 values)",
     "Refiners": {
       "RefinersFieldLabel": "Filtres",
       "RefinersFieldDescription": "Configurez ici les propriétés gerées à utiliser comme filtres. Si il n'existe pas de valeurs pour le filtre spécifié, il n'apparaîtra pas dans le panneau.",

--- a/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
@@ -18,6 +18,7 @@ declare interface ISearchRefinersWebPartStrings {
     FilterResultsButtonLabel: string;
     RefinerLayoutLabel: string;
     ConnectToSearchResultsLabel: string;
+    ShowFilterBoxForRefinerValuesLabel: string
     Refiners: {
         RefinersFieldLabel: string;
         RefinersFieldDescription: string;

--- a/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchRefiners/loc/mystrings.d.ts
@@ -30,6 +30,7 @@ declare interface ISearchRefinersWebPartStrings {
         ApplyFiltersLabel: string;
         ClearFiltersLabel: string;
         ShowExpanded: string;
+        FilterBoxPlaceholder: string;
         Templates: {
             RefinementItemTemplateLabel: string;
             MutliValueRefinementItemTemplateLabel: string;

--- a/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
@@ -19,6 +19,7 @@ define([], function() {
         "SelectedFiltersLabel": "Geselecteerde filters:",
         "RefinerLayoutLabel": "Filters weergave",
         "ConnectToSearchResultsLabel": "Verbind met een zoek webonderdeel",
+        "ShowFilterBoxForRefinerValuesLabel": "Display filter box on supported refiner templates (with more than 10 values)",
         "Refiners": {
             "RefinersFieldLabel": "Verfijningen",
             "RefinerManagedPropertyField": "Filter beheerde eigenschap",

--- a/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchRefiners/loc/nl-nl.js
@@ -30,6 +30,7 @@ define([], function() {
             "ApplyFiltersLabel": "Toepassen",
             "ClearFiltersLabel": "Opschonen",
             "ShowExpanded": "Vouw filters standaard uit",
+            "FilterBoxPlaceholder": "Lijst met opties filteren op naam",
             "Templates": {
                 "RefinementItemTemplateLabel": "Standaard verfijningsitem",
                 "MutliValueRefinementItemTemplateLabel": "Multi-value verfijningsitem",


### PR DESCRIPTION
Added text box to allow filtering list of refiner options by name. This is very useful when the list of refiner options is large (i.e. 100 options).
The text box is only visible when there are more than 10 refiner options.

![image](https://user-images.githubusercontent.com/19577724/75991027-b7ac3d80-5eed-11ea-95d8-0c29b1871397.png)


When checkbox group is set to multi-select, filter ignores selected items and those are always visible

![image](https://user-images.githubusercontent.com/19577724/75991260-2093b580-5eee-11ea-9067-177ef681cf6d.png)

