### PR TITLE
fix(doc): update contribution documentation

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -37,21 +37,33 @@ Before making any PR, you need to setup this project locally on your machine. Th
 
 ## Setup the **search-extensibility** project
 
-The `search-extensibilty` project is an SPFx library component containing all the shared interfaces for the `search-parts` and `search-extensibility-demo` other SPFx projects. As a result, **a symbolic link must be build to this project first before it can be used**:
+!!! note
+    By default, the `search-parts` and `search-extensibility-demo` projects use the npm reference [`@pnp/modern-search-extensibility`](https://www.npmjs.com/package/@pnp/modern-search-extensibility){:target="_blank"}.
+    
+    Follow these steps only if you intend to perform some changes on the `search-extensibility` project.
+
+!!! important
+    Because this project is published as an npm reference, any change is critical.
+    
+    Please do not commit changes if you are not sure about what you are doing.
+
+The `search-extensibilty` project is an SPFx library component containing all the shared interfaces for the `search-parts` and `search-extensibility-demo` other SPFx projects. As a result, **a symbolic link must be build to these projects first before it can be used**:
 
 1. Open the `search-extensibility` project and install dependencies using `npm i` or your favorite package manager.
 2. Build the project using the command `npm run build` or `gulp bundle`.
 3. Run the command `npm link` to create a symbolic link.
 
-> A symbolic link is a shortcut that points to another directory or another project (in our case) on your system
-
 You can also refer to the official [SPFx documentation about library component usage](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/library-component-tutorial).
+
+> _A symbolic link is a shortcut that points to another directory or another project (in this case) on your system_
 
 ## Setup the **search-parts** and **search-extensibility-demo** projects
 
 1. From the `search-parts` or `search-extensibility-demo` project, run `npm i`.
-2. Link the local `search-extensibility` project using the command `npm link @pnp/modern-search-extensibility` (The command `npm i` reinitialize the packages. **The command `npm link @pnp/modern-search-extensibility` must be executed after each `npm i`**)
-3. Build the project using `npm run build` or `gulp bundle`.
+2. Build the project using `npm run build` or `gulp bundle`.
+
+!!! note
+    If you made local changes on the `search-extensibility` project, after each `npm i`,  you must link the local `search-extensibility` project using the command `npm link @pnp/modern-search-extensibility`
 
 ## Debug the solution
 

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -63,7 +63,7 @@ You can also refer to the official [SPFx documentation about library component u
 2. Build the project using `npm run build` or `gulp bundle`.
 
 !!! note
-    If you made local changes on the `search-extensibility` project, after each `npm i`,  you must link the local `search-extensibility` project using the command `npm link @pnp/modern-search-extensibility`
+    If you made local changes on the `search-extensibility` project, after each `npm i`, you must link your local `search-extensibility` project using the command `npm link @pnp/modern-search-extensibility`
 
 ## Debug the solution
 


### PR DESCRIPTION
Take into account the @wobba comment https://github.com/microsoft-search/pnp-modern-search/issues/725#issuecomment-861607406.

The `@pnp/modern-search-extensibility` is an npm reference into the `search-parts` and `search-extensibility-demo` projects. Not no need to link the project locally except if some changes are made to it.

But, be aware about any change on `@pnp/modern-search-extensibility` is critical.