### PR TITLE
Fixed warning messages due to multiple file type icons load in the template service

### DIFF
--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -34,8 +34,6 @@
         "@types/react-dom": "16.8.3",
         "@uifabric/file-type-icons": "7.6.30",
         "@uifabric/icons": "7.5.23",
-        "@uifabric/styling": "7.19.0",
-        "@uifabric/utilities": "7.33.5",
         "@webcomponents/webcomponentsjs": "2.5.0",
         "core-js": "3.15.2",
         "dompurify": "2.0.17",

--- a/search-parts/src/components/PersonaComponent.tsx
+++ b/search-parts/src/components/PersonaComponent.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { Persona, IPersonaProps, IPersonaSharedProps, getInitials, Icon } from 'office-ui-fabric-react';
+import { Persona, IPersonaProps, IPersonaSharedProps, getInitials, Icon, ITheme } from 'office-ui-fabric-react';
 import { TemplateService } from "../services/templateService/TemplateService";
 import * as ReactDOM from 'react-dom';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
-import { ITheme } from '@uifabric/styling';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import { ITemplateService } from '../services/templateService/ITemplateService';
 import * as DOMPurify from 'dompurify';

--- a/search-parts/src/components/PersonaShimmersComponent.tsx
+++ b/search-parts/src/components/PersonaShimmersComponent.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup } from 'office-ui-fabric-react';
+import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup, ITheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
-import { ITheme } from "@uifabric/styling";
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 
 export interface IPersonaCardShimmersComponentProps {

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -10,6 +10,7 @@ import { IComponentDefinition } from "@pnp/modern-search-extensibility";
 import groupBy from 'handlebars-group-by';
 import { IComponentFieldsConfiguration } from "../../models/common/IComponentFieldsConfiguration";
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
+import { GlobalSettings } from 'office-ui-fabric-react';
 import { IDataResultType, ResultTypeOperator } from "../../models/common/IDataResultType";
 import { IDataResultsTemplateContext } from "../../models/common/ITemplateContext";
 import { UrlHelper } from "../../helpers/UrlHelper";
@@ -108,7 +109,11 @@ export class TemplateService implements ITemplateService {
             this.registerCustomHelpers();
 
             // Register icons and pull the fonts from the default SharePoint cdn.
-            initializeFileTypeIcons();
+            // Do not load icons twice as it may generate warnings
+            if  (!GlobalSettings.getValue('fileTypeIconsInitialized')) {
+                initializeFileTypeIcons();
+                GlobalSettings.setValue('fileTypeIconsInitialized', true);
+            }
         });
     }
 

--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { ISearchBoxContainerProps } from './ISearchBoxContainerProps';
 import { QueryPathBehavior, UrlHelper, PageOpenBehavior } from '../../../helpers/UrlHelper';
-import { MessageBar, MessageBarType, SearchBox, IconButton } from 'office-ui-fabric-react';
+import { MessageBar, MessageBarType, SearchBox, IconButton, ITheme } from 'office-ui-fabric-react';
 import { ISearchBoxContainerState } from './ISearchBoxContainerState';
-import { ITheme } from '@uifabric/styling';
 import { isEqual } from '@microsoft/sp-lodash-subset';
 import * as webPartStrings from 'SearchBoxWebPartStrings';
 import SearchBoxAutoComplete from './SearchBoxAutoComplete/SearchBoxAutoComplete';

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import styles from './SearchVerticalsContainer.module.scss';
 import { ISearchVerticalsContainerProps } from './ISearchVerticalsContainerProps';
-import { Pivot, PivotItem, IPivotItemProps, Icon, GlobalSettings, IChangeDescription } from 'office-ui-fabric-react';
-import { ITheme } from '@uifabric/styling';
+import { Pivot, PivotItem, IPivotItemProps, Icon, GlobalSettings, IChangeDescription, ITheme } from 'office-ui-fabric-react';
 import { WebPartTitle } from '@pnp/spfx-controls-react/lib/WebPartTitle';
 import { PageOpenBehavior } from '../../../helpers/UrlHelper';
 import { ISearchVerticalsContainerState } from './ISearchVerticalsContainerState';


### PR DESCRIPTION
Removed unecessary ITheme references from @uifabric/styling. Replace by the ITheme in office ui fabric package + fix warnings messages due to multiple file type icons load in the template service.