### PR TITLE
Fix [V3] Apply button always active for Multi-value refinement item t…

### DIFF
--- a/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/Checkbox/CheckboxTemplate.tsx
@@ -12,6 +12,7 @@ import { TextField } from "office-ui-fabric-react";
 
 //CSS
 import styles from './CheckboxTemplate.module.scss';
+import { isEqual } from "@microsoft/sp-lodash-subset";
 
 export default class CheckboxTemplate extends React.Component<IBaseRefinerTemplateProps, IBaseRefinerTemplateState> {
 
@@ -37,7 +38,10 @@ export default class CheckboxTemplate extends React.Component<IBaseRefinerTempla
 
         let disableButtons = false;
 
-        if ((this.props.selectedValues.length === 0 && this.state.refinerSelectedFilterValues.length === 0)) {
+        if (
+          (this.props.selectedValues.length === 0 && this.state.refinerSelectedFilterValues.length === 0) ||
+          (isEqual(this.props.selectedValues, this.state.refinerSelectedFilterValues))
+        ) {
             disableButtons = true;
         }
 


### PR DESCRIPTION
Fix #1015

Add a condition to disable Apply button for multi-value checkboxes when the refiners currently applied are equal to the ones currently selected in checkboxes.