### PR TITLE
Fixed #933

### DIFF
--- a/search-parts/src/layouts/resultTypes/default_simple_list.html
+++ b/search-parts/src/layouts/resultTypes/default_simple_list.html
@@ -12,7 +12,7 @@
             <a href="{{slot item @root.slots.PreviewUrl}}" target="_blank" data-interception="off">{{slot item @root.slots.Title}}</a>
         </span>
         <span>
-            {{getSummary (slot item @root.slots.Summary)}}
+            <div>{{getSummary (slot item @root.slots.Summary)}}</div>
             <span class="template--listItem--author">
                 {{#with (split (slot item @root.slots.Author) '|')}}
                     {{[1]}}

--- a/search-parts/src/layouts/results/simpleList/simple-list.html
+++ b/search-parts/src/layouts/results/simpleList/simple-list.html
@@ -75,7 +75,7 @@
                             </span>
                             <span class="template--listItem--date">{{getDate (slot item @root.slots.Date) "LL"}}</span>                            
                         </span>                        
-                        {{getSummary (slot item @root.slots.Summary)}}
+                        <div>{{getSummary (slot item @root.slots.Summary)}}</div>
                         <div class="template--listItem--tags example-themePrimary">
                             {{#if (slot item @root.slots.Tags)}}
                             <pnp-icon data-name="Tag" aria-hidden="true" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon>


### PR DESCRIPTION
A `div` was missing for the `{{getSummary}}` helper in the simple and default list templates causing an incorrect formatting.