### PR TITLE
fix regex in tokenservice.ts that broke legacy edge. Fix #803

### DIFF
--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -26,7 +26,7 @@ export class TokenService implements ITokenService {
     /**
      * This regex only matches expressions enclosed with single, not escaped, curly braces '{}'
      */    
-    private genericTokenRegexp: RegExp = /(?<!\\){[^\{]*?}(?!\\)/gi;
+    private genericTokenRegexp: RegExp = /{[^\{]+?[^\\]}/gi;
 
     /**
      * The list of user properties. Used to avoid refetching it every time.


### PR DESCRIPTION
Fix #803.

Only Edge is repaired. IE 11 wasn't targeted