### PR TITLE
Fix selected filter tags from overflowing

### DIFF
--- a/search-parts/src/components/filters/FilterSearchBoxComponent.module.scss
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.module.scss
@@ -14,6 +14,7 @@
     padding-left: 5px;
     border-radius: 12px;
     margin-bottom: 6px;
+    max-width: 100%;
 
     .tagItemText {
         overflow: hidden;

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -129,7 +129,12 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
                             data-selection-index={props.index} 
                             data-is-focusable="true"
                         >
-                            <Text><span className={styles.tagItemText} aria-label={props.item.name}>{props.item.name}</span></Text>
+                            <Text
+                                className={styles.tagItemText}
+                                aria-label={props.item.name}
+                            >
+                                {props.item.name}
+                            </Text>
                             <IconButton
                                 className={styles.tagRemoveBtn}
                                 iconProps={{ iconName: "Cancel" }}


### PR DESCRIPTION
Selected filter tags that are really long will overflow the container. This PR fixes that so they don't exceed the size of the container and the ellipsis overflow is correctly applied.

So it goes from this:

![image](https://user-images.githubusercontent.com/985283/149241695-2cca92db-91d4-4e04-8fd6-69b4e4ce9306.png)

To this:

![image](https://user-images.githubusercontent.com/985283/149241736-024cc2d4-4064-499e-a2e0-bc2aa2d16505.png)

Thanks!