### PR TITLE
Only load persona card details if required

### DIFF
--- a/search-parts/src/services/UserService/IUserService.ts
+++ b/search-parts/src/services/UserService/IUserService.ts
@@ -1,4 +1,5 @@
+import { IUserInfo } from "../../models/IUser";
 
 export default interface IUserService {
-  getUserInfos(accountNames: string[]): Promise<any>;
+  getUserInfos(accountNames: string[]): Promise<IUserInfo[]>;
 }


### PR DESCRIPTION
Fix #1008 

Only load details of users that don't have display name, instead of loading details for all users. Update array of users with retrieved display name