### PR TITLE
Amend fix for #1429

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -264,8 +264,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             valueFromDynamicSource = this.properties.queryText.tryGetValue();
             try {
-                valueFromDynamicSource = decodeURIComponent(valueFromDynamicSource);
-
+                if (valueFromDynamicSource !== undefined) {
+                    valueFromDynamicSource = decodeURIComponent(valueFromDynamicSource);
+                }
             } catch (error) {
                 // Likely issue when q=%25 in spfx
             }


### PR DESCRIPTION
This fixes situations where search query could be string('undefined') if the dynamic source for the input query is set to page context -> search.