### PR TITLE
Changed TS target to ES6.

### DIFF
--- a/search-parts/tsconfig.json
+++ b/search-parts/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@microsoft/rush-stack-compiler-3.9/includes/tsconfig-web.json",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES6",
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
I noticed that `npm run serve` no longer works with the recent changes to `tsconfig.json`, especially the `target` property (ESNext). 
Accroding to the [docs](https://www.typescriptlang.org/tsconfig#target):   

> The special `ESNext` value refers to the highest version your version of TypeScript supports. This setting should be used with caution, since it doesn’t mean the same thing between different TypeScript versions and can make upgrades less predictable.  

My suggestion is to use `ES6` instead, because it's fully implemented by all browsers and it's enough to get rid of IE (produces much cleaner output with `class` etc. I guess that was the goal of changing `target`). Also, it fixes `npm run serve` issue (which is quite difficult to track down with the `ESNext` target).   

