### PR TITLE
[search-parts] Fixed #232

### DIFF
--- a/search-parts/src/components/BaseWebComponent.ts
+++ b/search-parts/src/components/BaseWebComponent.ts
@@ -38,13 +38,14 @@ export abstract class BaseWebComponent extends HTMLElement {
                 const matches = attr.match(/data-(.+)/);
                 if (matches && matches.length === 2) {
                     attr = matches[1];
+                }
 
-                    // Booleans
-                    if (/^(true|false)$/i.test(value)) {
-                        props[camelCase(attr)] = (value === 'true');
-                    } else {
-                        props[camelCase(attr)] = value;
-                    }
+                // Booleans
+                if (/^(true|false)$/i.test(value)) {
+                    props[camelCase(attr)] = (value === 'true');
+                } else {
+                    // Any other attribute
+                    props[camelCase(attr)] = value;
                 }
             }         
         }

--- a/search-parts/src/templates/layouts/details-list.html
+++ b/search-parts/src/templates/layouts/details-list.html
@@ -43,7 +43,7 @@
                 <span class="shimmer line" style="width: 20%"></span>
             </div>
         {{/if}}
-        <pnp-details-list data-columns-configuration="{{JSONstringify @root.detailsListColumns}}" data-show-file-icon="{{@root.showFileIcon}}" is-compact="{{@root.isCompact}}" data-show-shimmers="true"></pnp-details-list>
+        <pnp-details-list data-columns-configuration="{{JSONstringify @root.detailsListColumns}}" data-show-file-icon="{{@root.showFileIcon}}" data-is-compact="{{@root.isCompact}}" data-show-shimmers="true"></pnp-details-list>
     </div>
 
 </content>

--- a/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
+++ b/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
@@ -33,6 +33,14 @@ export default class SearchResultsTemplate extends React.Component<ISearchResult
                 data.allowedTags[data.tagName] = true;
             }
         });
+
+        // Allow all custom attributes
+        this._domPurify.addHook('uponSanitizeAttribute', (attr, data) => {
+
+            if (data && data.attrName) {
+                data.allowedAttributes[data.attrName] = true;
+            }
+        });   
     }
 
     public render() {


### PR DESCRIPTION
Fixed issue #232. Now, we allow all custom attributes format (with or without `data-` prefix).