### PR TITLE
Fixed #1444 - Web Part does not re-render after a pushState when query string parameter is used in tokens

### DIFF
--- a/search-extensibility/src/models/dataSources/IDataContext.ts
+++ b/search-extensibility/src/models/dataSources/IDataContext.ts
@@ -73,6 +73,11 @@ export interface IDataContext {
         /**
          * The current selected sorting for this data source
          */
-         selectedSorting?: ISortFieldConfiguration[];
+        selectedSorting?: ISortFieldConfiguration[];
     };
+
+    /**
+     * Information about current query string parameters
+     */
+    queryStringParameters?: {[name: string]: string };
 }

--- a/search-parts/src/helpers/UrlHelper.ts
+++ b/search-parts/src/helpers/UrlHelper.ts
@@ -74,6 +74,21 @@ export class UrlHelper {
     }
 
     /**
+     * Gets the current query string parameters
+     * @returns query string parameters as object
+     */
+    public static getQueryStringParams(): {[parameter: string]: string } {
+
+        let queryStringParameters: {[parameter: string]: string } = {};
+        const urlParams = new URLSearchParams(window.location.search);
+        urlParams.forEach((value, key) => {
+            queryStringParameters[key] = value;
+        });
+
+        return queryStringParameters;
+    }
+
+    /**
      * Decodes a provided string
      * @param encodedStr the string to decode
      */

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -59,6 +59,7 @@ import { IDataVerticalSourceData } from '../../models/dynamicData/IDataVerticalS
 import { BaseWebPart } from '../../common/BaseWebPart';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import commonStyles from '../../styles/Common.module.scss';
+import { UrlHelper } from '../../helpers/UrlHelper';
 
 const LogSource = "SearchResultsWebPart";
 
@@ -290,6 +291,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 filterOperator: undefined
             },
             inputQueryText: inputQueryText,
+            queryStringParameters: UrlHelper.getQueryStringParams()
         };
 
         if (this.dataSource) {
@@ -1941,9 +1943,15 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     }
 
     private pushStateHandler(state, key, path) {
+        
         this._pushStateCallback.apply(history, [state, key, path]);
-        if (this.properties.queryText.isDisposed) return;
+        if (this.properties.queryText.isDisposed) {
+            return;
+        };
+
         const source = this.properties.queryText.tryGetSource();
-        if (source && source.id === ComponentType.PageEnvironment) this.render();
+        if (source && source.id === ComponentType.PageEnvironment) {
+            this.render();
+        }
     }
 }


### PR DESCRIPTION
Added a new `queryStringParameters` to the data context interface allowing to reevaluate query string even after a browser window history update (ex: pushState) and re-renders the Web Part.
