### PR TITLE
CurrentCulture is used instead of CurrentUiCulture

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -231,7 +231,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
             }
         }
 
-        const currentLocaleId = LocalizationHelper.getLocaleId(this.context.pageContext.cultureInfo.currentCultureName);
+        const currentLocaleId = LocalizationHelper.getLocaleId(this.context.pageContext.cultureInfo.currentUICultureName);
         const queryModifier = this._queryModifierInstance && this._queryModifierInstance.isInitialized ? this._queryModifierInstance.instance : null;
 
         // Configure the provider before the query according to our needs


### PR DESCRIPTION
**Problem**
This leads to having all labels in e.g. de-DE (set in SPO -> CurrentUiCulture)) but the search query is run in eg. en-US (set in Windows -> CurrentCulture).

This leads to no search results if I search for TaxFieldManagedProperty:"GermanLabel".

**Explanation**
Search query should be sent with CurrentUiCulture. In my case it would be 1031 (de-DE) but instead 1033 (en-US) is used.

![image](https://user-images.githubusercontent.com/2542696/84985702-89b9d480-b13d-11ea-937d-ab74c6b1592f.png)


**Info**
Documentation suggests using CurrentUiCulture as well: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/web-parts/guidance/localize-web-parts#localize-the-web-part-manifest

And if I searched for other uses of CurrentCulture, I couldn't find another one in the project.

