### PR TITLE
Ensure URL hash is always at the end of the string

### DIFF
--- a/search-parts/src/helpers/UrlHelper.ts
+++ b/search-parts/src/helpers/UrlHelper.ts
@@ -30,6 +30,7 @@ export class UrlHelper {
         let rtn = sourceURL.split("?")[0];
         let param = null;
         let paramsArr = [];
+        const hash = window.location.hash;
         const queryString = (sourceURL.indexOf("?") !== -1) ? sourceURL.split("?")[1] : "";
 
         if (queryString !== "") {
@@ -42,7 +43,7 @@ export class UrlHelper {
             }
 
             if (paramsArr.length > 0) {
-                rtn = rtn + "?" + paramsArr.join("&");
+                rtn = rtn + "?" + paramsArr.join("&").replace(hash, '') + hash;
             }
         }
         return rtn;
@@ -62,9 +63,10 @@ export class UrlHelper {
 
         if (match === null) {
             // Append new param
+            const hash = window.location.hash && window.location.hash !== '' ? window.location.hash : '#';
             const hasQuestionMark = /\?/.test(url);
             delimiter = hasQuestionMark ? "&" : "?";
-            newString = url + delimiter + param + "=" + encodeURIComponent(value);
+            newString = url.replace(hash, '') + delimiter + param + "=" + encodeURIComponent(value) + hash;
         } else {
             delimiter = match[0].charAt(0);
             newString = url.replace(re, delimiter + param + "=" + encodeURIComponent(value));


### PR DESCRIPTION
Currently there is a bug in the filters webpart when the search box is connected to the URL fragment. The search terms are always reflected in the URL hash, but when filters are applied, the deep link added to the URL does not respect the hash, and is instead appended after it. This results in the entire filters deep link being considered part of the search terms, and it breaks your search.

![image](https://user-images.githubusercontent.com/40488522/145814086-48431a43-7571-472b-a931-35eeb982cff1.png)

This PR ensures that the hash is always at the end of the new URL when filters are added/removed.