### PR TITLE
Adds possibility to dynamic sort in details list

### DIFF
--- a/search-extensibility/src/index.ts
+++ b/search-extensibility/src/index.ts
@@ -22,4 +22,5 @@ export * from './models/suggestions/BaseSuggestionProvider';
 export * from './models/suggestions/ISuggestion';
 export * from './models/suggestions/ISuggestionProvider';
 export * from './models/suggestions/ISuggestionProviderDefinition';
+export * from './models/ISortFieldConfiguration';
 export * from './constants/ExtensibilityConstants';

--- a/search-extensibility/src/models/ISortFieldConfiguration.ts
+++ b/search-extensibility/src/models/ISortFieldConfiguration.ts
@@ -1,0 +1,9 @@
+export interface ISortFieldConfiguration {
+    sortField: string;
+    sortDirection: SortFieldDirection;
+}
+
+export enum SortFieldDirection {
+    Ascending = 1,
+    Descending= 2    
+}

--- a/search-extensibility/src/models/dataSources/IDataContext.ts
+++ b/search-extensibility/src/models/dataSources/IDataContext.ts
@@ -1,5 +1,6 @@
 import { IDataFilterConfiguration } from '../filters/IDataFilterConfiguration';
 import { IDataFilter, FilterConditionOperator } from '../filters/IDataFilter';
+import { ISortFieldConfiguration } from '../ISortFieldConfiguration';
 
 /**
  * Provides useful information about the current Web Part context.
@@ -62,5 +63,15 @@ export interface IDataContext {
          * The connected filters Web Part instance ID
          */
         instanceId?: string;
+    };
+     /**
+     * Data source sorting information
+     */
+    sorting?: {
+
+        /**
+         * The current selected sorting for this data source
+         */
+        sortList: ISortFieldConfiguration[];
     };
 }

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -468,8 +468,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         });
 
         // Build sort properties
-        this.properties.sortProperties.forEach(sortProperty => {
-
+        (dataContext.sorting.selectedSorting ?? this.properties.sortProperties).forEach(sortProperty => {
             sortProperties.push({
                 name: sortProperty.sortField,
                 isDescending: sortProperty.sortDirection === SortFieldDirection.Descending ? true : false

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -812,7 +812,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
         }
 
         searchQuery.TrimDuplicates = false;
-        searchQuery.SortList = this._convertToSortList(this.properties.sortList);
+        searchQuery.SortList = this._convertToSortList(dataContext.sorting.selectedSorting ?? this.properties.sortList);
         searchQuery.SelectProperties = this.properties.selectedProperties.filter(a => a); // Fix to remove null values;
 
         // Toggle to include user's personal OneDrive results as a secondary result block

--- a/search-parts/src/models/search/ISortEventInfo.ts
+++ b/search-parts/src/models/search/ISortEventInfo.ts
@@ -1,0 +1,9 @@
+import { ISortFieldConfiguration } from "./ISortFieldConfiguration";
+
+export interface ISortEventInfo {
+    
+    /**
+     * The current sorting
+     */
+    sortList: ISortFieldConfiguration[];
+}

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -59,6 +59,8 @@ import { IDataVerticalSourceData } from '../../models/dynamicData/IDataVerticalS
 import { BaseWebPart } from '../../common/BaseWebPart';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import commonStyles from '../../styles/Common.module.scss';
+import { ISortFieldConfiguration } from '../../models/search/ISortFieldConfiguration';
+import { ISortEventInfo } from '../../models/search/ISortEventInfo';
 
 const LogSource = "SearchResultsWebPart";
 
@@ -140,6 +142,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * The current page number
      */
     private currentPageNumber: number = 1;
+
+    /**
+     * The current page sorting
+     */
+    private currentSorting: ISortFieldConfiguration[];
 
     /**
      * The page URL link if provided by the data source
@@ -277,6 +284,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 instanceId: undefined,
                 filterOperator: undefined
             },
+            sorting: {
+                selectedSorting: this.currentSorting
+            },
             inputQueryText: inputQueryText,
         };
 
@@ -348,7 +358,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                         dataContext.pageNumber = 1;
                     }
 
-                    // Use the filter confiugration and then get the corresponding values 
+                    // Use the filter configuration and then get the corresponding values 
                     dataContext.filters.filtersConfiguration = filtersSourceData.filterConfiguration;
                     dataContext.filters.selectedFilters = filtersSourceData.selectedFilters;
                     dataContext.filters.filterOperator = filtersSourceData.filterOperator;
@@ -484,6 +494,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Bind web component events
         this.bindPagingEvents();
+        this.bindSortingEvents();
 
         this._bindHashChange();
         this._handleQueryStringChange();
@@ -942,6 +953,26 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.currentPageNumber = eventDetails.pageNumber;
             this.currentPageLinkUrl = eventDetails.pageLink;
             this.availablePageLinks = eventDetails.pageLinks;
+
+            this.render();
+
+        }).bind(this));
+    }
+
+    /**
+     * Binds event fired from sorting web components
+     */
+    private bindSortingEvents() {
+
+        this.domElement.addEventListener('sortingUpdated', ((ev: CustomEvent) => {
+
+            // We ensure the event if not propagated outside the component (i.e. other Web Part instances)
+            ev.stopImmediatePropagation();
+
+            const eventDetails: ISortEventInfo = ev.detail;
+
+            // These information comes from the PaginationWebComponent class
+            this.currentSorting = eventDetails.sortList;
 
             this.render();
 
@@ -1867,7 +1898,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 this._verticalsSourceData.unregister(this.render);
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
Added the possibility for dynamic / query sort in details list.

Changed the checkbox to a dropdown for sortable:
![setupdynamic](https://user-images.githubusercontent.com/17863113/134782810-15d8cece-7480-426a-8b08-ce4d52042f2d.gif)

And the sorting in action (title has been replaced by contenttypeid):
![dynamicsort](https://user-images.githubusercontent.com/17863113/134782815-36fafa14-426e-4e14-bbd9-3d42d5a346f2.gif)

I'm adding it as a draft just to start the discussion:

What's missing:
- Add labels/localization for dropdown choices
- CollectionDropdownField https://github.com/pnp/sp-dev-fx-property-controls/blob/7fb3a42fcf61e69c49b7ba589dfa941b7ada62cd/src/propertyFields/collectionData/collectionDropdownField/CollectionDropdownField.tsx#L77 does not show false as possible value. I wanted it to be backward compatible with existing settings. Should make a pr to allow false as a valid key
- validateSortableProperty seems to return true for Title but I get a 500 error when trying to sort it dynamically, it it a bug? The same happens if I try to sort it with the existing settings

Improvements:
- Should the sorting be aware if default settings for sort has been set? Should it be reflected in initial render?
- Could add a filter connection and a sort webpart for other scenarios
