### PR TITLE
Fix mapping attempt of missing aggregations on Graph objects

### DIFF
--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -622,7 +622,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                     }
 
                     // Map refinement results
-                    hitContainer.aggregations.forEach((aggregation) => {
+                    hitContainer.aggregations && hitContainer.aggregations.forEach((aggregation) => {
 
                         let values: IDataFilterResultValue[] = [];
                         aggregation.buckets.forEach((bucket) => {


### PR DESCRIPTION
When testing out Microsoft Search with a ServiceNow connector, the query succeeded in pulling data, but failed when evaluating the response payload. Using my connector, the Graph query's result payload has no aggregations specified so that doesn't exist on the object at all. The code attempts to map aggregations in MicrosoftSearchDataSource.ts, which fails.

![image](https://user-images.githubusercontent.com/985283/102553615-fc1d5a00-4077-11eb-801a-c0610428c0c5.png)
![image](https://user-images.githubusercontent.com/985283/102553674-15260b00-4078-11eb-8c0f-7493d326118e.png)
![image](https://user-images.githubusercontent.com/985283/102553607-f889d300-4077-11eb-97e3-2a3a6c63c94f.png)

Fixed it by adding a check and only mapping aggregations if they exist on the response Graph query's payload.

Thanks!