### PR TITLE
Fix for #1584 ... Search Verticals Web Part Hover Issue on Dark Section Background

### DIFF
--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.module.scss
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.module.scss
@@ -7,7 +7,4 @@
     display: flex;
   }
   
-  .isLink:hover {
-    color: "[theme: themePrimary, default: #005a9e]"!important;
-  }
 }


### PR DESCRIPTION
I removed the :hover statement from the SearchVerticalsContainer.module.css file to ensure the hover acts according to the theme on dark section backgrounds.