### PR TITLE
added ImportExport nl-nl translation

### DIFF
--- a/search-parts/src/webparts/searchBox/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchBox/loc/nl-nl.js
@@ -39,7 +39,8 @@ define([], function() {
           PanelHeader: "Configureer inladen van uitbreidingsbibliotheken voor aangepaste zoeksuggestie bronnen bij opstarten",
           PanelDescription: "Beheer hier je aangepaste uitbreidingsbibliotheek ID's. Je kan hier een weergavenaam specificeren en aangeven of de bibliotheek geladen moet worden. Alleen aangepaste zoeksuggestie bronnen worden hier geladen.",
         }
-      }
+      },
+      ImportExport: "Importeer / Exporteer instellingen "
     },
     SearchBox: {
       DefaultPlaceholder: "Geef hier je zoektermen op..."

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -62,7 +62,8 @@ define([], function() {
                 ErrorTemplateResolve: "Kan het opgegeven template niet inladen. Foutmelding: '{0}'",
                 FiltersTemplateFieldLabel: "Bewerk filters sjabloon",
                 FiltersTemplatePanelHeader: "Bewerk filters sjabloon"
-            }
+            },
+            ImportExport: "Importeer / Exporteer instellingen "
         }
     }
 });

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -94,7 +94,8 @@ define([], function() {
           PanelHeader: "Configureer inladen van uitbreidingsbibliotheken bij opstarten",
           PanelDescription:"Beheer hier je aangepaste uitbreidingsbibliotheek ID's. Je kan hier een weergavenaam specificeren en aangeven of de bibliotheek geladen moet worden. Alleen aangepaste databronnen, indelingen, web componenten en Handlebars helpers worden hier geladen.",
         }
-      }
+      },
+      ImportExport: "Importeer / Exporteer instellingen "
     }
   }
 });

--- a/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
@@ -17,7 +17,8 @@ define([], function() {
                     LinkUrl: "Link URL",
                     OpenBehavior: "Gedrag bij openen"
                 }
-            }
+            },
+            ImportExport: "Importeer / Exporteer instellingen "
         }
     }
 });


### PR DESCRIPTION
Added nl-nl translation for key _'ImportExport'_ as this key was missing from nl-nl.js in webpart translation files.

tested by

- Adding updated solution package to dev tenant
- Adding the PnP webparts to page on sitecollection with nl-nl language setting
- Checking if the texts displayed in the webpart UI
- Checking if the webparts still function, separately and in coorperation
- finally checking the same points for the the webpart on en-US site