### PR TITLE
Vertical ResultCount Option

### DIFF
--- a/search-parts/src/models/dynamicData/IDataResultSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataResultSourceData.ts
@@ -26,4 +26,9 @@ export interface IDataResultSourceData {
      * The count of items returned by the getItemCount method of a datasource
      */
     totalCount?:number;
+
+    /**
+     * Passing the selectedVerticalKeys Properties
+     */
+     selectedVerticalKeys:string[];
 }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -1108,7 +1108,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         let dataResultsSourceData: IDataResultSourceData = {
             availableFieldsFromResults: [],
-            availablefilters: []
+            availablefilters: [],
+            selectedVerticalKeys:[]
         };
 
         let allAvailableFieldsFromResults: string[] = [];

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -82,7 +82,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _currentDataResultsSourceData: IDataResultSourceData = {
         availableFieldsFromResults: [],
         availablefilters: [],
-        selectedItems: []
+        selectedItems: [],
+        selectedVerticalKeys:[]
     };
 
     /**
@@ -262,14 +263,14 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     }
 
     public getPropertyValue(propertyId: string) {
-
+    
         switch (propertyId) {
-            case ComponentType.SearchResults:
-
+            case ComponentType.SearchResults:                
                 // Pass the Handlebars context to consumers, so they can register custom helpers for their own services 
-                this._currentDataResultsSourceData.handlebarsContext = this.templateService.Handlebars;
-                this._currentDataResultsSourceData.totalCount = this.dataSource.getItemCount();
-               
+                this._currentDataResultsSourceData.handlebarsContext = this.templateService.Handlebars;                
+                this._currentDataResultsSourceData.totalCount = this.dataSource?.getItemCount();               
+                // TODO: Check if in getPropertydef or custom propertyid?       
+                this._currentDataResultsSourceData.selectedVerticalKeys = this.properties.selectedVerticalKeys;
                 return this._currentDataResultsSourceData;
 
             case DynamicDataProperties.AvailableFieldValuesFromResults:
@@ -388,7 +389,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 // Reset data source information
                 this._currentDataResultsSourceData = {
                 availableFieldsFromResults: [],
-                availablefilters: []
+                availablefilters: [],
+                selectedVerticalKeys:[]
                 };
 
                 // Remove margin and padding for the empty control zone
@@ -2295,7 +2297,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // the data soure information since we don't want to expose them to consumers
             this._currentDataResultsSourceData = {
             availableFieldsFromResults: [],
-            availablefilters: []
+            availablefilters: [],
+            selectedVerticalKeys:[]
             };
         }
         }

--- a/search-parts/src/webparts/searchVerticals/ISearchVerticalsWebPartProps.ts
+++ b/search-parts/src/webparts/searchVerticals/ISearchVerticalsWebPartProps.ts
@@ -17,4 +17,9 @@ export interface ISearchVerticalsWebPartProps extends IBaseWebPartProps {
      * The query string parameter name to use to select a vertical tab by default
      */
     defaultVerticalQueryStringParam: string;
+    
+    /**
+     * The option used to set if the count of connected resultWebparts should be displayed
+     */
+     showResultsCount:boolean;
 }

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -5,7 +5,8 @@ import {
   IPropertyPaneConfiguration,
   IPropertyPanePage,
   IPropertyPaneField,
-  PropertyPaneTextField
+  PropertyPaneTextField,
+  PropertyPaneToggle
 } from '@microsoft/sp-property-pane';
 import * as commonStrings from 'CommonStrings';
 import * as webPartStrings from 'SearchVerticalsWebPartStrings';
@@ -140,7 +141,8 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
             themeVariant: this._themeVariant,
             onVerticalSelected: this.onVerticalSelected.bind(this),
             defaultSelectedKey: defaultSelectedKey,
-            dynamicDataProvider:this.dynamicDataService.dynamicDataProvider
+            dynamicDataProvider:this.dynamicDataService.dynamicDataProvider,
+            showResultsCount: this.properties.showResultsCount
             } as ISearchVerticalsContainerProps
         );
     }
@@ -359,6 +361,9 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
       PropertyPaneTextField('defaultVerticalQueryStringParam', {
         label: webPartStrings.PropertyPane.Verticals.DefaultVerticalQueryStringParamLabel,
         description: webPartStrings.PropertyPane.Verticals.DefaultVerticalQueryStringParamDescription
+      }),
+      PropertyPaneToggle('showResultsCount', {
+        label: webPartStrings.PropertyPane.Verticals.ShowResultsCountLabel,        
       })
     ];
 
@@ -366,7 +371,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
   }
 
   private initializeWebPartServices(): void {
-    this.tokenService = this.context.serviceScope.consume<ITokenService>(TokenService.ServiceKey);
+    this.tokenService = this.context.serviceScope.consume<ITokenService>(TokenService.ServiceKey);    
     this.webPartInstanceServiceScope = this.context.serviceScope.startNewChild();
     this.dynamicDataService = this.webPartInstanceServiceScope.createAndProvide(DynamicDataService.ServiceKey, DynamicDataService);
     this.dynamicDataService.dynamicDataProvider = this.context.dynamicDataProvider;

--- a/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerProps.ts
+++ b/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerProps.ts
@@ -41,7 +41,7 @@ export interface ISearchVerticalsContainerProps {
   dynamicDataProvider: DynamicDataProvider;  
 
   /**
-   * The option to set showCount of result Webparts
+   * The option used to set if the count of connected resultWebparts should be displayed
    */
-  //showCount:boolean;
+   showResultsCount:boolean;
 }

--- a/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerProps.ts
+++ b/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerProps.ts
@@ -1,5 +1,5 @@
 import { IDataVerticalConfiguration } from "../../../models/common/IDataVerticalConfiguration";
-import { IReadonlyTheme } from "@microsoft/sp-component-base";
+import { DynamicDataProvider, IReadonlyTheme } from "@microsoft/sp-component-base";
 import { IWebPartTitleProps } from "@pnp/spfx-controls-react/lib/WebPartTitle";
 import { ITokenService } from "@pnp/modern-search-extensibility";
 
@@ -34,4 +34,14 @@ export interface ISearchVerticalsContainerProps {
    * The default selected vertical
    */
   defaultSelectedKey: string;
+
+  /**
+   * The dynamicDataProvider used for listening to totalCountChanges of result sources
+   */
+  dynamicDataProvider: DynamicDataProvider;  
+
+  /**
+   * The option to set showCount of result Webparts
+   */
+  //showCount:boolean;
 }

--- a/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerState.ts
+++ b/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerState.ts
@@ -4,4 +4,14 @@ export interface ISearchVerticalsContainerState {
      * The current selected vertical key
      */
     selectedKey: string;
+
+    /**
+     * The connected Result Webparts for checking the count
+     */
+    connectedWebParts:  {
+            id:string;
+            verticalIds:string[];
+            totalCount:number;
+    }[];
 }
+

--- a/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerState.ts
+++ b/search-parts/src/webparts/searchVerticals/components/ISearchVerticalsContainerState.ts
@@ -8,10 +8,11 @@ export interface ISearchVerticalsContainerState {
     /**
      * The connected Result Webparts for checking the count
      */
-    connectedWebParts:  {
-            id:string;
-            verticalIds:string[];
-            totalCount:number;
-    }[];
+    connectedWebParts: IConnectedResultWebpart[];
 }
 
+export interface IConnectedResultWebpart{
+    id:string;
+    verticalIds:string[];
+    totalCount:number;
+}

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -4,9 +4,8 @@ import { ISearchVerticalsContainerProps } from './ISearchVerticalsContainerProps
 import { Pivot, PivotItem, IPivotItemProps, Icon, GlobalSettings, IChangeDescription, ITheme } from 'office-ui-fabric-react';
 import { WebPartTitle } from '@pnp/spfx-controls-react/lib/WebPartTitle';
 import { PageOpenBehavior } from '../../../helpers/UrlHelper';
-import { ISearchVerticalsContainerState } from './ISearchVerticalsContainerState';
+import { IConnectedResultWebpart, ISearchVerticalsContainerState } from './ISearchVerticalsContainerState';
 import { BuiltinTokenNames } from '../../../services/tokenService/TokenService';
-import { ComponentType } from '../../../common/ComponentType';
 
 export default class SearchVerticalsContainer extends React.Component<ISearchVerticalsContainerProps, ISearchVerticalsContainerState> {
 
@@ -15,7 +14,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
 
     this.state = {
       selectedKey: undefined,
-      connectedWebParts:[]
+      connectedWebParts: []
     };
 
     // Listen to inputQueryText value change on the page
@@ -26,70 +25,69 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
     });
 
     this.onVerticalSelected = this.onVerticalSelected.bind(this);
-    // Listen to changes in result webparts only when showResultsCount is true
-    if(this.props.showResultsCount)
+  }
+
+  private sourceUpdated = async (id: string) => {
+    const source = this.props.dynamicDataProvider.tryGetSource(id);
+    const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);
+    let copy = [...this.state.connectedWebParts];
+    const item = copy.find(existingItem => existingItem.id === source.id);
+    
+    if(item.totalCount !== propValue.totalCount)
     {
-      this.availableSourcesUpdated();
-      this.props.dynamicDataProvider.registerAvailableSourcesChanged(this.availableSourcesUpdated);    
+      item.totalCount = propValue.totalCount;
+      this.setState({
+        connectedWebParts: copy
+      });
     }
   }
 
-  private sourceUpdated = async (id:string) =>{
-    const source = this.props.dynamicDataProvider.tryGetSource(id);        
-    const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);
-    console.log("source updated",source,propValue);
-    let copy = [...this.state.connectedWebParts];
-    copy.find(item=>item.id === source.id ).totalCount = propValue.totalCount;
+  private availableSourcesUpdated = async () => {
+    const sources = this.props.dynamicDataProvider.getAvailableSources();
+    const webparts = new Array<IConnectedResultWebpart>();
 
-    this.setState({
-      connectedWebParts:copy
-    });
-  }
+    for (const source of sources) {
 
-  private availableSourcesUpdated = async () =>{
-    const sources= this.props.dynamicDataProvider.getAvailableSources();    
-console.log("sources",sources);
-    sources.forEach(async (source)=>{
-            
       // if we already added the webpart, skip it.
-      if(this.state.connectedWebParts.some(webpart=> webpart.id === source.id))
-      {        
-        
-        return;
-      }     
+      if (this.state.connectedWebParts.some(webpart => webpart.id === source.id)
+        || webparts.some(webpart => webpart.id === source.id)) {
+        continue;
+      }
       // get it once to see if it supports totalCount
-      const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);      
-      console.log("propval",source.metadata.alias, propValue);
-      if( !propValue || !('totalCount' in propValue))
-        return;
-        console.log("totalCount exists",sources);
-      this.props.dynamicDataProvider.registerSourceChanged(source.id, ()=>{this.sourceUpdated(source.id);} );
-      this.props.dynamicDataProvider.registerPropertyChanged(source.id, source?.metadata?.alias,  ()=>{this.sourceUpdated(source.id);});
-      
+      const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);
+
+      if (!propValue || (typeof propValue === 'string') || !('totalCount' in propValue))
+        continue;
+
+      webparts.push({
+        id: source.id,
+        verticalIds: propValue.selectedVerticalKeys,
+        totalCount: propValue.totalCount
+      });
+
+      this.props.dynamicDataProvider.registerPropertyChanged(source.id, source?.metadata?.alias, () => { this.sourceUpdated(source.id); });
+    }
+
+    if (webparts) {
       this.setState({
-        connectedWebParts:[...this.state.connectedWebParts, 
-          {
-            id: source.id,
-            verticalIds:propValue.selectedVerticalKeys,
-            totalCount:propValue.totalCount
-           }
+        connectedWebParts: [...this.state.connectedWebParts,
+        ...webparts
         ]
       });
-    });
+    }
   }
-
 
   public render(): React.ReactElement<ISearchVerticalsContainerProps> {
 
     let renderTitle: JSX.Element = null;
 
     // Web Part title
-    renderTitle = <WebPartTitle 
-                    displayMode={this.props.webPartTitleProps.displayMode} 
-                    title={this.props.webPartTitleProps.title} 
-                    updateProperty={this.props.webPartTitleProps.updateProperty}
-                    className={this.props.webPartTitleProps.className}
-                  />;
+    renderTitle = <WebPartTitle
+      displayMode={this.props.webPartTitleProps.displayMode}
+      title={this.props.webPartTitleProps.title}
+      updateProperty={this.props.webPartTitleProps.updateProperty}
+      className={this.props.webPartTitleProps.className}
+    />;
 
     const renderPivotItems = this.props.verticals.map(vertical => {
 
@@ -102,58 +100,61 @@ console.log("sources",sources);
 
       if (vertical.showLinkIcon) {
         renderLinkIcon = vertical.openBehavior === PageOpenBehavior.NewTab ?
-                        <Icon styles={{ root: { fontSize: 10, paddingLeft: 3 }}} iconName='NavigateExternalInline'></Icon>:
-                        <Icon styles={{ root: { fontSize: 10, paddingLeft: 3 }}} iconName='Link'></Icon>;
+          <Icon styles={{ root: { fontSize: 10, paddingLeft: 3 } }} iconName='NavigateExternalInline'></Icon> :
+          <Icon styles={{ root: { fontSize: 10, paddingLeft: 3 } }} iconName='Link'></Icon>;
       }
-      
-      let entryCount = 0;
-      this.state.connectedWebParts.filter(webpart=>webpart.verticalIds?.some(vId=> vId === vertical.key))?.forEach(entry=>entryCount+=entry.totalCount);
-    
-      return  <PivotItem
-                headerText={`${vertical.tabName} ${ entryCount ? ` (${entryCount})` : ''}`}
-                itemKey={vertical.key}                
-                onRenderItemLink={(props, defaultRender) => {
 
-                  if (vertical.isLink) {
-                    return  <div className={styles.isLink}>
-                              {defaultRender(props)}
-                              {renderLinkIcon}
-                            </div>;
-                  } else {
-                    return defaultRender(props);
-                  }              
-                }}
-                {...pivotItemProps}>
-              </PivotItem>;
+      let entryCount = 0;
+
+      this.state.connectedWebParts.filter(webpart => webpart.verticalIds?.
+        some(vId => vId === vertical.key))?.
+        forEach(entry => entryCount += entry.totalCount ?? 0);
+
+      return <PivotItem
+        headerText={`${vertical.tabName} ${entryCount ? ` (${entryCount})` : ''}`}
+        itemKey={vertical.key}
+        onRenderItemLink={(props, defaultRender) => {
+
+          if (vertical.isLink) {
+            return <div className={styles.isLink}>
+              {defaultRender(props)}
+              {renderLinkIcon}
+            </div>;
+          } else {
+            return defaultRender(props);
+          }
+        }}
+        {...pivotItemProps}>
+      </PivotItem>;
     });
 
-    return  <>
-              {renderTitle}
-              <Pivot                
-                className={styles.dataVerticals}
-                onLinkClick={this.onVerticalSelected}
-                selectedKey={this.state.selectedKey}
-                theme={this.props.themeVariant as ITheme}>
-                {renderPivotItems}
-              </Pivot>
-            </>;
+    return <>
+      {renderTitle}
+      <Pivot
+        className={styles.dataVerticals}
+        onLinkClick={this.onVerticalSelected}
+        selectedKey={this.state.selectedKey}
+        theme={this.props.themeVariant as ITheme}>
+        {renderPivotItems}
+      </Pivot>
+    </>;
   }
 
   public onVerticalSelected(item: PivotItem): void {
-    
+
     const verticalIdx = this.props.verticals.map(vertical => vertical.key).indexOf(item.props.itemKey);
-      
+
     if (verticalIdx !== -1) {
 
       const vertical = this.props.verticals[verticalIdx];
       if (vertical.isLink) {
-          // Send the query to the new page
-          const behavior = vertical.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
-          this.props.tokenService.resolveTokens(vertical.linkUrl).then((resolvedUrl: string) => {           
-            resolvedUrl = resolvedUrl.replace(/\{searchTerms\}|\{SearchBoxQuery\}/gi, GlobalSettings.getValue(BuiltinTokenNames.inputQueryText));
-            window.open(resolvedUrl, behavior);
-          });
-          
+        // Send the query to the new page
+        const behavior = vertical.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
+        this.props.tokenService.resolveTokens(vertical.linkUrl).then((resolvedUrl: string) => {
+          resolvedUrl = resolvedUrl.replace(/\{searchTerms\}|\{SearchBoxQuery\}/gi, GlobalSettings.getValue(BuiltinTokenNames.inputQueryText));
+          window.open(resolvedUrl, behavior);
+        });
+
       } else {
 
         this.setState({
@@ -162,10 +163,16 @@ console.log("sources",sources);
 
         this.props.onVerticalSelected(item.props.itemKey);
       }
-    }   
+    }
   }
 
-  public componentDidMount() {
+  public async componentDidMount() {
+
+    // Listen to changes in result webparts only when showResultsCount is true
+    if (this.props.showResultsCount) {
+      await this.availableSourcesUpdated();
+      this.props.dynamicDataProvider.registerAvailableSourcesChanged(this.availableSourcesUpdated);
+    }
 
     let defaultSelectedKey = undefined;
 

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -37,7 +37,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
   private sourceUpdated = async (id:string) =>{
     const source = this.props.dynamicDataProvider.tryGetSource(id);        
     const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);
-
+    console.log("source updated",source,propValue);
     let copy = [...this.state.connectedWebParts];
     copy.find(item=>item.id === source.id ).totalCount = propValue.totalCount;
 
@@ -48,19 +48,21 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
 
   private availableSourcesUpdated = async () =>{
     const sources= this.props.dynamicDataProvider.getAvailableSources();    
-
+console.log("sources",sources);
     sources.forEach(async (source)=>{
             
       // if we already added the webpart, skip it.
-      if(this.state.connectedWebParts.find(webpart=> webpart.id === source.id))
+      if(this.state.connectedWebParts.some(webpart=> webpart.id === source.id))
       {        
+        
         return;
       }     
       // get it once to see if it supports totalCount
       const propValue = await source.getPropertyValueAsync(source?.metadata?.alias);      
+      console.log("propval",source.metadata.alias, propValue);
       if( !propValue || !('totalCount' in propValue))
         return;
-      
+        console.log("totalCount exists",sources);
       this.props.dynamicDataProvider.registerSourceChanged(source.id, ()=>{this.sourceUpdated(source.id);} );
       this.props.dynamicDataProvider.registerPropertyChanged(source.id, source?.metadata?.alias,  ()=>{this.sourceUpdated(source.id);});
       

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -62,7 +62,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
         return;
       
       this.props.dynamicDataProvider.registerSourceChanged(source.id, ()=>{this.sourceUpdated(source.id);} );
-      this.props.dynamicDataProvider.registerPropertyChanged(source.id,ComponentType.SearchResults,  ()=>{this.sourceUpdated(source.id);});
+      this.props.dynamicDataProvider.registerPropertyChanged(source.id, source?.metadata?.alias,  ()=>{this.sourceUpdated(source.id);});
       
       this.setState({
         connectedWebParts:[...this.state.connectedWebParts, 
@@ -105,7 +105,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
       }
       
       let entryCount = 0;
-      this.state.connectedWebParts.filter(_=>_.verticalIds.some(vId=> vId === vertical.key))?.forEach(entry=>entryCount+=entry.totalCount);
+      this.state.connectedWebParts.filter(webpart=>webpart.verticalIds?.some(vId=> vId === vertical.key))?.forEach(entry=>entryCount+=entry.totalCount);
     
       return  <PivotItem
                 headerText={`${vertical.tabName} ${ entryCount ? ` (${entryCount})` : ''}`}

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -26,9 +26,12 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
     });
 
     this.onVerticalSelected = this.onVerticalSelected.bind(this);
-    
-    this.availableSourcesUpdated();
-    this.props.dynamicDataProvider.registerAvailableSourcesChanged(this.availableSourcesUpdated);    
+    // Listen to changes in result webparts only when showResultsCount is true
+    if(this.props.showResultsCount)
+    {
+      this.availableSourcesUpdated();
+      this.props.dynamicDataProvider.registerAvailableSourcesChanged(this.availableSourcesUpdated);    
+    }
   }
 
   private sourceUpdated = async (id:string) =>{
@@ -48,6 +51,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
 
     sources.forEach(async (source)=>{
             
+      // if we already added the webpart, skip it.
       if(this.state.connectedWebParts.find(webpart=> webpart.id === source.id))
       {        
         return;

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -43,7 +43,12 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
   }
 
   private availableSourcesUpdated = async () => {
-    const sources = this.props.dynamicDataProvider.getAvailableSources();
+    const sources = this.props.dynamicDataProvider?.getAvailableSources();
+    if(!sources)
+    {
+      return;
+    }
+
     const webparts = new Array<IConnectedResultWebpart>();
 
     for (const source of sources) {

--- a/search-parts/src/webparts/searchVerticals/loc/da-dk.js
+++ b/search-parts/src/webparts/searchVerticals/loc/da-dk.js
@@ -16,6 +16,7 @@ define([], function() {
         PanelHeader: "Konfigurér datavertikaler",
         PanelDescription: "Tilføj en ny vertikal for at give brugere mulighed for søge i en predefineret datakilde eller scope.",
         ButtonLabel: "Konfigurér vertikaler",
+        ShowResultsCountLabel: "Vis antallet af resultater", 
         Fields: {
           TabName: "Navn på fane",
           IconName: "Fluent UI ikonnavn",

--- a/search-parts/src/webparts/searchVerticals/loc/en-us.js
+++ b/search-parts/src/webparts/searchVerticals/loc/en-us.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configure verticals",
           DefaultVerticalQueryStringParamLabel: "Query string parameter to use to select a vertical tab by default",
           DefaultVerticalQueryStringParamDescription: "The match will be done against the tab name or the current page URL (if the tab is an hyperlink)",
+          ShowResultsCountLabel: "Show results count",          
           Fields: {
             TabName: "Tab name",
             TabValue: "Tab value",

--- a/search-parts/src/webparts/searchVerticals/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchVerticals/loc/fr-fr.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configurer les verticales",
           DefaultVerticalQueryStringParamLabel: "Paramètre de requête à utiliser pour sélectionner un onglet vertical par défaut",
           DefaultVerticalQueryStringParamDescription: "La correspondance sera faite avec le nom de l'onglet ou l'URL de la page actuelle (si l'onglet est un lien hypertexte)",
+          ShowResultsCountLabel: "Afficher le nombre de résultats", 
           Fields: {
             TabName: "Nom de l'onglet",
             TabValue: "Valeur de l'onglet",

--- a/search-parts/src/webparts/searchVerticals/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchVerticals/loc/mystrings.d.ts
@@ -17,6 +17,7 @@ declare interface ISearchVerticalsWebPartStrings {
       ButtonLabel: string;
       DefaultVerticalQueryStringParamLabel: string;
       DefaultVerticalQueryStringParamDescription: string;
+      ShowResultsCountLabel: string;
       Fields: {
         TabName: string;
         TabValue: string;

--- a/search-parts/src/webparts/searchVerticals/loc/nb-no.js
+++ b/search-parts/src/webparts/searchVerticals/loc/nb-no.js
@@ -16,6 +16,7 @@ define([], function() {
                 PanelHeader: "Konfigurer vertikaler",
                 PanelDescription: "Legg til ny vertikal som lar brukerne søke i en predefinert avgrensning eller datakilde.",
                 ButtonLabel: "Konfigurer vertikaler",
+                ShowResultsCountLabel: "Vis antall resultat", 
                 Fields: {
                     TabName: "Fane",
                     IconName: "Fluent UI ikonnavn",

--- a/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
@@ -16,6 +16,7 @@ define([], function() {
                 PanelHeader: "Configureer zoekverticalen",
                 PanelDescription: "Voeg nieuwe zoekverticalen toe zodat gebruikers kunnen zoeken in een voorgedefinieerde scope of databron.",
                 ButtonLabel: "Configureer zoekverticalen",
+                ShowResultsCountLabel: "Toon aantal resultaten", 
                 Fields: {
                     TabName: "Tab naam",
                     IconName: "Fluent UI icoon naam",

--- a/search-parts/src/webparts/searchVerticals/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchVerticals/loc/pl-pl.js
@@ -16,6 +16,7 @@ define([], function() {
                     PanelHeader: "Konfiguruj wertykały",
                     PanelDescription: "Dodaj nowy wertykał aby umożliwić wyszukiwanie w zadanym zakresie lub źródle.",
                     ButtonLabel: "Konfiguruj wertykały",
+                    ShowResultsCountLabel: "Pokaż liczbę wyników", 
                     Fields: {
                         TabName: "Nazwa karty",
                         IconName: "Nazwa ikony Fluent UI",

--- a/search-parts/src/webparts/searchVerticals/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchVerticals/loc/sv-SE.js
@@ -16,6 +16,7 @@ define([], function() {
                 PanelHeader: "Konfigurera vertikala data",
                 PanelDescription: "Lägg till en ny vertikal så att användare kan söka i en fördefinierad datakälla eller omfattning.",
                 ButtonLabel: "Konfigurera",
+                ShowResultsCountLabel: "Visa antalet resultat", 
                 Fields: {
                     TabName: "Fliknamn",
                     IconName: "Fluent UI Fabric ikonnamn",


### PR DESCRIPTION
Hi,

i created the following sampel code. I think i have to refactor it so it's just a draft / discussion basis.
Added Property "Show results count" to PnP Search Verticals.
![image](https://user-images.githubusercontent.com/935493/145189270-b1a55381-a4f2-4ea8-a1ff-bea0accd035e.png)

if on, i start listening to the dynamicDataProvider.registerAvailableSourcesChanged

If a webpart source has a property "totalCount" in getPropertyValueAsync(source?.metadata?.alias), i accept it as result providing webpart and start listening to this.props.dynamicDataProvider.registerSourceChanged and this.props.dynamicDataProvider.registerPropertyChanged for that webpart.
So we are not only reducing the interface to "pnpSearchResultsWebPart", but accept other result webparts as well!

Then we show the sum of all counts of the connected webparts in the vertical pivot item:
![image](https://user-images.githubusercontent.com/935493/145190256-bac70cdc-bc22-4424-a68d-29abdc7353b1.png)

if there are no results i don't show "(0)".
![image](https://user-images.githubusercontent.com/935493/145190602-37d70633-f2b9-4368-9ed3-8f36abe6a3f8.png)

I have to add some checks for some scenarious but it seems to work fine just now. Any comments?