### PR TITLE
Isolate result types rules for each webart instance

### DIFF
--- a/search-parts/src/services/TemplateService/BaseTemplateService.tsx
+++ b/search-parts/src/services/TemplateService/BaseTemplateService.tsx
@@ -194,7 +194,7 @@ abstract class BaseTemplateService {
      */
     private registerTemplateServices() {
 
-        //https://support.microsoft.com/en-us/office/file-types-supported-for-previewing-files-in-onedrive-sharepoint-and-teams-e054cd0f-8ef2-4ccb-937e-26e37419c5e4 
+        //https://support.microsoft.com/en-us/office/file-types-supported-for-previewing-files-in-onedrive-sharepoint-and-teams-e054cd0f-8ef2-4ccb-937e-26e37419c5e4
         const validPreviewExt = ["DOC", "DOCM", "DOCX", "DOTM", "DOTX", "POT", "POTM", "POTX", "PPS", "PPSM", "PPSX", "PPT", "PPTM", "PPTX", "VSD", "VSDX", "XLS", "XLSB", "XLSX", "3G2", "3GP", "3MF", "AI", "ARW", "ASF", "BAS", "BMP", "CR2", "CRW", "CSV", "CUR", "DCM", "DNG", "DWG", "EML", "EPUB", "ERF", "GIF", "GLB", "GLTF", "HCP", "HTM", "HTML", "ICO", "ICON", "JPG", "KEY", "LOG", "M", "M2TS", "M4V", "MARKDOWN", "MD", "MEF", "MOV", "MOVIE", "MP4", "MP4V", "MRW", "MSG", "MTS", "NEF", "NRW", "ODP", "ODS", "ODT", "ORF", "PAGES", "PANO", "PDF", "PEF", "PICT", "PLY", "PNG", "PSB", "PSD", "RTF", "SKETCH", "STL", "SVG", "TIF", "TIFF", "TS", "WMV", "XBM", "XCF", "XD", "XPM", "ZIP", "GITCONFIG", "ABAP", "ADA", "ADP", "AHK", "AS", "AS3", "ASC", "ASCX", "ASM", "ASP", "AWK", "BASH", "BASH_LOGIN", "BASH_LOGOUT", "BASH_PROFILE", "BASHRC", "BAT", "BIB", "BSH", "BUILD", "BUILDER", "C", "CAPFILE", "CBL", "CC", "CFC", "CFM", "CFML", "CL", "CLJ", "CLS", "CMAKE", "CMD", "COFFEE", "CPP", "CPT", "CPY", "CS", "CSHTML", "CSON", "CSPROJ", "CSS", "CTP", "CXX", "D", "DDL", "DI.DIF", "DIFF", "DISCO", "DML", "DTD", "DTML", "EL", "EMAKEFILE", "ERB", "ERL", "F", "F90", "F95", "FS", "FSI", "FSSCRIPT", "FSX", "GEMFILE", "GEMSPEC", "GO", "GROOVY", "GVY", "H", "H++", "HAML", "HANDLEBARS", "HH", "HPP", "HRL", "HS", "HTC", "HXX", "IDL", "IIM", "INC", "INF", "INI", "INL", "IPP", "IRBRC", "JADE", "JAV", "JAVA", "JS", "JSON", "JSP", "JSX", "L", "LESS", "LHS", "LISP", "LST", "LTX", "LUA", "MAKE", "MARKDN", "MDOWN", "MKDN", "ML", "MLI", "MLL", "MLY", "MM", "MUD", "NFO", "OPML", "OSASCRIPT", "OUT", "P", "PAS", "PATCH", "PHP", "PHP2", "PHP3", "PHP4", "PHP5", "PL", "PLIST", "PM", "POD", "PP", "PROFILE", "PROPERTIES", "PS1", "PT", "PY", "PYW", "R", "RAKE", "RB", "RBX", "RC", "RE", "REG", "REST", "RESW", "RESX", "RHTML", "RJS", "RPROFILE", "RPY", "RSS", "RST", "RXML", "S", "SASS", "SCALA", "SCM", "SCONSCRIPT", "SCONSTRUCT", "SCRIPT", "SCSS", "SGML", "SH", "SHTML", "SML", "SQL", "STY", "TCL", "TEX", "TEXT", "TLD", "TLI", "TMPL", "TPL", "TXT", "VB", "VI", "VIM", "WSDL", "XAML", "XHTML", "XOML", "XML", "XSD", "XSL", "XSLT", "YAML", "YAWS", "YML", "ZS", "MP3", "FBX", "HEIC", "JPEG", "HBS", "TEXTILE", "C++"];
 
         // Return the URL of the search result item
@@ -387,6 +387,15 @@ abstract class BaseTemplateService {
             return accum;
         });
 
+        Handlebars.registerPartial("resultTypes-default", "{{> @partial-block }}");
+
+        const self = this;
+        const hbs = Handlebars;
+        Handlebars.registerHelper('resultTypeResolve', (instanceId:string)=>{
+          return hbs.partials[`resultTypes-${instanceId}`] || "resultTypes-default";
+        });
+        Handlebars.registerPartial('resultTypes', '{{> (resultTypeResolve @root.instanceId)}}');
+
         Handlebars.registerHelper("regex", (regx: string, str: string) => {
             let rx = new RegExp(regx);
             let i = rx.exec(str);
@@ -415,7 +424,7 @@ abstract class BaseTemplateService {
             wc.componentClass.prototype._ctx = this._ctx;
         });
 
-        // Register slider component as partial 
+        // Register slider component as partial
         let sliderTemplate = Handlebars.compile(`<pnp-slider-component data-items="{{items}}" data-options="{{options}}" data-template="{{@partial-block}}"></pnp-slider-component>`);
         Handlebars.registerPartial('slider', sliderTemplate);
 
@@ -659,16 +668,14 @@ abstract class BaseTemplateService {
      * Builds and registers the result types as Handlebars partials
      * Based on https://github.com/helpers/handlebars-helpers/ operators
      * @param resultTypes the configured result types from the property pane
+     * @param instanceId id of the the webpart
      */
-    public async registerResultTypes(resultTypes: ISearchResultType[]): Promise<void> {
-
+    public async registerResultTypes(resultTypes: ISearchResultType[], instanceId:string): Promise<void> {
         if (resultTypes.length > 0) {
-            let content = await this._buildCondition(resultTypes, resultTypes[0], 0);
-            let template = Handlebars.compile(content);
-            Handlebars.registerPartial('resultTypes', template);
-        } else {
-            Handlebars.registerPartial('resultTypes', '{{> @partial-block }}');
-        }
+          let content = await this._buildCondition(resultTypes, resultTypes[0], 0);
+          let template = Handlebars.compile(content);
+          Handlebars.registerPartial(`resultTypes-${instanceId}`, template);
+      }
     }
 
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -564,7 +564,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
         this.properties.sortableFields = Array.isArray(this.properties.sortableFields) ? this.properties.sortableFields : [];
 
-        // Ensure the minmal managed properties are here        
+        // Ensure the minmal managed properties are here
         const defaultManagedProperties =    [
                                                 "Title",
                                                 "Path",
@@ -607,7 +607,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
 
             defaultManagedProperties.map(property => {
 
-                const idx = findIndex(properties, item => property.toLowerCase() === item.toLowerCase());                
+                const idx = findIndex(properties, item => property.toLowerCase() === item.toLowerCase());
                 if (idx === -1) {
                     properties.push(property);
                 }
@@ -617,7 +617,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
         } else {
             this.properties.selectedProperties = defaultManagedProperties.join(',');
         }
-        
+
         this.properties.resultTypes = Array.isArray(this.properties.resultTypes) ? this.properties.resultTypes : [];
         this.properties.synonymList = Array.isArray(this.properties.synonymList) ? this.properties.synonymList : [];
         this.properties.searchQueryLanguage = this.properties.searchQueryLanguage ? this.properties.searchQueryLanguage : -1;
@@ -907,7 +907,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
         }
 
         // Register result types inside the template
-        this._templateService.registerResultTypes(this.properties.resultTypes);
+        this._templateService.registerResultTypes(this.properties.resultTypes, this.instanceId);
 
         await this._templateService.optimizeLoadingForTemplate(this._templateContentToDisplay);
     }

--- a/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
+++ b/search-parts/src/webparts/searchResults/components/Layouts/SearchResultsTemplate.tsx
@@ -23,6 +23,7 @@ export default class SearchResultsTemplate extends React.Component<ISearchResult
         this._domPurify.setConfig({
             ADD_TAGS: ['style'],
             ADD_ATTR: ['onerror', 'target', 'loading'],
+            ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
             WHOLE_DOCUMENT: true
         });
 
@@ -40,7 +41,7 @@ export default class SearchResultsTemplate extends React.Component<ISearchResult
             if (data && data.attrName) {
                 data.allowedAttributes[data.attrName] = true;
             }
-        });   
+        });
     }
 
     public render() {


### PR DESCRIPTION
Fix #316

The idea is to register partials for each webpart instances.

The original `resultTypes` partial is replaced by a new one that rely on a helper that takes instance ID of the WebPart to select the actual partial to use.

The fix works in my case (a page with two search results webparts. One result type rule for one of the two). This should be reviewed I guess.


Hope that helped