### PR TITLE
Remove ID strings from highlighted summaries

### DIFF
--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -428,7 +428,7 @@ export class TemplateService implements ITemplateService {
         // <p>{{getSummary HitHighlightedSummary}}</p>
         this.Handlebars.registerHelper("getSummary", (hitHighlightedSummary: string) => {
             if (!isEmpty(hitHighlightedSummary)) {
-                return new this.Handlebars.SafeString(hitHighlightedSummary.replace(/<c0\>/g, "<strong>").replace(/<\/c0\>/g, "</strong>").replace(/<ddd\/>/g, "&#8230;"));
+                return new this.Handlebars.SafeString(hitHighlightedSummary.replace(/<c0\>/g, "<strong>").replace(/<\/c0\>/g, "</strong>").replace(/<ddd\/>/g, "&#8230;").replace(/\w+-\w+-\w+-\w+-\w+/g,""));
             }
         });
 


### PR DESCRIPTION
## Problem

the getSummary handlebar helper did not filter out ID strings from hitHighlightedSummary, resulting in summaries low legibility. Like this:

![image](https://user-images.githubusercontent.com/1475800/143493437-68a06ac8-f9b6-4e13-b721-b9b35e4fed29.png)

## Solution

Added a regex to remove all occurances of /\w+-\w+-\w+-\w+-\w+/ to the getSummary helper.