### PR TITLE
sortlist bugfix

### DIFF
--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -314,11 +314,11 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                     }
                     
                     if (resetSorting) {
-
                         // Get back to initial values
-                        this.props.searchService.sortList = [{ Property: this._defaultSortingValues.sortField, Direction: this._defaultSortingValues.sortDirection }];
+                        if(this._defaultSortingValues.sortField && this._defaultSortingValues.sortDirection){
+                            this.props.searchService.sortList = [{ Property: this._defaultSortingValues.sortField, Direction: this._defaultSortingValues.sortDirection }];
+                        }                        
                     }
-
                     const searchResults = await this._getSearchResults(this.props, selectedPage);
 
                     this.setState({


### PR DESCRIPTION
Hi all,

This PR is regarding issue https://github.com/microsoft-search/pnp-modern-search/issues/237

The values for _defaultSortingValues.sortField and _defaultSortingValues.sortDirection are only filled up when you have configuration for 'sort order' and 'sortable fields'. When you only got configuration for 'sort order' or no configuration at all the 'sortList' property for the 'Search Service' is still updated with the _defaultSortingValues object. This results in the search query being malformed for the 'sortList' propety.
![image](https://user-images.githubusercontent.com/33486494/81171358-89ee7e00-8f9c-11ea-9147-6b753e4ac219.png)


Added the extra check so that the SortList property isn't updated when you don't have 'sortable fields' configured.

Could you take a look at this?

Thx!

Regards,
Bart