### PR TITLE
Fixed problems with localization resource files

### DIFF
--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -145,8 +145,6 @@ declare interface ICommonStrings {
           SortPanelSortDirectionLabel:string;
           SortDirectionColumnLabel: string;
           SortFieldColumnLabel: string;
-          SortableFieldManagedPropertyField: string;
-          SortableFieldDisplayValueField: string;
           EditSortLabel: string;
           SortInvalidSortableFieldMessage: string;
           SortFieldColumnPlaceholder: string;
@@ -323,9 +321,8 @@ declare interface ICommonStrings {
       }
     }
 }
-  
+
 declare module 'CommonStrings' {
   const strings: ICommonStrings;
   export = strings;
 }
-  

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -182,7 +182,6 @@ define([], function() {
                 ResizableColumnLabel: "Størrelse kan redigeres",
                 MultilineColumnLabel: "Multi-linje",
                 LinkToItemColumnLabel: "Link til item",
-                SupportHTMLColumnLabel: "Tillad HTML",
                 CompactModeLabel: "Compakt-mode",
                 ShowFileIcon: "Vis filikon",
                 ManageDetailsListColumnDescription: "Tilføj, opdatér eller fjern kolonner fra layoutet på detaljelisten. Du kan enten bruge egenskabsværdier i listen direkte uden nogen transformation, eller du kan bruge et Handlebars-udtryk som feltets værdi. HTML er supporteret til brug i alle felter.",

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -182,7 +182,6 @@ define([], function() {
                 ResizableColumnLabel: "Resizable",
                 MultilineColumnLabel: "Multiline",
                 LinkToItemColumnLabel: "Link to item",
-                SupportHTMLColumnLabel: "Allow HTML",
                 CompactModeLabel: "Compact mode",
                 ShowFileIcon: "Show file icon",
                 ManageDetailsListColumnDescription: "Add, update or remove columns for the details list layout. You can use either property values in the list directly without any transformation or use an Handlebars expression in the value field. HTML is supported for all fields as well.",

--- a/search-parts/src/webparts/searchBox/loc/da-dk.js
+++ b/search-parts/src/webparts/searchBox/loc/da-dk.js
@@ -11,6 +11,7 @@ define([], function() {
         PageUrlLabel: "Sidens URL",
         UrlErrorMessage: "Indsæt venligst en gyldig URL.",
         QueryPathBehaviorLabel: "Metode",
+        QueryInputTransformationLabel: "Query input transformation template",
         UrlFragmentQueryPathBehavior: "URL-fragment",
         QueryStringQueryPathBehavior: "URL-parametre",
         QueryStringParameterName: "Parameternnavn",

--- a/search-parts/src/webparts/searchResults/loc/da-dk.js
+++ b/search-parts/src/webparts/searchResults/loc/da-dk.js
@@ -66,7 +66,6 @@ define([], function() {
           LessOrEqualOperator: "Mindre eller lig",
           LessThanOperator: "Mindre end",
           CancelButtonText: "Annuller",
-          DialogButtonLabel: "Redigér skabelon",
           DialogButtonText: "Redigér skabelon",
           DialogTitle: "Redigér resultatsskabelon",
           SaveButtonText: "Gem"

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -66,7 +66,6 @@ define([], function() {
           LessOrEqualOperator: "Less or equal",
           LessThanOperator: "Less than",
           CancelButtonText: "Cancel",
-          DialogButtonLabel: "Edit template",
           DialogButtonText: "Edit template",
           DialogTitle: "Edit results template",
           SaveButtonText: "Save"

--- a/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
@@ -42,7 +42,6 @@ declare interface ISearchResultsWebPartStrings {
       ErrorTemplateResolve: string;
       DialogButtonLabel: string;
       DialogTitle: string;
-      ManageDetailsListColumnLabel: string;
       ShowSelectedFilters: string;
       ShowBlankIfNoResult: string;
       ShowResultsCount: string;


### PR DESCRIPTION
I found some inconsistencies in localization resource files - some labels were removed, some migrated to new nodes, one label was missing. This PR fixes all that issues.   

To summarize the changes: 
- _commonStrings.d.ts_:
	- `Sort.SortableFieldManagedPropertyField` and `Sort.SortableFieldDisplayValueField` are not used anymore in solution (they are missing in corresponding `{locale}.js` files and no usages were found). So I removed them altogether from `commonStrings.d.ts`
	- `DetailsList.SupportHTMLColumnLabel` is not found in `commonStrings.d.ts`, so I removed corresponding properties from `{locale}.js` files
- _searchResults/loc/mystrings.d.ts_:
	- `LayoutPage.ManageDetailsListColumnLabel` was moved to the `common.d.ts` localization files, thus I removed this definition
	- `ResultTypes.DialogButtonLabel` is not defined in `searchResults/loc/mystrings.d.ts` (actually it was moved to `LayoutPage.DialogButtonLabel`), thus was removed from corresponding {locale}.js files
- _searchBox/loc/mystrings.d.ts_:
	- `da-dk.js` is missing `SearchBoxSettingsGroup.QueryInputTransformationLabel` property. I'm not sure what is the right Danish translation, so I just added an English version to fix the problem. If you could tell me the right translation in Danish for "Query input transformation template", I will update the PR.   

How I found all those issues? Recently I've published a VSCode extension called [SPFx Check Locale](https://marketplace.visualstudio.com/items?itemName=s-kainet.spfx-check-locale), which dynamically checks SPFx solutions for potential problems with localization files. It's also available as a Nodejs module, so you can integrate it to your build pipeline and fail a build if there are issues with resource files - [check it out an example here](https://github.com/s-KaiNet/spfx-check-locale). 