### PR TITLE
Fixed `window.history.pushState` updated twice causing default SharePoint links to break

### DIFF
--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -841,16 +841,29 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
      * Subscribes to URL query string change events using SharePoint page router
      */
     private _handleQueryStringChange() {
-        ((h) => {
-            this._pushStateCallback = history.pushState;
-            h.pushState = this.pushStateHandler.bind(this);
-        })(window.history);
+
+        // To avoid pushState modification from many components on the page (ex: search box, etc.), 
+        // only subscribe to query string changes if the connected source is either the searc queyr or explicit query string parameter
+        if (/^(PageContext:SearchData:searchQuery)|(PageContext:UrlData:queryParameters)/.test(this.properties.queryText.reference)) {
+
+            ((h) => {
+                this._pushStateCallback = history.pushState;
+                h.pushState = this.pushStateHandler.bind(this);
+            })(window.history);
+        }      
     }
 
     private pushStateHandler(state, key, path) {
+
         this._pushStateCallback.apply(history, [state, key, path]);
-        if (this.properties.queryText.isDisposed) return;
+        if (this.properties.queryText.isDisposed) {
+          return;
+        }
+    
         const source = this.properties.queryText.tryGetSource();
-        if (source && source.id === ComponentType.PageEnvironment) this.render();
+    
+        if (source && source.id === ComponentType.PageEnvironment) {
+          this.render();
+        }
     }
 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2323,20 +2323,27 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * Subscribes to URL query string change events using SharePoint page router
      */
     private _handleQueryStringChange() {
-        ((h) => {
-            this._pushStateCallback = history.pushState;
-            h.pushState = this.pushStateHandler.bind(this);
-        })(window.history);
+
+        // To avoid pushState modification from many components on the page (ex: search box, etc.), 
+        // only subscribe to query string changes if the connected source is either the searc queyr or explicit query string parameter
+        if (/^(PageContext:SearchData:searchQuery)|(PageContext:UrlData:queryParameters)/.test(this.properties.queryText.reference)) {
+
+            ((h) => {
+                this._pushStateCallback = history.pushState;
+                h.pushState = this.pushStateHandler.bind(this);
+            })(window.history);
+        } 
     }
 
-    private pushStateHandler(state, key, path) {
-        
+    private pushStateHandler(state, key, path) {   
+
         this._pushStateCallback.apply(history, [state, key, path]);
         if (this.properties.queryText.isDisposed) {
             return;
         }
 
         const source = this.properties.queryText.tryGetSource();
+
         if (source && source.id === ComponentType.PageEnvironment) {
             this.render();
         }


### PR DESCRIPTION
Fixed an issue with page hyperlinks once the Search box WP and Search Results are loaded on the same page and the search box uses query string parameter or search query. window.history.pushShate method is update twice causing default SharePoint to break.