### PR TITLE
Fixed #1323 - Focus and search behavior  for combo box filter template

### DIFF
--- a/search-parts/src/components/filters/FilterComboBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterComboBoxComponent.tsx
@@ -144,15 +144,12 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                 onRenderOption={this._onRenderOption}
                 useComboBoxAsMenuWidth={true}
                 onPendingValueChanged={(option?: IComboBoxOption, index?: number, value?: string) => {
+
+                    // Open the combo box
+                    this.comboRef.current.focus(true);
+
                     // A new value has been entered
                     if (value !== undefined) {
-
-                        if (this.state.searchValue === undefined) {
-
-                            // Open the combo box
-                            this.comboRef.current.focus(true);
-                        }
-
                         this.setState({
                             searchValue: value
                         });


### PR DESCRIPTION
Fixed #1323 Filter combo control stops to "search as you type" after closing dropdown once with Esc-key or mouse.