### PR TITLE
#1083 Added missing Handlebars helper 'getGraphPreviewUrl'

### DIFF
--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -44,6 +44,7 @@
         "handlebars": "4.7.7",
         "handlebars-group-by": "1.0.1",
         "handlebars-helpers": "0.10.0",
+        "html-loader": "1.1.0",
         "immutability-helper": "3.1.1",
         "jspath": "^0.4.0",
         "lit-html": "1.4.1",
@@ -53,7 +54,8 @@
         "react-ace": "5.8.0",
         "react-dom": "16.9.0",
         "react-js-pagination": "3.0.3",
-        "typescript": "~3.7.0"
+        "typescript": "~3.7.0",
+        "webpack": "4.42.0"
     },
     "resolutions": {
         "@types/react": "16.9.36"
@@ -65,6 +67,9 @@
         "@microsoft/sp-module-interfaces": "1.12.1",
         "@microsoft/sp-tslint-rules": "1.12.1",
         "@microsoft/sp-webpart-workbench": "1.12.1",
+        "@types/react": "16.9.36",
+        "@types/react-dom": "16.9.8",
+        "@types/webpack-env": "1.13.1",
         "ajv": "~5.2.2",
         "colors": "1.4.0",
         "fancy-log": "1.3.3",
@@ -72,9 +77,6 @@
         "spfx-fast-serve-helpers": "~1.12.11",
         "string-replace-loader": "2.3.0",
         "unlazy-loader": "0.1.3",
-        "webpack-bundle-analyzer": "^4.4.2",
-        "@types/react": "16.9.36",
-        "@types/react-dom": "16.9.8",
-        "@types/webpack-env": "1.13.1"
+        "webpack-bundle-analyzer": "^4.4.2"
     }
 }

--- a/search-parts/src/helpers/UrlHelper.ts
+++ b/search-parts/src/helpers/UrlHelper.ts
@@ -82,6 +82,40 @@ export class UrlHelper {
         const htmlContent: Document = domParser.parseFromString(`<!doctype html><body>${encodedStr}</body>`, 'text/html');
         return htmlContent.body.textContent;
     }
+
+    /**
+     * Try to guess the item URL according to its . (i.e the URL where the user will be redirected to)
+     * @param item the result item
+     */
+    public static getGraphPreviewUrl(url: string) {
+
+        // Try to guess the href link according to URL using the Microsoft Graph format
+        if (url) {
+            // See https://support.microsoft.com/en-us/office/file-types-supported-for-previewing-files-in-onedrive-sharepoint-and-teams-e054cd0f-8ef2-4ccb-937e-26e37419c5e4
+            url = UrlHelper.createOdspPreviewUrl(url);
+        }
+    
+        return url;
+    }
+
+    public static createOdspPreviewUrl(url: string): string {
+
+        let previewUrl: string = url;
+
+        if (url) {
+
+            const matches = url.match(/^(http[s]?:\/\/[^\/]*)(.+)\/(.+)$/);
+            // First match is the complete URL
+            if (matches) {
+                const [host, path, file] = matches.slice(1);
+                if (host && path && file) {
+                    previewUrl = `${host}${path}/?id=${path}/${file}&parent=${path}`;
+                }
+            }
+        }
+
+        return previewUrl;
+    }
 }
 
 export enum PageOpenBehavior {

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -374,6 +374,13 @@ export class TemplateService implements ITemplateService {
      * Registers custom Handlebars helpers in the global context
      */
     private registerCustomHelpers() {
+
+        // Return the URL of the search result item
+        // Usage: <a href="{{getGraphPreviewUrl url}}">
+        this.Handlebars.registerHelper("getGraphPreviewUrl", (url: any, context?: any) => {
+            return new this.Handlebars.SafeString(UrlHelper.getGraphPreviewUrl(url));
+        });
+
         // Return the search result count message
         // Usage: {{getCountMessage totalRows keywords}} or {{getCountMessage totalRows null}}
         this.Handlebars.registerHelper("getCountMessage", (totalRows: string, inputQuery?: string) => {


### PR DESCRIPTION
The documentation was referencing a Handlebars helper that didn't exist in the code.