### PR TITLE
Added theme variant to Web Part Title

### DIFF
--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -127,7 +127,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
         // WebPart Title
         if (this.props.webPartTitle && this.props.webPartTitle.length > 0) {
-            renderWebPartTitle = <WebPartTitle title={this.props.webPartTitle} updateProperty={null} displayMode={DisplayMode.Read} />;
+            renderWebPartTitle = <WebPartTitle title={this.props.webPartTitle} updateProperty={null} displayMode={DisplayMode.Read} themeVariant={this.props.themeVariant} />;
         }
 
         let totalPrimaryAndSecondaryResults = this.state.results.RelevantResults.length;


### PR DESCRIPTION
This makes the text colour of the web part title change appropriately when the section background changes.

See: https://github.com/microsoft-search/pnp-modern-search/issues/617

Note: the font styling (font-weight) has been updated in the latest version of sp-dev-fx-controls-react to match OOTB, but the version number diff is way off so a lot of testing needed before updating that dependency. This PR solely address the colour change issue for section backgrounds.