### PR TITLE
Fixed Preview Bugs

### DIFF
--- a/search-parts/src/services/TemplateService/BaseTemplateService.tsx
+++ b/search-parts/src/services/TemplateService/BaseTemplateService.tsx
@@ -275,16 +275,20 @@ abstract class BaseTemplateService {
         Handlebars.registerHelper("getPreviewSrc", (item: ISearchResult) => {
 
             let previewSrc = "";
-            const nonSupportedGraphThumbnails = ["xls"]; //let's add more as we proceed
+            const nonSupportedGraphThumbnails = ["xls","aspx"]; //let's add more as we proceed
+            const nonSupportedPreviews = ["aspx"]; //let's add more as we proceed
 
             if (item) {
-                if (!isEmpty(item.SiteLogo)) previewSrc = item.SiteLogo;
-                else if ((!isEmpty(item.FileType) && nonSupportedGraphThumbnails.indexOf(item.FileType) === -1) && !isEmpty(item.NormSiteID) && !isEmpty(item.NormListID) && !isEmpty(item.NormUniqueID)) previewSrc = `${this._ctx.pageContext.site.absoluteUrl}/_api/v2.0/sites/${item.NormSiteID}/lists/${item.NormListID}/items/${item.NormUniqueID}/driveItem/thumbnails/0/large/content?preferNoRedirect=true`;
-                else if (!isEmpty(item.PreviewUrl)) previewSrc = item.PreviewUrl;
-                else if (!isEmpty(item.PictureThumbnailURL)) previewSrc = item.PictureThumbnailURL;
-                else if (!isEmpty(item.ServerRedirectedPreviewURL)) previewSrc = item.ServerRedirectedPreviewURL;
-                else if (!isEmpty(item.ServerRedirectedURL)) previewSrc = UrlHelper.addOrReplaceQueryStringParam(item.ServerRedirectedURL, 'action', 'interactivepreview');
-                else if (!isEmpty(item.SiteId) && !isEmpty(item.WebId) && !isEmpty(item.UniqueID)) previewSrc = `${this._ctx.pageContext.site.absoluteUrl}/_layouts/15/getpreview.ashx?guidSite=${item.SiteId}&guidWeb=${item.WebId}&guidFile=${item.UniqueID.replace(/\{|\}/g, '')}&resolution=3`;
+                if (!isEmpty(item.IsDocument) && item.IsDocument.toLowerCase() == "true"){ //Preivew only for documents
+                    if (!isEmpty(item.SiteLogo)) previewSrc = item.SiteLogo;
+                    else if ((!isEmpty(item.FileType) && nonSupportedGraphThumbnails.indexOf(item.FileType) === -1) && !isEmpty(item.NormSiteID) && !isEmpty(item.NormListID) && !isEmpty(item.NormUniqueID)) previewSrc = `${this._ctx.pageContext.site.absoluteUrl}/_api/v2.0/sites/${item.NormSiteID}/lists/${item.NormListID}/items/${item.NormUniqueID}/driveItem/thumbnails/0/large/content?preferNoRedirect=true`;
+                    else if (!isEmpty(item.FileType) && nonSupportedPreviews.indexOf(item.FileType) > -1) previewSrc = ""; //Empty for non supported preview filetypes
+                    else if (!isEmpty(item.PreviewUrl)) previewSrc = item.PreviewUrl;
+                    else if (!isEmpty(item.PictureThumbnailURL)) previewSrc = item.PictureThumbnailURL;
+                    else if (!isEmpty(item.ServerRedirectedPreviewURL)) previewSrc = item.ServerRedirectedPreviewURL;
+                    else if (!isEmpty(item.ServerRedirectedURL)) previewSrc = UrlHelper.addOrReplaceQueryStringParam(item.ServerRedirectedURL, 'action', 'interactivepreview');
+                    else if (!isEmpty(item.SiteId) && !isEmpty(item.WebId) && !isEmpty(item.UniqueID)) previewSrc = `${this._ctx.pageContext.site.absoluteUrl}/_layouts/15/getpreview.ashx?guidSite=${item.SiteId}&guidWeb=${item.WebId}&guidFile=${item.UniqueID.replace(/\{|\}/g, '')}&resolution=3`;
+                }
             }
 
             return new Handlebars.SafeString(previewSrc);

--- a/search-parts/src/templates/layouts/simple-list.html
+++ b/search-parts/src/templates/layouts/simple-list.html
@@ -59,16 +59,18 @@
                                         </div>
                                     </div>
                                     <div class="template_previewContainer ms-hiddenSm">
-                                    {{#if (getPreviewSrc item)}}
+                                    {{#eq IsDocument 'true'}}
+                                        {{#isnt FileType 'aspx'}}
                                         <div class="doc-container">
                                             <div class="img-container">
-                                                <img class="document-preview-item img-preview" width="120" loading="lazy" src="{{getPreviewSrc item}}" data-src="{{getPreviewSrc item}}" data-url="{{#if ServerRedirectedEmbedURL}}{{ServerRedirectedEmbedURL}}{{else}}{{getPreviewSrc item}}{{/if}}" onerror="this.onerror=null;this.src='{{@root.utils.defaultImage}}';"/> 
+                                                <img class="document-preview-item img-preview" width="120" loading="lazy" src="{{getPreviewSrc item}}" data-src="{{getPreviewSrc item}}" data-url="{{#eq FileType 'pdf'}}{{#contains Path '-my.sharepoint'}}{{{ServerRedirectedEmbedURL}}}{{else}}{{{Path}}}{{/contains}}{{else}}{{{ServerRedirectedEmbedURL}}}{{/eq}}" onerror="this.onerror=null;this.src='{{@root.utils.defaultImage}}';"/> 
                                                 <div class="hover">
                                                     <div><i class="ms-Icon ms-Icon--Preview" aria-hidden="true"></i></div>
                                                 </div>
                                             </div>
                                         </div>
-                                    {{/if}} 
+                                        {{/isnt}}
+                                    {{/eq}} 
                                     </div>
                             </div>
                         {{/resultTypes}}

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -576,6 +576,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
                                                 "ServerRedirectedURL",
                                                 "DefaultEncodingURL",
                                                 "IsContainer",
+                                                "IsDocument",
                                                 "IsListItem",
                                                 "FileType",
                                                 "HtmlFileType",


### PR DESCRIPTION
Added IsDocument to default managed properities
Added IsDocument check around the getPreviewSrc HB Helper so it only returns preview src for documents
Changed simple layout to match document card  preview for data-url in preview img (fixes PDF issue #273)
Changed handlebar block around preview to only show for documents that are not aspx filetype (Fixes container issue #274) - for some reason the if (getPreviewSrc item) always returns true even after fixing the helper to return "" for non preview-able items