### PR TITLE
Fixed small issues in Swedish resource files

### DIFF
--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -182,7 +182,6 @@ define([], function () {
           ResizableColumnLabel: "Storleken kan redigeras",
           MultilineColumnLabel: "Flera linjer",
           LinkToItemColumnLabel: "Länk till artikel",
-          SupportHTMLColumnLabel: "Tillåt HTML",
           CompactModeLabel: "Kompakt läge",
           ShowFileIcon: "Visa filikon",
           ManageDetailsListColumnDescription: "Lägg till, uppdatera eller ta bort kolumner från layouten i detaljlistan. Du kan antingen använda egenskapsvärden i listan direkt utan någon transformation, eller så kan du använda ett styruttryck som fältets värde. HTML stöds för användning i alla fält.",
@@ -324,4 +323,3 @@ define([], function () {
       }
     }
   })
-  

--- a/search-parts/src/webparts/searchResults/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchResults/loc/sv-SE.js
@@ -66,7 +66,6 @@ define([], function() {
           LessOrEqualOperator: "Mindre eller lika med",
           LessThanOperator: "Mindre än",
           CancelButtonText: "Avbryt",
-          DialogButtonLabel: "Redigera mall",
           DialogButtonText: "Redigera mall",
           DialogTitle: "Redigera resultatmall",
           SaveButtonText: "Spara"


### PR DESCRIPTION
I noticed some labels in Swedish localization were obsolete and removed them in order to maintain consistency across resource files. 