### PR TITLE
SearchRefiners: Unwanted filters checked when using filters in URL #1085

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1902,7 +1902,7 @@ export default class SearchResultsWebPart extends BaseClientSideWebPart<ISearchR
                                 updatedSelectedFilterValue.RefinementValue.indexOf(refinementValue.RefinementValue) > -1) {
                                 // There is a deep link filter in FQL expression that will be duplicated in the UI if the next else if is evaluated to true
                                 updatedSelectedFilterValues.push(refinementValue);
-                            } else if (StringHelper.longestCommonSubstring(updatedSelectedFilterValue.RefinementToken, refinementValue.RefinementValue) && updatedSelectedFilterValue.RefinementToken.indexOf("range") === -1) {
+                            } else if (updatedSelectedFilterValue.RefinementToken.indexOf("ǂǂ") === -1 && StringHelper.longestCommonSubstring(updatedSelectedFilterValue.RefinementToken, refinementValue.RefinementValue) && updatedSelectedFilterValue.RefinementToken.indexOf("range") === -1) {
                                 // Means the provided condition in URL is an FQL expression so we try to guess the corresponding refinement results using the text value contained in the expression itself
                                 updatedSelectedFilterValues.push(refinementValue);
                             }


### PR DESCRIPTION
SearchRefiners: Unwanted filters checked when using filters in URL #1085

If RefinementToken doesn't contains ǂǂ, then it could means that the provided condition in URL is an FQL expression