### PR TITLE
[search-parts] [searchVerticals]: Removing white space if no icon selected  

### DIFF
--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer/SearchVerticalsContainer.tsx
@@ -26,9 +26,12 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
         pivotItemProps.itemCount = vertical.count;
       }
 
+      if (vertical.iconName !== "") {
+        pivotItemProps.itemIcon = vertical.iconName;
+      }
+
       return <PivotItem
                 headerText={vertical.tabName}
-                itemIcon={vertical.iconName}
                 itemKey={vertical.key}
                 {...pivotItemProps}>
               </PivotItem>;

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer/SearchVerticalsContainer.tsx
@@ -20,25 +20,25 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
 
     const renderPivotItems = this.props.verticals.map(vertical => {
 
-      let pivotItemProps: IPivotItemProps= {};
+      let pivotItemProps: IPivotItemProps = {};
 
       if (this.props.showCounts && (vertical.count !== undefined || vertical.count !== null)) {
         pivotItemProps.itemCount = vertical.count;
       }
 
-      if (vertical.iconName !== "") {
+      if (vertical.iconName && vertical.iconName.trim() !== "") {
         pivotItemProps.itemIcon = vertical.iconName;
       }
 
       return <PivotItem
-                headerText={vertical.tabName}
-                itemKey={vertical.key}
-                {...pivotItemProps}>
-              </PivotItem>;
+        headerText={vertical.tabName}
+        itemKey={vertical.key}
+        {...pivotItemProps}>
+      </PivotItem>;
     });
 
     return <Pivot className={styles.searchVerticals}
-              componentRef={(e) => {this._pivotRef = e; }}
+              componentRef={(e) => { this._pivotRef = e; }}
               onLinkClick={this.onVerticalSelected}
               theme={this.props.themeVariant as ITheme}>
               {renderPivotItems}


### PR DESCRIPTION
Removing placeholder (whitespace) if the icon property is empty or wrong for the search verticals

### Before
![Before](https://m2x0sg.db.files.1drv.com/y4mV65FceH7bwcUnKMSCkvT7JDHTXuwqRtPiiEbfkwO65TOegvdM1nRhYMQbZ7hmk4uP8CPSk8--Nvd_cbuYIa-yhZYWL20Xoil_4JnRWtSk-Nk2ogvyptxgmEUcwt88pGbDL5j-7PRnLlpVMJRYESCuWBcYClBIbGGG_zNDkMzUCwrsZSEzYczAEChci1scEHMnXtsZBhzAFLtkH1xnTYFlQ/searchVerticals-before.png)

### After
![After](https://nmx0sg.db.files.1drv.com/y4muQVfEQL_Fo-Fy550e5AKNvReJ7ugNN0H9kgeCooWjDtPaBytdWrdzbmd0GTPmVTaCvF3VnDjwyf-17CSxXUhhfcGpI1BoAhGF3i7mvTgpYmNEZ_IXcPadWEedtBFM0pbSK3GkAwER_E609HvWtc02GugvjpSsjhL63Vt9qxx8sYDzvuLgGFrkdRNf8fTwXRO_GzpC5m5vFntMXP8rvalJw/searchVerticals-after.png)