### PR TITLE
Fixed #1675

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -486,7 +486,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
             },
             {
                 slotName: BuiltinTemplateSlots.PersonQuery,
-                slotField: 'UserName'
+                slotField: 'AADObjectID'
             },
             {
                 slotName: BuiltinTemplateSlots.UserDisplayName,

--- a/search-parts/src/layouts/results/people/people.html
+++ b/search-parts/src/layouts/results/people/people.html
@@ -38,7 +38,7 @@
                             <li class="template--peopleListItem" tabindex="0">
                                 {{#> resultTypes item=item}}
 
-                                    {{#if @root.properties.layoutProperties.showPersonaCard}}
+                                    {{#and @root.properties.layoutProperties.showPersonaCard (slot item @root.slots.PersonQuery)}}
                                         <mgt-person user-id="{{getUserEmail (slot item @root.slots.PersonQuery)}}" person-card="hover">
                                             <template>
                                                 <pnp-persona 
@@ -65,7 +65,7 @@
                                             data-instance-id="{{@root.instanceId}}"
                                             data-theme-variant="{{JSONstringify @root.theme}}"
                                         ></pnp-persona>
-                                    {{/if}}
+                                    {{/and}}
                                     
                                 {{/resultTypes}}
                             </li>


### PR DESCRIPTION
- Render MGT component only if the user id is not empty.
- Update SharePoint data source slot **PersonQuery** to use the managed property `AADObjectID` (more reliable)