### PR TITLE
Extend getPropertyValue return value by itemCount 

### DIFF
--- a/search-parts/src/models/dynamicData/IDataResultSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataResultSourceData.ts
@@ -21,4 +21,9 @@ export interface IDataResultSourceData {
      * The current selected items in the Search Results Web Part
      */
     selectedItems?: {[key: string]: string}[];
+
+    /**
+     * The count of items returned by the getItemCount method of a datasource
+     */
+    totalCount?:number;
 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -268,7 +268,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
                 // Pass the Handlebars context to consumers, so they can register custom helpers for their own services 
                 this._currentDataResultsSourceData.handlebarsContext = this.templateService.Handlebars;
-
+                this._currentDataResultsSourceData.totalCount = this.dataSource.getItemCount();
+               
                 return this._currentDataResultsSourceData;
 
             case DynamicDataProperties.AvailableFieldValuesFromResults:


### PR DESCRIPTION
as discussed in https://github.com/microsoft-search/pnp-modern-search/discussions/1577 i added the count of items to the getPropertyValue "dynamic data interface".

Tested the call and it worked well.