### PR TITLE
update getAttachments handlebars helper code to include index 

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -49,7 +49,7 @@ The following custom helpers are available in addition to the [handlebars-helper
 | `{{#times <number>}}` | Iterate the block `<number>` times. | `{{#times 5}} some mark up  {{/times}}`
 | `{{regex <expression> <string>}}` | Run a regular expression and return the match. Return `-` if not match. | `{{regex '\d+' 'digit 15 is a number'}}` will return `15`.
 | `{{getPageContext "<SPFx page property>"}}` | Retrieve a property from the SPFx context object. | `{{getPageContext "user.displayName"}}` or `{{getPageContext "cultureInfo.currentUICultureName"}}`
-| `{{getAttachments}}`| Return object structure for list item attachments. | `{{#getAttachments LinkOfficeChild}}<a href="{{url}}">{{fileName}}</href>{{/getAttachments}}`
+| `{{getAttachments}}`| Return object structure for list item attachments. | `{{#getAttachments LinkOfficeChild}}<a href="{{url}}">{{index}} - {{fileName}}</href>{{/getAttachments}}`
 
 
 > Need any other helper? Let us know [here](https://github.com/aequos-solutions/modern-search-results/issues)!

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -578,12 +578,14 @@ export class TemplateService implements ITemplateService {
                 let splitArr: string[] = value.split(/\n+/);
 
                 if (splitArr && splitArr.length > 0) {
+                    let index: number = 0;
                     for (let i of splitArr) {
                         let pos: number = i.lastIndexOf("/");
                         if (pos !== -1) {
                             let fileName: string = i.substring(pos + 1);
-                            let objLine = { url: i, fileName: fileName };
+                            let objLine = { url: i, fileName: fileName, index: index };
                             out += options.fn(objLine);
+                            index++;
                         }
                     }
                 }


### PR DESCRIPTION
this PR would include an index in the handlebars getAttachments helper function. - this provides functionality more like #each to be available.