### PR TITLE
Fixed #1236: Double encoding for queryText in Search Box

### DIFF
--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -90,7 +90,7 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
           newUrl = searchUrl.href;
         }
         else {
-          newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, urlEncodedQueryText);
+          newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, queryText);
         }
 
         // Send the query to the new page


### PR DESCRIPTION
Changed line 93 on SearchBoxContainer.tsx to use queryText instead of urlEncodedQueryText that caused double encoding on queryText.