### PR TITLE
Added ability to set pnp-fabric-icon error image

### DIFF
--- a/docs/search-parts/templating.md
+++ b/docs/search-parts/templating.md
@@ -198,7 +198,7 @@ The web part has a couple of helper web-components to ease rendering, used by th
 - slider-component
 - persona-card
 - persona-card-shimmers
-- fabric-icon - You only need to set one property, which are evaluated in order if multiple ones are set.
+- fabric-icon - You only need to set one property, which are evaluated in order if multiple ones are set. The data-error-image, used to set a fallback image on error, is used only when the data-image-url fails to load, it will not load a fallback for data-icon-name usage.
 
 ```html
 <pnp-fabric-icon
@@ -206,6 +206,7 @@ The web part has a couple of helper web-components to ease rendering, used by th
     data-file-extension='[file extension - pri 2]'
     data-icon-name='[office ui fabric icon name - pri 3]'
     data-size='16 | 20 | 32 (default) | 40 | 48 | 64 | 96'
+    data-error-image='[url to image]'
 >
 </pnp-fabric-icon>
 ```

--- a/search-parts/src/components/IconComponent.tsx
+++ b/search-parts/src/components/IconComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Icon, IconType, mergeStyles, ImageFit, ITheme } from 'office-ui-fabric-react';
+import { Icon, IconType, mergeStyles, ImageFit, ITheme, ImageLoadState } from 'office-ui-fabric-react';
 import { getFileTypeIconProps, FileTypeIconSize, FileIconType } from '@uifabric/file-type-icons';
 import { isEmpty, trimStart } from '@microsoft/sp-lodash-subset';
 import { BaseWebComponent } from './BaseWebComponent';
@@ -16,12 +16,25 @@ export interface IIconProps {
      * The current theme settings
      */
     themeVariant?: IReadonlyTheme;
+
+    /**
+     * Fallback image or icon should loading fail
+     */
+    errorImage?:string;
 }
 
 export interface IIconState {
+    errorImage:string;
 }
 
 export class IconComponent extends React.Component<IIconProps, IIconState> {
+
+    constructor(props: IIconProps){
+        super(props);
+        this.state = {
+            errorImage : undefined
+        };
+    }
 
     public render() {
         let iconSize: FileTypeIconSize = 32;
@@ -38,8 +51,10 @@ export class IconComponent extends React.Component<IIconProps, IIconState> {
         });
 
         let iconProps;
-        if (!isEmpty(this.props.imageUrl)) {
-            iconProps = { iconType: IconType.Image, imageProps: { src: this.props.imageUrl, imageFit: ImageFit.contain, width: iconSize + 'px', height: iconSize + 'px' } };
+        if (!isEmpty(this.props.imageUrl) || this.state.errorImage) {
+            
+            iconProps = { iconType: IconType.Image, imageProps: { src: this.state.errorImage || this.props.imageUrl, imageFit: ImageFit.contain, width: iconSize + 'px', height: iconSize + 'px', onLoadingStateChange: this.onLoadingStateChange.bind(this) } };
+
         } else if (!isEmpty(this.props.fileExtension)) {
 
             if (this.props.fileExtension == "IsListItem") {
@@ -50,13 +65,30 @@ export class IconComponent extends React.Component<IIconProps, IIconState> {
                 let fileExt = trimStart(this.props.fileExtension.trim(), '.');
                 iconProps = getFileTypeIconProps({ extension: fileExt, size: iconSize });
             }
+
         } else if (!isEmpty(this.props.iconName)) {
+            
             iconProps = { iconName: this.props.iconName };
+
         } else {
+            
             iconProps = getFileTypeIconProps({ type: FileIconType.genericFile, size: iconSize, imageFileType: 'svg' });
+            
         }
         return <Icon {...iconProps} theme={this.props.themeVariant as ITheme} className={iconClass} />;
     }
+
+    private onLoadingStateChange(loadState: ImageLoadState) {
+        // check to see if we have an error and assign fallback image or skip if we've already tried to load it
+        if(loadState === ImageLoadState.error 
+            && this.props.errorImage 
+            && this.props.errorImage !== this.state.errorImage) {
+            this.setState({
+                errorImage: this.props.errorImage
+            });
+        }
+    }
+    
 }
 
 export class IconWebComponent extends BaseWebComponent {


### PR DESCRIPTION
Added the ability to set pnp-fabric-icon error image.

The error image can be used when the url passed to data-image-url fails to load. It does not work in scenarios where a data-icon-name is passed as the onLoadingStateChange callback is not fired.

As this is an enhancement please feel free to reject. 