### PR TITLE
Taxonomy refiners translations fix

### DIFF
--- a/docs/usage/search-filters/index.md
+++ b/docs/usage/search-filters/index.md
@@ -32,7 +32,7 @@ The filter settings are as follow:
 |------------|-----------------|
 | **Display Name** | A friendly name for the filter |
 | **Filter field** | The internal data source field to use as filter. Here you can select a field from the current data source (if data have been already retrieved) of type your own custom value (press enter to validate).
-| **# of values** | The maximum number of filter values/buckets to return (may be restricted by the API).
+| **# of values** | The maximum number of values to be retrieved for a given filter. This value is useful if you use SharePoint refiners with a lot of refiner values. By default SharePoint will only retreve the first 100 values. To get all refiner values, you must specify an higher number manually (maximum value is 1000).
 | **Template** | The template to use to display filter values. The builtin templates are: </br><ul><li>**Check box** <p align="center">!["Check box"](../../assets/webparts/search-filters/checkbox_template.png)</p></li><li>**Date range** <p align="center">!["Date range"](../../assets/webparts/search-filters/daterange_template.png)</p></li><li>**Date interval** <p align="center">!["Date interval"](../../assets/webparts/search-filters/dateinterval_template.png)</p></li><li>**Combo** <p align="center">!["Combo"](../../assets/webparts/search-filters/combo_template.png)</p></br> You can search a value directly in the list by typing keywords in the combo text field.</li></ul>
 | **Filter type** | Specify if the filter is a 'static' filter or a 'refiner' filter. See below for more information.
 | **Expand by default** | If applicable for the selected template, display values as expanded.

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -33,7 +33,9 @@ import { PropertyPaneNonReactiveTextField } from '../controls/PropertyPaneNonRea
 import { ITerm } from '../services/taxonomyService/ITaxonomyItems';
 import { DataFilterHelper } from '../helpers/DataFilterHelper';
 import { ISortFieldConfiguration, SortFieldDirection } from '../models/search/ISortFieldConfiguration';
+
 import { EnumHelper } from '../helpers/EnumHelper';
+const TAXONOMY_REFINER_REGEX = /((L0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
 
 export enum BuiltinSourceIds {
     Documents = 'e7ec8cee-ded8-43c9-beb5-436b54b31e84',
@@ -929,7 +931,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
             filterResult.values.forEach((value) => {
 
-                const isTerm = /L0\|#(.+)\|/.test(value.name);
+                const isTerm = TAXONOMY_REFINER_REGEX.test(value.name);
 
                 if (isTerm) {
 
@@ -939,27 +941,15 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
                     values.forEach((term) => {
 
-                        // 20210811: We strip the language specific part of the term and use the GP0 value as the filter value
-                        // and use also the striped value as the new term/key...
-                        // --> 'GP0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3' instead of 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Category 1' for the value/filter
-                        // --> 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|' instead of 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Category 1' for the name
-                        // Background: if the same term is used on sites with different default language, the indexed taxid property value contains the 
-                        // translation of that site collection and therefore it comes back as different values meaning the same with the same id but causing
-                        // separate filters.
-                        // (Example: 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Food' and 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Nahrung')
-                        let matches = /L0\|#(.+)\|/.exec(value.name);
-                        let termId = Guid.isValid(matches[1]) ? matches[1] : matches[1].substr(1);
-                        let strippedTermFilter = "GP0|#" + termId.toString();
-                        let strippedTerm = term.substring(0, term.lastIndexOf('|') + 1); // (we keep the last pipe for compatibility with further code/regexp)
-
-                        const fqlFilterValue = `"ǂǂ${this._bytesToHex(this._stringToUTF8Bytes(strippedTermFilter))}"`;
-                        const existingFilterIdx = updatedValues.map(updatedValue => updatedValue.name).indexOf(strippedTerm);
+                        // Use FQL expression here to get the correct output. Otherwise a full match is performed
+                        const fqlFilterValue = `"ǂǂ${this._bytesToHex(this._stringToUTF8Bytes(term))}"`;
+                        const existingFilterIdx = updatedValues.map(updatedValue => updatedValue.name).indexOf(term);
 
                         if (existingFilterIdx === -1) {
                             // Create a dedicated filter value entry
                             updatedValues.push({
                                 count: value.count,
-                                name: strippedTerm, // New stripped term, ex: 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3' instead of 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Category 1'
+                                name: term,
                                 value: fqlFilterValue
                             } as IDataFilterResultValue);
 
@@ -990,14 +980,14 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                 // Check if the value seems to be a taxonomy term
                 // If the field value looks like a taxonomy value, we get the label according to the current locale
                 // To get this type of values, we need to map the RefinableStringXXX properties with ows_taxId_xxx crawled properties
-                const isTerm = /L0\|#(.+)\|/.test(value.name);
+                const isTerm = TAXONOMY_REFINER_REGEX.test(value.name);
 
                 if (isTerm) {
 
-                    let matches = /L0\|#(.+)\|/.exec(value.name);
+                    let matches = TAXONOMY_REFINER_REGEX.exec(value.name);
 
                     if (matches.length > 0) {
-                        let termId = Guid.isValid(matches[1]) ? matches[1] : matches[1].substr(1); // The substr(1) is to cover the case when a '0' is added at the beginning of the GUID for taxonomy values 
+                        let termId = matches[3];
 
                         // Duplicates can appear if multiple taxonomy filters with the same values are displayed at the same time.
                         if (termsToLocalize.map(t => t.uniqueIdentifier).indexOf(value.value) === -1) {
@@ -1069,12 +1059,25 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                     const existingFilters = localizedTerms.filter((e) => { return e.uniqueIdentifier === value.value; });
 
                     if (existingFilters.length > 0) {
-                        // 20210811: because we have modified the filter value to use the GP0 also for the L0 items, the mapping also returns items which are not L0
-                        // therefore we have to check the name for L0 again and only replace those...
-                        const isTerm = /L0\|#(.+)\|/.test(value.name);
+
+                        const isTerm = TAXONOMY_REFINER_REGEX.test(value.name);
                         if (isTerm) {
-                            value.name = existingFilters[0].localizedTermLabel;
+                            const matches = TAXONOMY_REFINER_REGEX.exec(value.name);
+                            const termId = matches[3];
+                            const termPrefix = matches[2]; // 'L0'
+                            if (termPrefix.localeCompare("L0") === 0) {
+
+                                // If the same term is used on sites with different default language, the indexed taxid property value contains the 
+                                // translation of that site collection and therefore it comes back as different values meaning the same with the same id but causing
+                                // separate filters.
+                                // (Example: 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Food' and 'L0|#a2cf1afb-44b6-4cf4-bf37-642bb2e9bff3|Nahrung')
+                                // Using the GP0 refinement will ensure content will be filtered regardless of translations
+                                const termFilterWithoutTranslations =  `ǂǂ${this._bytesToHex(this._stringToUTF8Bytes(`GP0|#${termId.toString()}`))}`;
+                                value.value = `or(${value.value},${termFilterWithoutTranslations})`;
+                            }
                         }
+
+                        value.name = existingFilters[0].localizedTermLabel;
                     }
 
                     // Keep only terms (L0). The crawl property ows_taxid_xxx return term sets too.


### PR DESCRIPTION
- Fixed an issue regarding taxonomy label translations. Refiners coming from formatted property bag properties (ex: L0|#<termid>) or 'owstaxidmetadataalltagsinfo' managed property were not translated correctly.