### PR TITLE
[v3] Fixed an issue in the Tree Container filter template

### DIFF
--- a/search-parts/src/webparts/searchRefiners/components/Templates/ContainerTree/ContainerTreeTemplate.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/Templates/ContainerTree/ContainerTreeTemplate.tsx
@@ -127,6 +127,10 @@ export default class ContainerTreeTemplate extends React.Component<IFoldersTempl
                             isExpanded: this.props.showExpanded,
                             refinementValue: url === currPath ? value : null,
                             onClick: (ev, item: INavLink) => {
+
+                                // Re-encode the refinement token to make sure it corresponds to the actual path
+                                // If the path is too long, the SharePoint search will return a truncated refinement token value resulting to empty results 
+                                value.RefinementToken = `"${value.RefinementValue}"`;
             
                                 ev.preventDefault();
             


### PR DESCRIPTION
Re-encode the refinement token to make sure it corresponds to the actual path. Sometimes, when the path is too long, the SharePoint search will return a truncated refinement token value resulting to empty results.