### PR TITLE
Fix duplicities in proposed suggestions

### DIFF
--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -165,7 +165,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
               //  1) the input value hasn't been searched
               //  2) we have suggestions from this provider
               //  3) the input value hasn't changed while the provider was retrieving suggestions
-              if (!this.state.isSearchExecuted && suggestions.length > 0 && (!this.state.termToSuggestFrom || inputValue === this.state.searchInputValue)) {
+              if (!this.state.isSearchExecuted && suggestions.length > 0 && inputValue === this.state.searchInputValue) {
                 this.setState({
                   proposedQuerySuggestions: this.state.proposedQuerySuggestions.concat(suggestions), // Merge suggestions
                   termToSuggestFrom: inputValue, // The term that was used as basis to get the suggestions from


### PR DESCRIPTION
In case, when you are writing slowly search input value, in combination with slow async suggestion provider, method updateQuerySuggestions is triggered multiple times (previous execution is not yet finished). Result is that suggestions are duplicated. 

Proposed solution will wait for condition: inputValue is the same as searchInputValue and skip the state, when termToSuggestFrom is empty. I don't understand exactly, why condition !termToSuggestFrom has been in line 168.