### PR TITLE
[search-parts] Fixed #129

### DIFF
--- a/search-parts/src/services/SearchService/SearchService.ts
+++ b/search-parts/src/services/SearchService/SearchService.ts
@@ -291,7 +291,7 @@ class SearchService implements ISearchService {
                         values.push({
                             RefinementCount: parseInt(item.RefinementCount, 10),
                             // replace string;# for calculated columns https://github.com/SharePoint/sp-dev-solutions/issues/304
-                            RefinementName: this._formatDate(item.RefinementName).replace("string;#", ""), // This value will appear in the selected filter bar
+                            RefinementName: refiner.Name, // This value will appear in the selected filter bar
                             RefinementToken: item.RefinementToken,
                             RefinementValue: this._formatDate(item.RefinementValue).replace("string;#", ""), // This value will appear in the filter panel
                         });

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.module.scss
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.module.scss
@@ -23,10 +23,13 @@
     &__selectedFilters {
 
         padding: 10px;
+        display: flex;
+        flex-wrap: wrap;
 
         label.filter {
-            display: inline-block;
-            margin-bottom: 5px;
+            display: flex;
+            align-items: center;
+            margin-right: 8px;
         }
 
         label.filter~label.filter:before {

--- a/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Layouts/LinkPanel/LinkPanel.tsx
@@ -51,8 +51,10 @@ export default class LinkPanel extends React.Component<ILinkPanelProps, ILinkPan
       let filterName = configuredRefiners.length === 1 ? configuredRefiners[0].displayValue : value.RefinementName;
 
       // Date refiner value
-      if (/range\(.+\)/.test(value.RefinementToken) && value.RefinementName !== value.RefinementValue) {
-        filterName = `${filterName} ${value.RefinementValue}`;
+      if (/range\(((-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?).+\)/.test(value.RefinementToken)) {
+        filterName = `[${filterName}${value.RefinementValue}"]`;
+      } else {
+        filterName = `[${filterName}: "${value.RefinementValue}"]`;
       }
 
       return (

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -3,7 +3,6 @@ import IBaseRefinerTemplateProps from '../IBaseRefinerTemplateProps';
 import IBaseRefinerTemplateState from '../IBaseRefinerTemplateState';
 import { IRefinementValue, RefinementOperator } from "../../../../../models/ISearchResult";
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { intersection } from '@microsoft/sp-lodash-subset';
 import { Text } from '@microsoft/sp-core-library';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as strings from 'SearchRefinersWebPartStrings';
@@ -54,7 +53,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
                             theme={this.props.themeVariant as ITheme}
                             key={j}
                             checked={this._isValueInFilterSelection(refinementValue)}
-                            disabled={this.state.refinerSelectedFilterValues.length > 0 && !this._isValueInFilterSelection(refinementValue) && !this.props.isMultiValue}
+                            disabled={this.state.refinerSelectedFilterValues.length > 0 && !this._isValueInFilterSelection(refinementValue) && !this.props.isMultiValue && refinementValue.RefinementName !== 'Size'}
                             label={Text.format(refinementValue.RefinementValue + ' ({0})', refinementValue.RefinementCount)}
                             onChange={(ev, checked: boolean) => {  
                                 checked ? this._onFilterAdded(refinementValue) : this._onFilterRemoved(refinementValue);

--- a/search-parts/src/webparts/searchRefiners/components/Templates/DateRange/DateRangeTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/DateRange/DateRangeTemplate.tsx
@@ -197,7 +197,7 @@ export default class DateRangeTemplate extends React.Component<IDateRangeTemplat
         if ((window as any).searchHBHelper) {
 
             if (startDate.localeCompare('min') !== 0) {
-                filterDisplayValue.push(`> ${this._onFormatDate(new Date(startDate))}`);
+                filterDisplayValue.push(`>= ${this._onFormatDate(new Date(startDate))}`);
             }
 
             if (endDate.localeCompare('max') !== 0) {
@@ -209,7 +209,7 @@ export default class DateRangeTemplate extends React.Component<IDateRangeTemplat
             RefinementCount: 0,
             RefinementName: this.props.refinementResult.FilterName,
             RefinementToken: rangeConditions,
-            RefinementValue: filterDisplayValue.length > 0 ? `(${filterDisplayValue.join(",")})` : this.props.refinementResult.FilterName
+            RefinementValue: filterDisplayValue.length > 0 ? `${filterDisplayValue.join(",")}` : this.props.refinementResult.FilterName
         };
 
         if (this.state.refinerSelectedFilterValues.length > 0) {

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -490,7 +490,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                         existingFilters.map((existingFilter) => {
                             updatedValues.push({
                                 RefinementCount: value.RefinementCount,
-                                RefinementName: existingFilter.localizedTermLabel,
+                                RefinementName: value.RefinementName,
                                 RefinementToken: value.RefinementToken,
                                 RefinementValue: existingFilter.localizedTermLabel,
                             } as IRefinementValue);


### PR DESCRIPTION
Related to #129. The 'Size' managed property was not returning the correct refinement name. Now, we use the refiner name every time regardless the value returned by the API.