### PR TITLE
Use input query text Hover Message update

### DIFF
--- a/search-parts/src/webparts/searchResults/loc/da-dk.js
+++ b/search-parts/src/webparts/searchResults/loc/da-dk.js
@@ -80,7 +80,7 @@ define([], function() {
         LinkToVerticalLabel: "Vis kun data, når følgende vertikaler er valgt",
         LinkToVerticalLabelHoverMessage: "Resultaterne vil kun blive vist, hvis de valgte vertikaler matcher med den, der er konfigureret til denne webpart. Ellers vil denne webpart være blank.",
         UseInputQueryText: "Anvend input til forespørgselstekst",
-        UseInputQueryTextHoverMessage: "Anvend {searchQueryText} token i din datakilde for at hente denne værdi",
+        UseInputQueryTextHoverMessage: "Anvend {inputQueryText} token i din datakilde for at hente denne værdi",
         SearchQueryTextFieldLabel: "Forespørgselstekst",
         SearchQueryTextFieldDescription: "",
         SearchQueryPlaceHolderText: "Indsæt forespørgselstekst...",

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -80,7 +80,7 @@ define([], function() {
                 LinkToVerticalLabel: "Display data only when the following vertical is selected",
                 LinkToVerticalLabelHoverMessage: "The results will be displayed only if the selected vertical matches with the one configured for this Web Part. Otherwise, the Web part will be blank (no margin and no padding) in display mode.",
                 UseInputQueryText: "Use input query text",
-                UseInputQueryTextHoverMessage: "Use the {searchQueryText} token in your data source to retrieve this value",
+                UseInputQueryTextHoverMessage: "Use the {inputQueryText} token in your data source to retrieve this value",
                 SearchQueryTextFieldLabel: "Query text",
                 SearchQueryTextFieldDescription: "",
                 SearchQueryPlaceHolderText: "Enter query text...",

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -81,7 +81,7 @@ define([], function() {
         LinkToVerticalLabel: "Afficher les données seulement lorsque le composant vertical suivant est sélectionné",
         LinkToVerticalLabelHoverMessage: "Les résultats s’afficheront seulement si le secteur vertical sélectionné correspond à celui configuré pour ce composant Web Sinon, le composant Web sera vide (aucune marge et aucun remplissage) en mode d’affichage.",
         UseInputQueryText: "Utiliser le texte de la requête",
-        UseInputQueryTextHoverMessage: "Utilisez le jeton {searchQueryText} de votre source de données pour récupérer cette valeur",
+        UseInputQueryTextHoverMessage: "Utilisez le jeton {inputQueryText} de votre source de données pour récupérer cette valeur",
         SearchQueryTextFieldLabel: "Texte de la requête",
         SearchQueryTextFieldDescription: "",
         SearchQueryPlaceHolderText: "Entrez le texte qui suit...",

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -80,7 +80,7 @@ define([], function() {
         LinkToVerticalLabel: "Toon data alleen wanneer de volgende zoekverticaal geselecteerd is",
         LinkToVerticalLabelHoverMessage: "De resultaten worden enkel getoond wanneer de geselecteerde zoekverticaal overeenkomt met degene die geconfigureerd is voor dit webonderdeel. Wanneer dit niet het geval is blijft dit webonderdeel leeg in weergave modus (zonder marge en zonder padding)",
         UseInputQueryText: "Gebruik ingegeven zoekopdracht",
-        UseInputQueryTextHoverMessage: "Gebruik het {searchQueryText} token in je databron om de waarde op te halen",
+        UseInputQueryTextHoverMessage: "Gebruik het {inputQueryText} token in je databron om de waarde op te halen",
         SearchQueryTextFieldLabel: "Zoekopdracht",
         SearchQueryTextFieldDescription: "",
         SearchQueryPlaceHolderText: "Geef zoekopdracht...",

--- a/search-parts/src/webparts/searchResults/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchResults/loc/sv-SE.js
@@ -80,7 +80,7 @@ define([], function() {
         LinkToVerticalLabel: "Visa endast data när följande vertikaler är valda",
         LinkToVerticalLabelHoverMessage: "Resultaten visas endast om de valda vertikalerna matchar den som har konfigurerats för denna webbdel. Annars är den här webbdelen tom.",
         UseInputQueryText: "Använd inmatning för sökfrågetext",
-        UseInputQueryTextHoverMessage: "Använd {searchQueryText} i din datakälla för att hämta detta värde",
+        UseInputQueryTextHoverMessage: "Använd {inputQueryText} i din datakälla för att hämta detta värde",
         SearchQueryTextFieldLabel: "Sökfrågetext",
         SearchQueryTextFieldDescription: "",
         SearchQueryPlaceHolderText: "Ange frågetext ...",


### PR DESCRIPTION
`{searchQueryText}` no longer works but is still used in the hover message as a tip.  

`Use the {searchQueryText} token in your data source to retrieve this value`  

new value that does work is `{inputQueryText}`  
  
Example:  
`Path:https://tenant.sharepoint.com/sites/sitename/Lists/listname/* AND ListItemID:{inputQueryText}`

Files updated in the following location:  

- Search-parts/src/webparts/searchResults/loc/*