### PR TITLE
Persist selected values when filtering refiner options

### DIFF
--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -43,7 +43,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
 
         return <div className={styles.pnpRefinersTemplateCheckbox}>
             {
-                this.props.showValueFilter ? 
+                this.props.showValueFilter ?
                     <div className="pnp-value-filter-container">
                         <TextField className="pnp-value-filter" value={this.state.valueFilter} placeholder="Filter" onChange={(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,newValue?: string) => { this._onValueFilterChanged(newValue); }} onClick={this._onValueFilterClick} />
                         <Link onClick={this._clearValueFilter} disabled={!this.state.valueFilter || this.state.valueFilter === ""}>Clear</Link>
@@ -69,7 +69,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
                             checked={this._isValueInFilterSelection(refinementValue)}
                             disabled={this.state.refinerSelectedFilterValues.length > 0 && !this._isValueInFilterSelection(refinementValue) && !this.props.isMultiValue && refinementValue.RefinementName !== 'Size'}
                             label={Text.format(refinementValue.RefinementValue + ' ({0})', refinementValue.RefinementCount)}
-                            onChange={(ev, checked: boolean) => {  
+                            onChange={(ev, checked: boolean) => {
                                 checked ? this._onFilterAdded(refinementValue) : this._onFilterRemoved(refinementValue);
                             }} />
                     );
@@ -77,11 +77,11 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
             }
             {
                 this.props.isMultiValue ?
-            
+
                     <div>
-                        <Link 
-                            theme={this.props.themeVariant as ITheme} 
-                            onClick={() => { this._applyFilters(this.state.refinerSelectedFilterValues); }} 
+                        <Link
+                            theme={this.props.themeVariant as ITheme}
+                            onClick={() => { this._applyFilters(this.state.refinerSelectedFilterValues); }}
                             disabled={disableButtons}>{strings.Refiners.ApplyFiltersLabel}
                         </Link>|<Link theme={this.props.themeVariant as ITheme}  onClick={this._clearFilters} disabled={this.state.refinerSelectedFilterValues.length === 0}>{strings.Refiners.ClearFiltersLabel}</Link>
                     </div>
@@ -177,7 +177,7 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
     }
 
     /**
-     * Applies all selected filters for the current refiner 
+     * Applies all selected filters for the current refiner
      */
     private _applyFilters(updatedValues: IRefinementValue[]) {
         this.props.onFilterValuesUpdated(this.props.refinementResult.FilterName, updatedValues, this._operator);
@@ -199,9 +199,11 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
      * Checks if an item-object matches the provided refinement value filter value
      * @param item The item-object to be checked
      */
-    private _isFilterMatch(item): boolean {
+    private _isFilterMatch(item: IRefinementValue): boolean {
         if(!this.state.valueFilter) { return false; }
-        return item.RefinementValue.toLowerCase().indexOf(this.state.valueFilter.toLowerCase()) === -1 ;
+        const isSelected = this.state.refinerSelectedFilterValues.some(selectedValue => selectedValue.RefinementValue === item.RefinementValue);
+        if(isSelected) { return false; }
+        return item.RefinementValue.toLowerCase().indexOf(this.state.valueFilter.toLowerCase()) === -1;
     }
 
     /**

--- a/search-parts/src/webparts/searchRefiners/components/Templates/FileType/FileTypeTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/FileType/FileTypeTemplate.tsx
@@ -55,7 +55,7 @@ export default class FileTypeTemplate extends React.Component<IBaseRefinerTempla
     return (
       <div className={styles.pnpRefinersTemplateFileType}>
         {
-            this.props.showValueFilter ? 
+            this.props.showValueFilter ?
                 <div className="pnp-value-filter-container">
                     <TextField className="pnp-value-filter" value={this.state.valueFilter} placeholder="Filter" onChange={(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,newValue?: string) => { this._onValueFilterChanged(newValue); }} onClick={this._onValueFilterClick} />
                     <Link onClick={this._clearValueFilter} disabled={!this.state.valueFilter || this.state.valueFilter === ""}>Clear</Link>
@@ -103,8 +103,8 @@ export default class FileTypeTemplate extends React.Component<IBaseRefinerTempla
           this.props.isMultiValue ?
 
             <div>
-              <Link 
-                onClick={() => { this._applyFilters(this.state.refinerSelectedFilterValues); }} 
+              <Link
+                onClick={() => { this._applyFilters(this.state.refinerSelectedFilterValues); }}
                 disabled={disableButtons}>{strings.Refiners.ApplyFiltersLabel}</Link>|<Link onClick={this._clearFilters} disabled={this.state.refinerSelectedFilterValues.length === 0}>{strings.Refiners.ClearFiltersLabel}</Link>
             </div>
 
@@ -222,8 +222,10 @@ export default class FileTypeTemplate extends React.Component<IBaseRefinerTempla
    * Checks if an item-object matches the provided refinement value filter value
    * @param item The item-object to be checked
    */
-  private _isFilterMatch(item): boolean {
+  private _isFilterMatch(item: IRefinementValue): boolean {
       if(!this.state.valueFilter) { return false; }
+      const isSelected = this.state.refinerSelectedFilterValues.some(selectedValue => selectedValue.RefinementValue === item.RefinementValue);
+      if(isSelected) { return false; }
       return item.RefinementValue.toLowerCase().indexOf(this.state.valueFilter.toLowerCase()) === -1 ;
   }
 

--- a/search-parts/src/webparts/searchRefiners/components/Templates/Persona/PersonaTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Persona/PersonaTemplate.tsx
@@ -44,7 +44,7 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
   }
 
   public render() {
-    
+
     let renderTemplate: JSX.Element = null;
 
     if (this.state.isLoading) {
@@ -56,26 +56,26 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
 
                               let imageProps: IPersonaProps = null;
 
-                              // Try to see if the value looks like a login claim                              
+                              // Try to see if the value looks like a login claim
                               let displayName = refinementValue.RefinementValue.split('|').length > 1 ? refinementValue.RefinementValue.split('|')[1].trim() : refinementValue.RefinementValue;
                               const claimMatch = refinementValue.RefinementValue.match(/([ic]:0[#.5!+\-%?\\e][.+][wstmrfc]\|.+?(?=\|)\|.*)/);
-                              
+
                               if (claimMatch) {
                                 const accountName = claimMatch[0];
                                 const claimParts = accountName.split('|');
                                 const accountNameWithoutClaim = claimParts[claimParts.length-1];
-  
+
                                 // Get the user info from the already fetched list
                                 const userInfos = this.state.userInfos.filter(user => {
                                     return user.AccountName.toLowerCase() === accountName.toLowerCase();
                                 });
-                                
+
                                 if (userInfos.length > 0) {
                                   displayName = userInfos[0].Properties.DisplayName;
                                   imageProps = {
                                     imageUrl: accountNameWithoutClaim ? `/_layouts/15/userphoto.aspx?size=L&accountname=${accountNameWithoutClaim.toLowerCase()}`: null
                                   };
-                                }                                
+                                }
                               }
 
                               if (refinementValue.RefinementCount === 0) {
@@ -84,7 +84,7 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
                               return (
                                 <Persona
                                   {...imageProps}
-                                  key={j}           
+                                  key={j}
                                   className='pnp-persona'
                                   styles={{
                                     root: {
@@ -94,11 +94,11 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
                                       fontWeight: this._isValueInFilterSelection(refinementValue) ? 'bold' : 'normal'
                                     }
                                   }}
-                                  size={PersonaSize.size40}                                  
+                                  size={PersonaSize.size40}
                                   primaryText={`${displayName} (${refinementValue.RefinementCount})`}
                                   theme={this.props.themeVariant as ITheme}
                                   onClick={() => {
-                                    if (!this._isValueInFilterSelection(refinementValue)) { 
+                                    if (!this._isValueInFilterSelection(refinementValue)) {
                                       refinementValue.RefinementValue = displayName;
                                       this._onFilterAdded(refinementValue);
                                     } else {
@@ -115,7 +115,7 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
     return (
       <div className={styles.pnpRefinersTemplatePersona}>
         {
-            this.props.showValueFilter ? 
+            this.props.showValueFilter ?
                 <div className="pnp-value-filter-container">
                     <TextField value={this.state.valueFilter} placeholder="Filter" onChange={(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,newValue?: string) => { this._onValueFilterChanged(newValue); }} onClick={this._onValueFilterClick} />
                     <Link onClick={this._clearValueFilter} disabled={!this.state.valueFilter || this.state.valueFilter === ""}>Clear</Link>
@@ -144,7 +144,7 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
   private async getUserInfos(props: IPersonaTemplateProps) {
 
     const accountNames = [];
-      
+
     props.refinementResult.Values.map((refinementValue: IRefinementValue) => {
 
       // Identify the login adress using Regex
@@ -225,7 +225,7 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
         this._applyFilters(newFilterValues);
     }
   }
-  
+
   /**
    * Applies all selected filters for the current refiner
    */
@@ -252,8 +252,10 @@ export default class PersonaTemplate extends React.Component<IPersonaTemplatePro
    * Checks if an item-object matches the provided refinement value filter value
    * @param item The item-object to be checked
    */
-  private _isFilterMatch(item): boolean {
+  private _isFilterMatch(item: IRefinementValue): boolean {
       if(!this.state.valueFilter) { return false; }
+      const isSelected = this.state.refinerSelectedFilterValues.some(selectedValue => selectedValue.RefinementValue === item.RefinementValue);
+      if(isSelected) { return false; }
       let displayName = item.RefinementValue.split('|').length > 1 ? item.RefinementValue.split('|')[1].trim() : item.RefinementValue;
       return displayName.toLowerCase().indexOf(this.state.valueFilter.toLowerCase()) === -1 ;
   }


### PR DESCRIPTION
Small update on refiner options filter to always display selected options, even if they do not match the filtering text specified in the text box by the user
