### PR TITLE
Update TokenService.ts

### DIFF
--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -429,7 +429,7 @@ export class TokenService implements ITokenService {
                 }
                 else if (matches[0].includes("?")) {
                     // If QueryString Token is specified like this, {?QueryString.Parameter}, it is changed to an * if the QueryString doesn't exist
-                    modifiedString = modifiedString.replace(matches[0], "*");
+                    modifiedString = modifiedString.replace(matches[0], "");
                 }
 
                 matches = webRegExp.exec(inputString);

--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -428,7 +428,7 @@ export class TokenService implements ITokenService {
                     modifiedString = modifiedString.replace(matches[0], itemProp);
                 }
                 else if (matches[0].includes("?")) {
-                    // If QueryString Token is specified like this, {?QueryString.Parameter}, it is changed to an * if the QueryString doesn't exist
+                    // If QueryString Token is specified like this, {?QueryString.Parameter}, it is removed if the QueryString doesn't exist
                     modifiedString = modifiedString.replace(matches[0], "");
                 }
 

--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -414,7 +414,7 @@ export class TokenService implements ITokenService {
      */
     private replaceQueryStringTokens(inputString: string) {
 
-        const webRegExp = /\{(?:QueryString)\.(.*?)\}/gi;
+        const webRegExp = /\{(?:\?){0,1}(?:QueryString)\.(.*?)\}/gi;
         let modifiedString = inputString;
         let matches = webRegExp.exec(inputString);
 
@@ -424,7 +424,14 @@ export class TokenService implements ITokenService {
             while (matches !== null) {
                 const qsProp = matches[1];
                 const itemProp = decodeURIComponent(queryParameters.getValue(qsProp) || "");
-                modifiedString = modifiedString.replace(new RegExp(matches[0], "gi"), itemProp);
+                if (itemProp) {
+                    modifiedString = modifiedString.replace(matches[0], itemProp);
+                }
+                else if (matches[0].includes("?")) {
+                    // If QueryString Token is specified like this, {?QueryString.Parameter}, it is changed to an * if the QueryString doesn't exist
+                    modifiedString = modifiedString.replace(matches[0], "*");
+                }
+
                 matches = webRegExp.exec(inputString);
             }
         }


### PR DESCRIPTION
If QueryString Token is specified like this, {?QueryString.Parameter}, it is changed to an * if the QueryString doesn't exist

https://github.com/microsoft-search/pnp-modern-search/issues/512