### PR TITLE
Issue-264: Race condition while registering / loading custom renderers

### DIFF
--- a/search-custom-renderer/src/services/ResultService/ResultService.ts
+++ b/search-custom-renderer/src/services/ResultService/ResultService.ts
@@ -57,6 +57,9 @@ export class ResultService implements IResultService {
     }
 
     public getRegisteredRenderers(): IRenderer[] {
+        if (window[this.SEARCH_RENDERERS_OBJECT_NAME] === undefined) {
+            window[this.SEARCH_RENDERERS_OBJECT_NAME] = [];
+        }
         return window[this.SEARCH_RENDERERS_OBJECT_NAME];
     }
 


### PR DESCRIPTION
Sets the global scope variable as an array in cases where **getRegisteredRenderers** is called before **registerRenderer**. Fixes race condition as global scope object variables share mutations.