### PR TITLE
Fixed #699

### DIFF
--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -97,7 +97,7 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         this.properties.fieldIconExtension = this.properties.fieldIconExtension ?  this.properties.fieldIconExtension: 'FileType';
         this.properties.enableGrouping = this.properties.enableGrouping !== null && this.properties.enableGrouping !== undefined ?  this.properties.enableGrouping: false;
         this.properties.groupByField = this.properties.groupByField ?  this.properties.groupByField: '';     
-        this.properties.groupsCollapsed = this.properties.groupsCollapsed !== null && this.properties.groupsCollapsed !== undefined ?  this.properties.enableGrouping: true;
+        this.properties.groupsCollapsed = this.properties.groupsCollapsed !== null && this.properties.groupsCollapsed !== undefined ?  this.properties.groupsCollapsed: true;
     
         const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
             /* webpackChunkName: 'pnp-modern-search-property-pane' */


### PR DESCRIPTION
Typo in the "groupsCollapsed" property name during initialization.