### PR TITLE
Updated the token resolution logic to use an escaped Regex

### DIFF
--- a/search-parts/src/helpers/StringHelper.ts
+++ b/search-parts/src/helpers/StringHelper.ts
@@ -1,0 +1,7 @@
+export class StringHelper {
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+    public static escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    }
+}


### PR DESCRIPTION
- Updated the token resolution logic to use an escaped Regex instead of raw string if the case it contains special characters
- Added the '{&' operator to create AND KQL queries with comma delimited strings