### PR TITLE
Added support for faster development with a separate webpack dev server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ obj
 
 # Styles Generated Code
 *.scss.ts
+*.scss.d.ts
 
 # compiled output
 dist/

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -969,6 +969,16 @@
                     "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
                     "dev": true
                 },
+                "cross-spawn": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
                 "glob": {
                     "version": "7.0.6",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
@@ -981,6 +991,37 @@
                         "minimatch": "^3.0.2",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "node-sass": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+                    "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+                    "dev": true,
+                    "requires": {
+                        "async-foreach": "^0.1.3",
+                        "chalk": "^1.1.1",
+                        "cross-spawn": "^3.0.0",
+                        "gaze": "^1.0.0",
+                        "get-stdin": "^4.0.1",
+                        "glob": "^7.0.3",
+                        "in-publish": "^2.0.0",
+                        "lodash": "^4.17.11",
+                        "meow": "^3.7.0",
+                        "mkdirp": "^0.5.1",
+                        "nan": "^2.13.2",
+                        "node-gyp": "^3.8.0",
+                        "npmlog": "^4.0.0",
+                        "request": "^2.88.0",
+                        "sass-graph": "^2.2.4",
+                        "stdout-stream": "^1.4.0",
+                        "true-case-path": "^1.0.2"
                     }
                 }
             }
@@ -1925,6 +1966,114 @@
                     "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
                     "dev": true
                 },
+                "acorn": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "css-loader": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.0.2.tgz",
+                    "integrity": "sha512-28hdCb5gCuTKUA+R6KzLwgxK6pUfgvrUyMNn7avOUQYFvmc13djru28uG+NF/pRre7Odd6B/kmJErCcpFZZQpQ==",
+                    "dev": true,
+                    "requires": {
+                        "icss-utils": "^4.0.0",
+                        "loader-utils": "^1.0.2",
+                        "lodash": "^4.17.11",
+                        "postcss": "^7.0.6",
+                        "postcss-modules-extract-imports": "^2.0.0",
+                        "postcss-modules-local-by-default": "^2.0.3",
+                        "postcss-modules-scope": "^2.0.0",
+                        "postcss-modules-values": "^2.0.0",
+                        "postcss-value-parser": "^3.3.0",
+                        "schema-utils": "^1.0.0"
+                    }
+                },
                 "debug": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -1934,11 +2083,231 @@
                         "ms": "0.7.1"
                     }
                 },
+                "define-property": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+                    "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+                    "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.5.0",
+                        "tapable": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "memory-fs": {
+                            "version": "0.5.0",
+                            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+                            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+                            "dev": true,
+                            "requires": {
+                                "errno": "^0.1.3",
+                                "readable-stream": "^2.0.1"
+                            }
+                        }
+                    }
+                },
                 "etag": {
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
                     "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
                     "dev": true
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
                 },
                 "finalhandler": {
                     "version": "0.4.1",
@@ -1993,11 +2362,67 @@
                         "statuses": "1"
                     }
                 },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
                 "lodash": {
                     "version": "4.17.15",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
                     "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
                 },
                 "mime": {
                     "version": "1.3.4",
@@ -2010,6 +2435,57 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                     "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
                     "dev": true
+                },
+                "postcss": {
+                    "version": "7.0.27",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+                    "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "postcss-modules-extract-imports": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+                    "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+                    "dev": true,
+                    "requires": {
+                        "postcss": "^7.0.5"
+                    }
+                },
+                "postcss-modules-local-by-default": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+                    "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
+                    "dev": true,
+                    "requires": {
+                        "postcss": "^7.0.6",
+                        "postcss-selector-parser": "^6.0.0",
+                        "postcss-value-parser": "^3.3.1"
+                    }
+                },
+                "postcss-modules-scope": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+                    "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+                    "dev": true,
+                    "requires": {
+                        "postcss": "^7.0.6",
+                        "postcss-selector-parser": "^6.0.0"
+                    }
+                },
+                "postcss-modules-values": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+                    "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
+                    "dev": true,
+                    "requires": {
+                        "icss-replace-symbols": "^1.1.0",
+                        "postcss": "^7.0.6"
+                    }
                 },
                 "range-parser": {
                     "version": "1.0.3",
@@ -2051,6 +2527,17 @@
                         }
                     }
                 },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
                 "send": {
                     "version": "0.13.2",
                     "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
@@ -2082,10 +2569,31 @@
                         "send": "0.13.2"
                     }
                 },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
                 "statuses": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                     "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tapable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+                    "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
                     "dev": true
                 },
                 "uuid": {
@@ -2093,6 +2601,37 @@
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
                     "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
                     "dev": true
+                },
+                "webpack": {
+                    "version": "4.35.3",
+                    "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
+                    "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.8.5",
+                        "@webassemblyjs/helper-module-context": "1.8.5",
+                        "@webassemblyjs/wasm-edit": "1.8.5",
+                        "@webassemblyjs/wasm-parser": "1.8.5",
+                        "acorn": "^6.2.0",
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0",
+                        "chrome-trace-event": "^1.0.0",
+                        "enhanced-resolve": "^4.1.0",
+                        "eslint-scope": "^4.0.0",
+                        "json-parse-better-errors": "^1.0.2",
+                        "loader-runner": "^2.3.0",
+                        "loader-utils": "^1.1.0",
+                        "memory-fs": "~0.4.1",
+                        "micromatch": "^3.1.8",
+                        "mkdirp": "~0.5.0",
+                        "neo-async": "^2.5.0",
+                        "node-libs-browser": "^2.0.0",
+                        "schema-utils": "^1.0.0",
+                        "tapable": "^1.1.0",
+                        "terser-webpack-plugin": "^1.1.0",
+                        "watchpack": "^1.5.0",
+                        "webpack-sources": "^1.3.0"
+                    }
                 }
             }
         },
@@ -2113,6 +2652,385 @@
                 "gulp": "~3.9.1",
                 "webpack": "~4.35.3",
                 "yargs": "~4.6.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+                    "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+                    "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.5.0",
+                        "tapable": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "memory-fs": {
+                            "version": "0.5.0",
+                            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+                            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+                            "dev": true,
+                            "requires": {
+                                "errno": "^0.1.3",
+                                "readable-stream": "^2.0.1"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "tapable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+                    "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+                    "dev": true
+                },
+                "webpack": {
+                    "version": "4.35.3",
+                    "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
+                    "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
+                    "dev": true,
+                    "requires": {
+                        "@webassemblyjs/ast": "1.8.5",
+                        "@webassemblyjs/helper-module-context": "1.8.5",
+                        "@webassemblyjs/wasm-edit": "1.8.5",
+                        "@webassemblyjs/wasm-parser": "1.8.5",
+                        "acorn": "^6.2.0",
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0",
+                        "chrome-trace-event": "^1.0.0",
+                        "enhanced-resolve": "^4.1.0",
+                        "eslint-scope": "^4.0.0",
+                        "json-parse-better-errors": "^1.0.2",
+                        "loader-runner": "^2.3.0",
+                        "loader-utils": "^1.1.0",
+                        "memory-fs": "~0.4.1",
+                        "micromatch": "^3.1.8",
+                        "mkdirp": "~0.5.0",
+                        "neo-async": "^2.5.0",
+                        "node-libs-browser": "^2.0.0",
+                        "schema-utils": "^1.0.0",
+                        "tapable": "^1.1.0",
+                        "terser-webpack-plugin": "^1.1.0",
+                        "watchpack": "^1.5.0",
+                        "webpack-sources": "^1.3.0"
+                    }
+                }
             }
         },
         "@microsoft/sp-component-base": {
@@ -4442,6 +5360,12 @@
                 "ansi-wrap": "0.1.0"
             }
         },
+        "ansi-html": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+            "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+            "dev": true
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -5714,6 +6638,28 @@
                 }
             }
         },
+        "bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "requires": {
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
+            },
+            "dependencies": {
+                "array-flatten": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+                    "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+                    "dev": true
+                }
+            }
+        },
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5892,6 +6838,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "buffer-xor": {
@@ -6358,6 +7310,25 @@
             "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
             "dev": true
         },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                }
+            }
+        },
         "clone-stats": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -6558,6 +7529,41 @@
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
             "dev": true
         },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6634,6 +7640,12 @@
                     "dev": true
                 }
             }
+        },
+        "connect-history-api-fallback": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "dev": true
         },
         "connect-livereload": {
             "version": "0.5.4",
@@ -6863,21 +7875,23 @@
             }
         },
         "css-loader": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.0.2.tgz",
-            "integrity": "sha512-28hdCb5gCuTKUA+R6KzLwgxK6pUfgvrUyMNn7avOUQYFvmc13djru28uG+NF/pRre7Odd6B/kmJErCcpFZZQpQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.2.tgz",
+            "integrity": "sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==",
             "dev": true,
             "requires": {
-                "icss-utils": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "lodash": "^4.17.11",
-                "postcss": "^7.0.6",
+                "camelcase": "^5.3.1",
+                "cssesc": "^3.0.0",
+                "icss-utils": "^4.1.1",
+                "loader-utils": "^1.2.3",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.23",
                 "postcss-modules-extract-imports": "^2.0.0",
-                "postcss-modules-local-by-default": "^2.0.3",
-                "postcss-modules-scope": "^2.0.0",
-                "postcss-modules-values": "^2.0.0",
-                "postcss-value-parser": "^3.3.0",
-                "schema-utils": "^1.0.0"
+                "postcss-modules-local-by-default": "^3.0.2",
+                "postcss-modules-scope": "^2.1.1",
+                "postcss-modules-values": "^3.0.0",
+                "postcss-value-parser": "^4.0.2",
+                "schema-utils": "^2.6.0"
             },
             "dependencies": {
                 "ajv": {
@@ -6901,6 +7915,18 @@
                         "color-convert": "^1.9.0"
                     }
                 },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
                 "chalk": {
                     "version": "2.4.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6923,10 +7949,48 @@
                         }
                     }
                 },
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                "cssesc": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                    "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
                     "dev": true
                 },
                 "postcss": {
@@ -6950,20 +8014,21 @@
                     }
                 },
                 "postcss-modules-local-by-default": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
-                    "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+                    "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
                     "dev": true,
                     "requires": {
-                        "postcss": "^7.0.6",
-                        "postcss-selector-parser": "^6.0.0",
-                        "postcss-value-parser": "^3.3.1"
+                        "icss-utils": "^4.1.1",
+                        "postcss": "^7.0.16",
+                        "postcss-selector-parser": "^6.0.2",
+                        "postcss-value-parser": "^4.0.0"
                     }
                 },
                 "postcss-modules-scope": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
-                    "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+                    "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
                     "dev": true,
                     "requires": {
                         "postcss": "^7.0.6",
@@ -6971,24 +8036,29 @@
                     }
                 },
                 "postcss-modules-values": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
-                    "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+                    "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
                     "dev": true,
                     "requires": {
-                        "icss-replace-symbols": "^1.1.0",
+                        "icss-utils": "^4.0.0",
                         "postcss": "^7.0.6"
                     }
                 },
+                "postcss-value-parser": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+                    "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+                    "dev": true
+                },
                 "schema-utils": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "version": "2.6.5",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+                    "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-errors": "^1.0.0",
-                        "ajv-keywords": "^3.1.0"
+                        "ajv": "^6.12.0",
+                        "ajv-keywords": "^3.4.1"
                     }
                 },
                 "source-map": {
@@ -7047,6 +8117,56 @@
                     "requires": {
                         "has-flag": "^1.0.0"
                     }
+                }
+            }
+        },
+        "css-modules-typescript-loader": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/css-modules-typescript-loader/-/css-modules-typescript-loader-4.0.0.tgz",
+            "integrity": "sha512-K6ii0+kt2i3sHN+VKTWdF728x+N4PFitsjE8aldUO+N98XlZhanJYIEZrnh4FMTZzDvOjyBialU0LnkCSeeUig==",
+            "dev": true,
+            "requires": {
+                "line-diff": "^2.0.1",
+                "loader-utils": "^1.2.3"
+            },
+            "dependencies": {
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
                 }
             }
         },
@@ -7391,6 +8511,16 @@
                 }
             }
         },
+        "default-gateway": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+            "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "ip-regex": "^2.1.0"
+            }
+        },
         "default-require-extensions": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -7520,6 +8650,12 @@
             "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
             "dev": true
         },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "dev": true
+        },
         "dezalgo": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -7545,6 +8681,31 @@
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
+            }
+        },
+        "dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "dns-packet": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+            "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+            "dev": true,
+            "requires": {
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "requires": {
+                "buffer-indexof": "^1.0.0"
             }
         },
         "dom-serializer": {
@@ -7723,6 +8884,12 @@
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.0"
             }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
         },
         "emojis-list": {
             "version": "2.1.0",
@@ -8073,6 +9240,15 @@
             "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
             "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
             "dev": true
+        },
+        "eventsource": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+            "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+            "dev": true,
+            "requires": {
+                "original": "^1.0.0"
+            }
         },
         "evp_bytestokey": {
             "version": "1.0.3",
@@ -8939,6 +10115,15 @@
                 "readable-stream": "^2.3.6"
             }
         },
+        "follow-redirects": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
+            "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.0.0"
+            }
+        },
         "for-in": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
@@ -8970,6 +10155,346 @@
             "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
             "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
             "dev": true
+        },
+        "fork-ts-checker-webpack-plugin": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.0.tgz",
+            "integrity": "sha512-2DLwUVUR/AdNmMD2utfmSR8r4qHRFhnfL6QQDQS5q4g5uBZzXYDgg8MXPIbu0HzyLjyvbogqjBNKILG5fufwzg==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.4.1",
+                "micromatch": "^3.1.10",
+                "minimatch": "^3.0.4",
+                "semver": "^5.6.0",
+                "tapable": "^1.0.0",
+                "worker-rpc": "^0.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+                    "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tapable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+                    "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+                    "dev": true
+                }
+            }
         },
         "form-data": {
             "version": "2.3.3",
@@ -10844,6 +12369,12 @@
                 }
             }
         },
+        "handle-thing": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
+            "dev": true
+        },
         "handlebars": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
@@ -11123,6 +12654,18 @@
             "integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg==",
             "dev": true
         },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
         "hsl-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
@@ -11149,6 +12692,12 @@
             "requires": {
                 "whatwg-encoding": "^1.0.1"
             }
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
         },
         "html-loader": {
             "version": "0.5.5",
@@ -11219,6 +12768,12 @@
                 "void-elements": "^2.0.1"
             }
         },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
         "http-errors": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -11244,6 +12799,342 @@
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
             "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
             "dev": true
+        },
+        "http-proxy": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "dependencies": {
+                "eventemitter3": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+                    "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+                    "dev": true
+                }
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+            "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+            "dev": true,
+            "requires": {
+                "http-proxy": "^1.17.0",
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.11",
+                "micromatch": "^3.1.10"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+                    "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                }
+            }
         },
         "http-signature": {
             "version": "1.2.0",
@@ -11427,9 +13318,9 @@
             "dev": true
         },
         "in-publish": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
             "dev": true
         },
         "indent-string": {
@@ -11456,6 +13347,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
             "integrity": "sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c="
+        },
+        "infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -11598,6 +13495,16 @@
                 }
             }
         },
+        "internal-ip": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+            "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+            "dev": true,
+            "requires": {
+                "default-gateway": "^4.2.0",
+                "ipaddr.js": "^1.9.0"
+            }
+        },
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
@@ -11616,6 +13523,18 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
             "dev": true
         },
         "ipaddr.js": {
@@ -13431,6 +15350,12 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
+        "json3": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+            "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+            "dev": true
+        },
         "json5": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -13497,6 +15422,12 @@
             "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
             "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
         },
+        "killable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+            "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+            "dev": true
+        },
         "kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -13562,6 +15493,12 @@
             "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
             "dev": true
         },
+        "levdist": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/levdist/-/levdist-1.0.0.tgz",
+            "integrity": "sha1-kdejBElk8szEIaBHfKyCf+dcVxg=",
+            "dev": true
+        },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -13592,6 +15529,15 @@
                 "object.map": "^1.0.0",
                 "rechoir": "^0.6.2",
                 "resolve": "^1.1.7"
+            }
+        },
+        "line-diff": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/line-diff/-/line-diff-2.1.0.tgz",
+            "integrity": "sha512-EciuZHwQfFG5ITBdIjN+zyJtcJXRVgbDSxtv6sz8BBf16rw4iGRO28AwIDVlNSoKlpDzp1UzRti54j3wBlU9Fw==",
+            "dev": true,
+            "requires": {
+                "levdist": "^1.0.0"
             }
         },
         "livereload-js": {
@@ -13825,6 +15771,12 @@
             "requires": {
                 "chalk": "^1.0.0"
             }
+        },
+        "loglevel": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+            "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+            "dev": true
         },
         "longest": {
             "version": "1.0.1",
@@ -14373,6 +16325,12 @@
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
         },
+        "microevent.ts": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
+            "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
+            "dev": true
+        },
         "micromatch": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -14626,6 +16584,22 @@
             "requires": {
                 "tslib": "^1.9.3"
             }
+        },
+        "multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "dev": true,
+            "requires": {
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
+            }
+        },
+        "multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
         },
         "multipipe": {
             "version": "0.1.2",
@@ -14960,9 +16934,9 @@
             }
         },
         "node-sass": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-            "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+            "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -14972,7 +16946,7 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "in-publish": "^2.0.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.15",
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
                 "nan": "^2.13.2",
@@ -15348,6 +17322,12 @@
                 "has": "^1.0.3"
             }
         },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true
+        },
         "office-ui-fabric-core": {
             "version": "9.6.1-fluent2",
             "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-9.6.1-fluent2.tgz",
@@ -15428,6 +17408,12 @@
             "requires": {
                 "ee-first": "1.1.1"
             }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "dev": true
         },
         "once": {
             "version": "1.4.0",
@@ -15533,6 +17519,15 @@
                 "readable-stream": "^2.0.1"
             }
         },
+        "original": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+            "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+            "dev": true,
+            "requires": {
+                "url-parse": "^1.4.3"
+            }
+        },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -15620,6 +17615,15 @@
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "dev": true
+        },
+        "p-retry": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+            "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+            "dev": true,
+            "requires": {
+                "retry": "^0.12.0"
+            }
         },
         "p-try": {
             "version": "1.0.0",
@@ -15863,6 +17867,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "picomatch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+            "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+            "dev": true
+        },
         "pidof": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pidof/-/pidof-1.0.2.tgz",
@@ -15993,6 +18003,34 @@
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
             "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
             "dev": true
+        },
+        "portfinder": {
+            "version": "1.0.25",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+            "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.2",
+                "debug": "^3.1.1",
+                "mkdirp": "^0.5.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
         },
         "posix-character-classes": {
             "version": "0.1.1",
@@ -16943,6 +18981,12 @@
             "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
             "dev": true
         },
+        "querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "dev": true
+        },
         "quill": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
@@ -17818,6 +19862,12 @@
             "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz",
             "integrity": "sha1-EUgiyRfsh5NFCy2qoeubvxEB6TE="
         },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
         "requires-regex": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/requires-regex/-/requires-regex-0.3.3.tgz",
@@ -17887,6 +19937,12 @@
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
             "dev": true
         },
         "rgb-regex": {
@@ -18345,6 +20401,87 @@
                 }
             }
         },
+        "sass-loader": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+            "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "loader-utils": "^1.2.3",
+                "neo-async": "^2.6.1",
+                "schema-utils": "^2.6.1",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.6.5",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+                    "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.12.0",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -18402,6 +20539,29 @@
                     "requires": {
                         "amdefine": ">=0.0.4"
                     }
+                }
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "selfsigned": {
+            "version": "1.10.7",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+            "dev": true,
+            "requires": {
+                "node-forge": "0.9.0"
+            },
+            "dependencies": {
+                "node-forge": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+                    "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+                    "dev": true
                 }
             }
         },
@@ -18547,6 +20707,23 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                }
             }
         },
         "shebang-command": {
@@ -18695,6 +20872,56 @@
                 "kind-of": "^3.2.0"
             }
         },
+        "sockjs": {
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+            "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+            "dev": true,
+            "requires": {
+                "faye-websocket": "^0.10.0",
+                "uuid": "^3.0.1"
+            }
+        },
+        "sockjs-client": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+            "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.2.5",
+                "eventsource": "^1.0.7",
+                "faye-websocket": "~0.11.1",
+                "inherits": "^2.0.3",
+                "json3": "^3.3.2",
+                "url-parse": "^1.4.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "faye-websocket": {
+                    "version": "0.11.3",
+                    "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+                    "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+                    "dev": true,
+                    "requires": {
+                        "websocket-driver": ">=0.5.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -18781,6 +21008,78 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
+        },
+        "spdy": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
+            "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "split": {
             "version": "1.0.1",
@@ -19084,6 +21383,78 @@
             "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
             "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
         },
+        "style-loader": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
+            "integrity": "sha512-rlkH7X/22yuwFYK357fMN/BxYOorfnfq0eD7+vqlemSK4wEcejFF1dg4zxP0euBW8NrYx2WZzZ8PPFevr7D+Kw==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.2.3",
+                "schema-utils": "^2.6.4"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.6.5",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+                    "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.12.0",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                }
+            }
+        },
         "stylehacks": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -19371,6 +21742,12 @@
                 "xtend": "~4.0.0"
             }
         },
+        "thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true
+        },
         "tildify": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
@@ -19652,6 +22029,12 @@
                 "through2": "^2.0.3"
             }
         },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
         "tough-cookie": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -19693,6 +22076,126 @@
             "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
             "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
             "dev": true
+        },
+        "ts-loader": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
+            "integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^4.0.0",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+                    "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.5.0",
+                        "tapable": "^1.0.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "memory-fs": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+                    "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+                    "dev": true,
+                    "requires": {
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tapable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+                    "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
         },
         "tslib": {
             "version": "1.9.3",
@@ -20146,6 +22649,16 @@
                 }
             }
         },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
         "url-toolkit": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
@@ -20207,6 +22720,12 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+            "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
             "dev": true
         },
         "v8flags": {
@@ -20411,46 +22930,55 @@
                 "neo-async": "^2.5.0"
             }
         },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
         "webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "webpack": {
-            "version": "4.35.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
-            "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
+            "version": "4.42.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
+            "integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
                 "@webassemblyjs/helper-module-context": "1.8.5",
                 "@webassemblyjs/wasm-edit": "1.8.5",
                 "@webassemblyjs/wasm-parser": "1.8.5",
-                "acorn": "^6.2.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chrome-trace-event": "^1.0.0",
+                "acorn": "^6.2.1",
+                "ajv": "^6.10.2",
+                "ajv-keywords": "^3.4.1",
+                "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^4.1.0",
-                "eslint-scope": "^4.0.0",
+                "eslint-scope": "^4.0.3",
                 "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "micromatch": "^3.1.8",
-                "mkdirp": "~0.5.0",
-                "neo-async": "^2.5.0",
-                "node-libs-browser": "^2.0.0",
+                "loader-runner": "^2.4.0",
+                "loader-utils": "^1.2.3",
+                "memory-fs": "^0.4.1",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.1",
+                "neo-async": "^2.6.1",
+                "node-libs-browser": "^2.2.1",
                 "schema-utils": "^1.0.0",
-                "tapable": "^1.1.0",
-                "terser-webpack-plugin": "^1.1.0",
-                "watchpack": "^1.5.0",
-                "webpack-sources": "^1.3.0"
+                "tapable": "^1.1.3",
+                "terser-webpack-plugin": "^1.4.3",
+                "watchpack": "^1.6.0",
+                "webpack-sources": "^1.4.1"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-                    "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
                     "dev": true
                 },
                 "ajv": {
@@ -20475,6 +23003,12 @@
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
                     "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
                     "dev": true
                 },
                 "braces": {
@@ -20506,6 +23040,29 @@
                         }
                     }
                 },
+                "cacache": {
+                    "version": "12.0.3",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+                    "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.5",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.1.15",
+                        "infer-owner": "^1.0.3",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.3",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
+                    }
+                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -20524,6 +23081,12 @@
                         "is-descriptor": "^1.0.2",
                         "isobject": "^3.0.1"
                     }
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+                    "dev": true
                 },
                 "enhanced-resolve": {
                     "version": "4.1.1",
@@ -20749,11 +23312,40 @@
                         "kind-of": "^6.0.2"
                     }
                 },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
                 "kind-of": {
                     "version": "6.0.3",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
                     "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
                     "dev": true
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
                 },
                 "micromatch": {
                     "version": "3.1.10",
@@ -20776,6 +23368,12 @@
                         "to-regex": "^3.0.2"
                     }
                 },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
                 "schema-utils": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -20787,10 +23385,72 @@
                         "ajv-keywords": "^3.1.0"
                     }
                 },
+                "serialize-javascript": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+                    "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.16",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+                    "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                },
                 "tapable": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
                     "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+                    "dev": true
+                },
+                "terser": {
+                    "version": "4.6.7",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
+                    "integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "^2.20.0",
+                        "source-map": "~0.6.1",
+                        "source-map-support": "~0.5.12"
+                    }
+                },
+                "terser-webpack-plugin": {
+                    "version": "1.4.3",
+                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+                    "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+                    "dev": true,
+                    "requires": {
+                        "cacache": "^12.0.2",
+                        "find-cache-dir": "^2.1.0",
+                        "is-wsl": "^1.1.0",
+                        "schema-utils": "^1.0.0",
+                        "serialize-javascript": "^2.1.2",
+                        "source-map": "^0.6.1",
+                        "terser": "^4.1.2",
+                        "webpack-sources": "^1.4.0",
+                        "worker-farm": "^1.7.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                     "dev": true
                 }
             }
@@ -20865,6 +23525,1027 @@
                     "requires": {
                         "async-limiter": "~1.0.0"
                     }
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
+            "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.4.2",
+                "cross-spawn": "6.0.5",
+                "enhanced-resolve": "4.1.0",
+                "findup-sync": "3.0.0",
+                "global-modules": "2.0.0",
+                "import-local": "2.0.0",
+                "interpret": "1.2.0",
+                "loader-utils": "1.2.3",
+                "supports-color": "6.1.0",
+                "v8-compile-cache": "2.0.3",
+                "yargs": "13.2.4"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "big.js": {
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+                    "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "enhanced-resolve": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+                    "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "tapable": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
+                },
+                "global-modules": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+                    "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^3.0.0"
+                    }
+                },
+                "global-prefix": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+                    "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.5",
+                        "kind-of": "^6.0.2",
+                        "which": "^1.3.1"
+                    }
+                },
+                "import-local": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+                    "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+                    "dev": true,
+                    "requires": {
+                        "pkg-dir": "^3.0.0",
+                        "resolve-cwd": "^2.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+                    "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+                    "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tapable": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+                    "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+                    "dev": true
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "13.2.4",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+                    "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "os-locale": "^3.1.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+            "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+            "dev": true,
+            "requires": {
+                "memory-fs": "^0.4.1",
+                "mime": "^2.4.4",
+                "mkdirp": "^0.5.1",
+                "range-parser": "^1.2.1",
+                "webpack-log": "^2.0.0"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-dev-server": {
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+            "integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
+            "dev": true,
+            "requires": {
+                "ansi-html": "0.0.7",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.1.8",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^1.6.0",
+                "debug": "^4.1.1",
+                "del": "^4.1.1",
+                "express": "^4.17.1",
+                "html-entities": "^1.2.1",
+                "http-proxy-middleware": "0.19.1",
+                "import-local": "^2.0.0",
+                "internal-ip": "^4.3.0",
+                "ip": "^1.1.5",
+                "is-absolute-url": "^3.0.3",
+                "killable": "^1.0.1",
+                "loglevel": "^1.6.6",
+                "opn": "^5.5.0",
+                "p-retry": "^3.0.1",
+                "portfinder": "^1.0.25",
+                "schema-utils": "^1.0.0",
+                "selfsigned": "^1.10.7",
+                "semver": "^6.3.0",
+                "serve-index": "^1.9.1",
+                "sockjs": "0.3.19",
+                "sockjs-client": "1.4.0",
+                "spdy": "^4.0.1",
+                "strip-ansi": "^3.0.1",
+                "supports-color": "^6.1.0",
+                "url": "^0.11.0",
+                "webpack-dev-middleware": "^3.7.2",
+                "webpack-log": "^2.0.0",
+                "ws": "^6.2.1",
+                "yargs": "12.0.5"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "body-parser": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+                    "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.1.0",
+                        "content-type": "~1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "~1.1.2",
+                        "http-errors": "1.7.2",
+                        "iconv-lite": "0.4.24",
+                        "on-finished": "~2.3.0",
+                        "qs": "6.7.0",
+                        "raw-body": "2.4.0",
+                        "type-is": "~1.6.17"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "content-disposition": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+                    "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.2"
+                    }
+                },
+                "cookie": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+                    "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "del": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+                    "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "globby": "^6.1.0",
+                        "is-path-cwd": "^2.0.0",
+                        "is-path-in-cwd": "^2.0.0",
+                        "p-map": "^2.0.0",
+                        "pify": "^4.0.1",
+                        "rimraf": "^2.6.3"
+                    }
+                },
+                "express": {
+                    "version": "4.17.1",
+                    "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+                    "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+                    "dev": true,
+                    "requires": {
+                        "accepts": "~1.3.7",
+                        "array-flatten": "1.1.1",
+                        "body-parser": "1.19.0",
+                        "content-disposition": "0.5.3",
+                        "content-type": "~1.0.4",
+                        "cookie": "0.4.0",
+                        "cookie-signature": "1.0.6",
+                        "debug": "2.6.9",
+                        "depd": "~1.1.2",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
+                        "finalhandler": "~1.1.2",
+                        "fresh": "0.5.2",
+                        "merge-descriptors": "1.0.1",
+                        "methods": "~1.1.2",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.3",
+                        "path-to-regexp": "0.1.7",
+                        "proxy-addr": "~2.0.5",
+                        "qs": "6.7.0",
+                        "range-parser": "~1.2.1",
+                        "safe-buffer": "5.1.2",
+                        "send": "0.17.1",
+                        "serve-static": "1.14.1",
+                        "setprototypeof": "1.1.1",
+                        "statuses": "~1.5.0",
+                        "type-is": "~1.6.18",
+                        "utils-merge": "1.0.1",
+                        "vary": "~1.1.2"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "finalhandler": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+                    "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.3",
+                        "statuses": "~1.5.0",
+                        "unpipe": "~1.0.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
+                "http-errors": {
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+                    "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.1",
+                        "statuses": ">= 1.5.0 < 2",
+                        "toidentifier": "1.0.0"
+                    }
+                },
+                "import-local": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+                    "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+                    "dev": true,
+                    "requires": {
+                        "pkg-dir": "^3.0.0",
+                        "resolve-cwd": "^2.0.0"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
+                },
+                "is-absolute-url": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+                    "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "is-path-cwd": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+                    "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+                    "dev": true
+                },
+                "is-path-in-cwd": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+                    "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-path-inside": "^2.1.0"
+                    }
+                },
+                "is-path-inside": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+                    "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.2"
+                    }
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "opn": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+                    "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+                    "dev": true,
+                    "requires": {
+                        "is-wsl": "^1.1.0"
+                    }
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+                    "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-map": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+                    "dev": true
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                },
+                "raw-body": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+                    "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.1.0",
+                        "http-errors": "1.7.2",
+                        "iconv-lite": "0.4.24",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "send": {
+                    "version": "0.17.1",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+                    "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "depd": "~1.1.2",
+                        "destroy": "~1.0.4",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
+                        "fresh": "0.5.2",
+                        "http-errors": "~1.7.2",
+                        "mime": "1.6.0",
+                        "ms": "2.1.1",
+                        "on-finished": "~2.3.0",
+                        "range-parser": "~1.2.1",
+                        "statuses": "~1.5.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            },
+                            "dependencies": {
+                                "ms": {
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "serve-static": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+                    "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+                    "dev": true,
+                    "requires": {
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.3",
+                        "send": "0.17.1"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+                    "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "webpack-log": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+            "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^3.0.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "ansi-colors": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+                    "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+                    "dev": true
                 }
             }
         },
@@ -21008,6 +24689,15 @@
             "dev": true,
             "requires": {
                 "errno": "~0.1.7"
+            }
+        },
+        "worker-rpc": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
+            "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
+            "dev": true,
+            "requires": {
+                "microevent.ts": "~0.1.1"
             }
         },
         "wrap-ansi": {

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -286,6 +286,21 @@
                         "which": "^1.2.9"
                     }
                 },
+                "del": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                    "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                    "dev": true,
+                    "requires": {
+                        "globby": "^5.0.0",
+                        "is-path-cwd": "^1.0.0",
+                        "is-path-in-cwd": "^1.0.0",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "rimraf": "^2.2.8"
+                    }
+                },
                 "execa": {
                     "version": "0.7.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -395,6 +410,12 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "is-path-cwd": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                    "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
                     "dev": true
                 },
                 "jest-changed-files": {
@@ -3752,6 +3773,32 @@
             "integrity": "sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q==",
             "dev": true
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
         "@pnp/common": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.3.4.tgz",
@@ -5273,6 +5320,24 @@
             "dev": true,
             "requires": {
                 "es6-promisify": "^5.0.0"
+            }
+        },
+        "aggregate-error": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+            "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "dependencies": {
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+                    "dev": true
+                }
             }
         },
         "ajv": {
@@ -7256,6 +7321,12 @@
                 }
             }
         },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
+        },
         "cli-cursor": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -8570,18 +8641,82 @@
             }
         },
         "del": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+            "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
             "dev": true,
             "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "^10.0.1",
+                "graceful-fs": "^4.2.2",
+                "is-glob": "^4.0.1",
+                "is-path-cwd": "^2.2.0",
+                "is-path-inside": "^3.0.1",
+                "p-map": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                },
+                "globby": {
+                    "version": "10.0.2",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+                    "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.0.3",
+                        "glob": "^7.1.3",
+                        "ignore": "^5.1.1",
+                        "merge2": "^1.2.3",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "merge2": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+                    "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+                    "dev": true
+                },
+                "p-map": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+                    "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+                    "dev": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                }
             }
         },
         "delayed-stream": {
@@ -8681,6 +8816,23 @@
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
+            }
+        },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                }
             }
         },
         "dns-equal": {
@@ -9481,6 +9633,89 @@
             "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
             "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
         },
+        "fast-glob": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+            "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "merge2": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+                    "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9504,6 +9739,15 @@
             "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
             "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
             "dev": true
+        },
+        "fastq": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.1.tgz",
+            "integrity": "sha512-mpIH5sKYueh3YyeJwqtVo8sORi0CgtmkVbK6kZStpQlZBYQuTzG2CZ7idSiJuA7bY0SFCWUc5WIs+oYumGCQNw==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "faye-websocket": {
             "version": "0.10.0",
@@ -13257,6 +13501,12 @@
             "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
             "dev": true
         },
+        "ignore": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+            "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+            "dev": true
+        },
         "imagesloaded": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.4.tgz",
@@ -13749,9 +13999,9 @@
             }
         },
         "is-path-cwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
             "dev": true
         },
         "is-path-in-cwd": {
@@ -13761,16 +14011,24 @@
             "dev": true,
             "requires": {
                 "is-path-inside": "^1.0.0"
+            },
+            "dependencies": {
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+                    "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                }
             }
         },
         "is-path-inside": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "^1.0.1"
-            }
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -19945,6 +20203,12 @@
             "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rgb-regex": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -19999,6 +20263,12 @@
             "requires": {
                 "is-promise": "^2.1.0"
             }
+        },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
         },
         "run-queue": {
             "version": "1.0.3",

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -73,6 +73,7 @@
         "ajv": "~5.2.2",
         "css-loader": "3.4.2",
         "css-modules-typescript-loader": "4.0.0",
+        "del": "5.1.0",
         "fork-ts-checker-webpack-plugin": "4.1.0",
         "gulp": "~3.9.1",
         "node-sass": "4.13.1",

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -9,7 +9,8 @@
     "scripts": {
         "build": "gulp bundle",
         "clean": "gulp clean",
-        "test": "gulp test"
+        "test": "gulp test",
+        "serve": "gulp bundle --custom-serve && webpack-dev-server --mode development --config ./webpack.js --env.env=dev"
     },
     "dependencies": {
         "react": "16.8.5",
@@ -70,9 +71,19 @@
         "@webcomponents/custom-elements": "1.3.2",
         "@webcomponents/webcomponentsjs": "2.4.1",
         "ajv": "~5.2.2",
+        "css-loader": "3.4.2",
+        "css-modules-typescript-loader": "4.0.0",
+        "fork-ts-checker-webpack-plugin": "4.1.0",
         "gulp": "~3.9.1",
+        "node-sass": "4.13.1",
+        "sass-loader": "8.0.2",
+        "style-loader": "1.1.3",
+        "ts-loader": "6.2.1",
         "unlazy-loader": "0.1.3",
-        "webpack-bundle-analyzer": "^3.6.0"
+        "webpack": "4.42.0",
+        "webpack-bundle-analyzer": "^3.6.0",
+        "webpack-cli": "3.3.11",
+        "webpack-dev-server": "3.10.3"
     },
     "resolutions": {
         "@types/react": "16.8.8"

--- a/search-parts/webpack.js
+++ b/search-parts/webpack.js
@@ -1,0 +1,201 @@
+const path = require('path');
+const webpack = require("webpack");
+const resolve = require("path").resolve;
+const CertStore = require('@microsoft/gulp-core-build-serve/lib/CertificateStore');
+const CertificateStore = CertStore.CertificateStore || CertStore.default;
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const host = "https://localhost:4321";
+
+///
+// Transforms define("<guid>", ...) to web part specific define("<web part id_version", ...)
+// the same approach is used inside copyAssets SPFx build step
+///
+class DynamicLibraryPlugin {
+  constructor(options) {
+    this.opitons = options;
+  }
+
+  apply(compiler) {
+    compiler.hooks.emit.tap("DynamicLibraryPlugin", compilation => {
+      for (const assetId in this.opitons.modulesMap) {
+        const moduleMap = this.opitons.modulesMap[assetId];
+
+        if (compilation.assets[assetId]) {
+          const rawValue = compilation.assets[assetId].children[0]._value;
+          compilation.assets[assetId].children[0]._value = rawValue.replace(this.opitons.libraryName, moduleMap.id + "_" + moduleMap.version);
+        }
+      }
+    });
+  }
+}
+
+let baseConfig = {
+  target: "web",
+  mode: "development",
+  devtool: "source-map",
+  node: {
+    fs: 'empty'
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+    modules: ["node_modules"]
+  },
+  context: path.resolve(__dirname),
+  module: {
+    rules: [
+      {
+        test: /utils\.js$/,
+        loader: 'unlazy-loader',
+        include: [
+          /node_modules/,
+        ]
+      },
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        options: {
+          transpileOnly: true,
+          compilerOptions: {
+            declarationMap: false
+          }
+        },
+        exclude: /node_modules/
+      },
+      {
+        use: [{
+          loader: "@microsoft/loader-cased-file",
+          options: {
+            name: "[name:lower]_[hash].[ext]"
+          }
+        }],
+        test: /.(jpg|png|woff|eot|ttf|svg|gif|dds)((\\?|\\#).+)?$/
+      },
+      {
+        use: [{
+          loader: "html-loader"
+        }],
+        test: /\.html$/
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: "@microsoft/loader-load-themed-styles",
+            options: {
+              async: true
+            }
+          },
+          {
+            loader: 'css-loader'
+          }
+        ]
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          {
+            loader: "@microsoft/loader-load-themed-styles",
+            options: {
+              async: true
+            }
+          },
+          'css-modules-typescript-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true
+            }
+          }, // translates CSS into CommonJS
+          "sass-loader" // compiles Sass to CSS, using Node Sass by default
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new ForkTsCheckerWebpackPlugin({
+      tslint: true
+    }),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.DEBUG': JSON.stringify(true),
+      'DEBUG': JSON.stringify(true)
+    })],
+  devServer: {
+    hot: false,
+    contentBase: resolve(__dirname),
+    publicPath: host + "/dist/",
+    host: "localhost",
+    port: 4321,
+    disableHostCheck: true,
+    historyApiFallback: true,
+    open: true,
+    openPage: host + "/temp/workbench.html",
+    stats: {
+      colors: true,
+      chunks: false,
+      "errors-only": true
+    },
+    proxy: { // url re-write for resources to be served directly from src folder
+      "/lib/webparts/**/loc/*.js": {
+        target: host,
+        pathRewrite: { '^/lib': '/src' },
+        secure: false
+      }
+    },
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+    },
+    https: {
+      cert: CertificateStore.instance.certificateData,
+      key: CertificateStore.instance.keyData
+    }
+  },
+}
+
+const createConfig = function () {
+
+  // we need only 'externals', 'output' and 'entry' from the original webpack config
+  let originalWebpackConfig = require("./temp/_webpack_config.json");
+  baseConfig.externals = originalWebpackConfig.externals;
+  baseConfig.output = originalWebpackConfig.output;
+
+  // fix: ".js" entry needs to be ".ts"
+  // also replaces the path form /lib/* to /src/*
+  let newEntry = {};
+  const pathToSearch = path.sep + "lib" + path.sep;
+  const pathToReplace = path.sep + "src" + path.sep;
+  const originalEntries = Object.keys(originalWebpackConfig.entry);
+
+  for (const key in originalWebpackConfig.entry) {
+    let entry = originalWebpackConfig.entry[key];
+    entry = entry.replace(pathToSearch, pathToReplace).slice(0, -3) + ".ts";
+    newEntry[key] = entry;
+  }
+
+  baseConfig.entry = newEntry;
+
+  baseConfig.output.publicPath = host + "/dist/";
+
+  const manifest = require("./temp/manifests.json");
+  const modulesMap = {};
+
+  for (const jsModule of manifest) {
+    if (jsModule.loaderConfig
+      && jsModule.loaderConfig.entryModuleId
+      && originalEntries.indexOf(jsModule.loaderConfig.entryModuleId) !== -1) {
+      modulesMap[jsModule.loaderConfig.entryModuleId + ".js"] = {
+        id: jsModule.id,
+        version: jsModule.version
+      }
+    }
+  }
+
+  baseConfig.plugins.push(new DynamicLibraryPlugin({
+    modulesMap: modulesMap,
+    libraryName: originalWebpackConfig.output.library
+  }));
+
+  return baseConfig;
+}
+
+module.exports = createConfig();

--- a/search-parts/webpack.js
+++ b/search-parts/webpack.js
@@ -85,13 +85,13 @@ let baseConfig = {
               async: true
             }
           },
-          {
-            loader: 'css-loader'
-          }
+          "css-loader"
         ]
       },
       {
-        test: /\.scss$/,
+        test: function (fileName) {
+          return fileName.endsWith(".module.scss");   // scss modules support
+        },
         use: [
           {
             loader: "@microsoft/loader-load-themed-styles",
@@ -103,9 +103,26 @@ let baseConfig = {
           {
             loader: 'css-loader',
             options: {
-              modules: true
+              modules: {
+                localIdentName: '[local]_[hash:base64:8]'
+              }
             }
           }, // translates CSS into CommonJS
+          "sass-loader" // compiles Sass to CSS, using Node Sass by default
+        ]
+      },
+      {
+        test: function (fileName) {
+          return !fileName.endsWith(".module.scss") && fileName.endsWith(".scss");  // just regular .scss
+        },
+        use: [
+          {
+            loader: "@microsoft/loader-load-themed-styles",
+            options: {
+              async: true
+            }
+          },
+          "css-loader", // translates CSS into CommonJS
           "sass-loader" // compiles Sass to CSS, using Node Sass by default
         ]
       }

--- a/search-parts/webpack.js
+++ b/search-parts/webpack.js
@@ -4,6 +4,7 @@ const resolve = require("path").resolve;
 const CertStore = require('@microsoft/gulp-core-build-serve/lib/CertificateStore');
 const CertificateStore = CertStore.CertificateStore || CertStore.default;
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const del = require('del');
 const host = "https://localhost:4321";
 
 ///
@@ -170,6 +171,8 @@ let baseConfig = {
 }
 
 const createConfig = function () {
+  // remove old css module TypeScript definitions and dist folder for source maps to work correctly
+  del.sync(["src/**/*.module.scss.ts", "dist/*.*"]);
 
   // we need only 'externals', 'output' and 'entry' from the original webpack config
   let originalWebpackConfig = require("./temp/_webpack_config.json");


### PR DESCRIPTION
This PR doesn't add any new functionality, but it tries to improve the development speed.  
   
I tried to improve the performance of the default SPFx builds using different ways.   
The latest and fastest approach is the tool [spfx-fast-serve](https://github.com/s-KaiNet/spfx-fast-serve).    

I used `pnp-modern-search` solution to test performance gain and the test demonstrated significant performance improvements. Since I have the code, which speeds up serve for `pnp-modern-search` locally, I decided to push a PR, so that you can try `fast-serve` and maybe even merge the PR.   

Basically you just need to run `npm install` to restore additional dependencies and then run `npm run serve`.