### PR TITLE
Issue 708 scrolling into view

### DIFF
--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -320,8 +320,8 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                       if ((this._searchWpRef as any).scrollIntoViewIfNeeded) {                          
                         (this._searchWpRef as any).scrollIntoViewIfNeeded(false);
                       } else {
-                        // Set the focus at the top of the component
-                        this._searchWpRef.focus();
+                        // Scroll to the top of the component
+                        this._searchWpRef.scrollIntoView(true);
                       }                      
                     }
 

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -318,6 +318,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                     if (isPageUpdated) {
                         // Set the focus at the top of the component
                         this._searchWpRef.focus();
+                        this._searchWpRef.scrollIntoView(true);
                     }
 
                     if (resetSorting) {

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer/SearchResultsContainer.tsx
@@ -316,9 +316,13 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                     });
 
                     if (isPageUpdated) {
+                      // This is WebKit only, so defensively code and fallback to a simple "focus"
+                      if ((this._searchWpRef as any).scrollIntoViewIfNeeded) {                          
+                        (this._searchWpRef as any).scrollIntoViewIfNeeded(false);
+                      } else {
                         // Set the focus at the top of the component
                         this._searchWpRef.focus();
-                        this._searchWpRef.scrollIntoView(true);
+                      }                      
                     }
 
                     if (resetSorting) {


### PR DESCRIPTION
Added a `scrollIntoView`, so that when you navigate pages the top of the results goes to the top of the view, if necessary.

See issue: https://github.com/microsoft-search/pnp-modern-search/issues/708