### PR TITLE
BaseWebComponent in Extensibility Lib was not considering data-*

### DIFF
--- a/docs/search-parts/search-pagination.md
+++ b/docs/search-parts/search-pagination.md
@@ -3,13 +3,13 @@
 ```
 {{#if @root.paging.showPaging}}
     <pnp-pagination 
-        total-items="{{@root.paging.totalItemsCount}}" 
-        hide-first-last-pages="{{@root.paging.hideFirstLastPages}}"
-        hide-disabled="{{@root.paging.hideDisabled}}"
-        hide-navigation="{{@root.paging.hideNavigation}}"
-        range="{{@root.paging.pagingRange}}" 
-        items-count-per-page="{{@root.paging.itemsCountPerPage}}" 
-        current-page-number="{{@root.paging.currentPageNumber}}"
+        data-total-items="{{@root.paging.totalItemsCount}}" 
+        data-hide-first-last-pages="{{@root.paging.hideFirstLastPages}}"
+        data-hide-disabled="{{@root.paging.hideDisabled}}"
+        data-hide-navigation="{{@root.paging.hideNavigation}}"
+        data-range="{{@root.paging.pagingRange}}" 
+        data-items-count-per-page="{{@root.paging.itemsCountPerPage}}" 
+        data-current-page-number="{{@root.paging.currentPageNumber}}"
     >
     </pnp-pagination>
 {{/if}}

--- a/search-extensibility-library/src/models/BaseWebComponent.ts
+++ b/search-extensibility-library/src/models/BaseWebComponent.ts
@@ -1,7 +1,7 @@
 import * as ReactDOM from 'react-dom';
 import { camelCase } from '@microsoft/sp-lodash-subset';
 import { WebPartContext } from '@microsoft/sp-webpart-base';
-import { IReadonlyTheme } from '@microsoft/sp-component-base';
+import { IReadonlyTheme, ThemeProvider } from '@microsoft/sp-component-base';
 import '@webcomponents/custom-elements/src/native-shim';
 import '@webcomponents/custom-elements/custom-elements.min';
 
@@ -14,35 +14,46 @@ export abstract class BaseWebComponent extends HTMLElement {
     protected connectedCallback() {
         throw 'Not implemented';
     }
-    
+
     protected disconnectedCallback() {
         ReactDOM.unmountComponentAtNode(this);
     }
-    
+
     /**
      * Transforms web component attributes to camel case propreties to pass in React components
      * (ex: a 'preview-image' HTML attribute becomes 'previewImage' prop, etc.)
      */
     protected resolveAttributes(): { [key:string] : any } {
-        
-        let props = {};
+
+      let props: {[key:string] : any}= {};
 
         for (let i =0;i < this.attributes.length;i++) {
 
             if (this.attributes.item(i)) {
 
-                let value = this.attributes.item(i).value; 
-                let attr = this.attributes.item(i).name;  
+                let value = this.attributes.item(i).value;
+                let attr = this.attributes.item(i).name;
 
-                // Booleans
-                if (/^(true|false)$/.test(value)) {
-                    props[camelCase(attr)] = (value === 'true');
-                } else {
-                    props[camelCase(attr)] = value;
+                // Resolve 'data-*' attribute name
+                const matches = attr.match(/data-(.+)/);
+                if (matches && matches.length === 2) {
+                    attr = matches[1];
+
+                    // Booleans
+                    if (/^(true|false)$/i.test(value)) {
+                        props[camelCase(attr)] = (value === 'true');
+                    } else {
+                        props[camelCase(attr)] = value;
+                    }
                 }
-            }         
+            }
         }
-         
+
+        // Added theme variant to be available in components
+        const themeProvider = this._ctx.serviceScope.consume(ThemeProvider.serviceKey);
+        const themeVariant = themeProvider.tryGetTheme();
+        props.themeVariant = themeVariant;
+
         return props;
     }
 }

--- a/search-parts/src/templates/layouts/default.html
+++ b/search-parts/src/templates/layouts/default.html
@@ -35,14 +35,14 @@
                 {{/each}}
             </ul>
             {{#if @root.paging.showPaging}}
-                <pnp-pagination 
-                    total-items="{{@root.paging.totalItemsCount}}" 
-                    hide-first-last-pages="{{@root.paging.hideFirstLastPages}}"
-                    hide-disabled="{{@root.paging.hideDisabled}}"
-                    hide-navigation="{{@root.paging.hideNavigation}}"
-                    range="{{@root.paging.pagingRange}}" 
-                    items-count-per-page="{{@root.paging.itemsCountPerPage}}" 
-                    current-page-number="{{@root.paging.currentPageNumber}}"
+                <pnp-pagination
+                    data-total-items="{{@root.paging.totalItemsCount}}"
+                    data-hide-first-last-pages="{{@root.paging.hideFirstLastPages}}"
+                    data-hide-disabled="{{@root.paging.hideDisabled}}"
+                    data-hide-navigation="{{@root.paging.hideNavigation}}"
+                    data-range="{{@root.paging.pagingRange}}"
+                    data-items-count-per-page="{{@root.paging.itemsCountPerPage}}"
+                    data-current-page-number="{{@root.paging.currentPageNumber}}"
                 >
                 </pnp-pagination>
             {{/if}}


### PR DESCRIPTION
The __BaseWebComponent__._resolveAttributes_ method was not considering that now the attributes must start by _data-*_
Custom renderer Layout template updated also with data- (some doc updated too)