### PR TITLE
Grammatical error in the search box suggestions

### DIFF
--- a/search-parts/src/webparts/searchBox/loc/en-us.js
+++ b/search-parts/src/webparts/searchBox/loc/en-us.js
@@ -56,7 +56,7 @@ define([], function() {
       "ExternalUrlLabel": "External Template Url",
       "InlineTemplateEditPanelTitle": "Edit suggestion template",
       "DefaultSuggestionGroupName": "Recommended",
-      "SharePointSuggestionGroupName": "Others have search for",
+      "SharePointSuggestionGroupName": "Others have searched for",
     }
   }
 });


### PR DESCRIPTION
Fixed a subtle grammatical error in the search box suggestions.

"Others have search for" should be "Others have search**ed** for"