### PR TITLE
Added handlebars helper filterArrayByProperty

### DIFF
--- a/docs/search-parts/templating.md
+++ b/docs/search-parts/templating.md
@@ -216,7 +216,7 @@ Setting | Description
 `{{#group items by="owstaxidmetadataalltagsinfo"}}` | Group items by a specific results property. See [https://github.com/shannonmoeller/handlebars-group-by](https://github.com/shannonmoeller/handlebars-group-by) for usage.
 `{{#getAttachments LinkOfficeChild}} <a href="{{url}}">{{fileName}}</href> {{/getAttachments}}`| Get Attachments is Handlebars block helper intended to be used with the context variables it provides like this (url and filename) in the example.The helper is intended to be used only with the LinkOfficeChild managed property wich is the default managed property for list attachments.
 `{{getPageContext "property"}}` | Retrieve SPFx page context data to show in the template. See [https://docs.microsoft.com/en-us/javascript/api/sp-page-context/pagecontext](https://docs.microsoft.com/en-us/javascript/api/sp-page-context/pagecontext) for possible values. Example `{{getPageContext "user.displayName"}}` `{{getPageContext "cultureInfo.currentUICultureName"}}`.<br>**Note: Casing matches the object model.**
- 
+`{{filterArrayByProperty items "property" "regex"}}` | Filter items based on a property's value using regular expression. 
 
 You can also define your own in the *BaseTemplateService.ts* file. See [helper-moment](https://github.com/helpers/helper-moment) for date samples using moment.
 

--- a/search-parts/src/services/TemplateService/BaseTemplateService.tsx
+++ b/search-parts/src/services/TemplateService/BaseTemplateService.tsx
@@ -193,6 +193,18 @@ abstract class BaseTemplateService {
      * Registers useful helpers for search results templates
      */
     private registerTemplateServices() {
+        
+        // Return a new array based on the regex filter specified property for an object in the array
+        // {{#each (filterArrayByProperty items "Topic" "^[Aa]|^[Bb]")}}</p>
+        Handlebars.registerHelper("filterArrayByProperty", (array: any[], property: string, regex: string) => {
+            if (!Array.isArray(array)) return 0;
+            if (array.length === 0 || property.length === 0 || regex.length === 0) return 0;
+
+            return array.filter( (arrayItem) => {
+                return new RegExp(regex).test(arrayItem[property]);
+            });
+        });
+        
         // Return the URL of the search result item
         // Usage: <a href="{{url item}}">
         Handlebars.registerHelper("getUrl", (item: ISearchResult, forceDirectLink: boolean = false) => {


### PR DESCRIPTION
## Problem

_What problem are you trying to solve?_

We can filter the search results on managed property values using KQL however sometimes we might not get the exact filter we need using KQL. Example _filter the results which have first character of the Title between A-H_ . 

The existing Handlebars helpers do have a `regex` helper however that cannot be used directly in filtering an array.

## Solution

_How did you solve the problem?_

A new helper named `filterArrayByProperty` has been added in this PR. The helper function accepts an array, name of the property and a regular expression. Based on the property and the regular expression, the function returns a filtered array that matches the regex specified for the property.

## Example use case

Say we want to group the results in 3 groups of alphabets - A-H, I-P and Q-Z. In that scenario we can use this helper to get the filtered items for these groups i.e. get the items which have the first character of Title between A-H, the I-P and then Q-Z.

The results would be as shown in the image below (SharePoint List on the left and the PnP Search Results webpart on the right)

![image](https://user-images.githubusercontent.com/9694225/95005538-f7f1ac80-05f1-11eb-8324-caaeddc9bddd.png)

Template needed for the example above

```html
             <ul>
                <b>A-H</b>
                {{#each (filterArrayByProperty items "Title" "^[a-hA-H]")}}
                    <li>
                            <span>{{Title}}</span>
                    </li>
                {{/each}}
                <br />
                <b>I-P</b>
                {{#each (filterArrayByProperty items "Title" "^[i-pI-P]")}}
                    <li>
                            <span>{{Title}}</span>
                    </li>
                {{/each}}
                <br />
                <b>Q-Z</b>
                {{#each (filterArrayByProperty items "Title" "^[q-zQ-Z]")}}
                    <li>
                            <span>{{Title}}</span>
                    </li>
                {{/each}}
            </ul>
```

## Other notes

The file `IFilterLayoutProps.ts` has a property named `eLanguage` which is causing an issue. Hence during development of this PR that property had to be changed to `language`.

The scenario explained in example above can be solved using the combination of `regex` and `startsWith` helpers. However, that would be slightly complex approach. 

Apologies if I have overthought this and missed a different way of solving the problem.
