### PR TITLE
Query template field value persistence fix

### DIFF
--- a/search-parts/src/controls/PropertyPaneNonReactiveTextField/IPropertyPaneNonReactiveTextFieldProps.ts
+++ b/search-parts/src/controls/PropertyPaneNonReactiveTextField/IPropertyPaneNonReactiveTextFieldProps.ts
@@ -1,4 +1,10 @@
 export interface IPropertyPaneNonReactiveTextFieldProps {
+    
+    /**
+     * The unique key for the component
+     */
+    componentKey: string;
+
     /**
      * The default value to display
      */
@@ -14,7 +20,7 @@ export interface IPropertyPaneNonReactiveTextFieldProps {
     multiline?: boolean;
 
     /**
-     * The text field lable
+     * The text field label
      */
     label?: string;
 

--- a/search-parts/src/controls/PropertyPaneNonReactiveTextField/PropertyPaneNonReactiveTextField.ts
+++ b/search-parts/src/controls/PropertyPaneNonReactiveTextField/PropertyPaneNonReactiveTextField.ts
@@ -20,7 +20,8 @@ export class PropertyPaneNonReactiveTextField implements IPropertyPaneField<IPro
         this.targetProperty = targetProperty;
 
         this.properties = {
-            key: properties.label,
+            componentKey: properties.componentKey,
+            key: properties.componentKey,
             description: properties.description,
             label: properties.label,
             placeholderText: properties.placeholderText,
@@ -54,6 +55,7 @@ export class PropertyPaneNonReactiveTextField implements IPropertyPaneField<IPro
 
         const element: React.ReactElement<any> = React.createElement("div", { key: this.properties.key },
             React.createElement(NonReactiveTextField, {
+             key: this.properties.componentKey,
              onUpdate: ((value) => {
                 changeCallback(this.targetProperty, value);
              }).bind(this),

--- a/search-parts/src/controls/PropertyPaneNonReactiveTextField/components/INonReactiveTextFieldProps.ts
+++ b/search-parts/src/controls/PropertyPaneNonReactiveTextField/components/INonReactiveTextFieldProps.ts
@@ -1,6 +1,11 @@
 export interface INonReactiveTextFieldProps {
 
     /**
+     * Unique key for the component
+     */
+    key?: string;
+
+    /**
      * The default value to display
      */
     defaultValue?: string;

--- a/search-parts/src/controls/PropertyPaneNonReactiveTextField/components/NonReactiveTextField.tsx
+++ b/search-parts/src/controls/PropertyPaneNonReactiveTextField/components/NonReactiveTextField.tsx
@@ -25,6 +25,7 @@ export class NonReactiveTextField extends React.Component<INonReactiveTextFieldP
 
         return  <>
                     <TextField
+                        key={this.props.key}
                         defaultValue={this.props.defaultValue}
                         label={this.props.label}
                         placeholder={this.props.placeholderText}

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -1,4 +1,4 @@
-import { BaseDataSource, IDataSourceData, FilterSortType, FilterSortDirection, ITemplateSlot, BuiltinTemplateSlots, IDataContext, ITokenService, FilterBehavior, PagingBehavior, IDataFilterResult, IDataFilterResultValue, FilterComparisonOperator } from "@pnp/modern-search-extensibility";
+import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, BuiltinTemplateSlots, IDataContext, ITokenService, FilterBehavior, PagingBehavior, IDataFilterResult, IDataFilterResultValue, FilterComparisonOperator } from "@pnp/modern-search-extensibility";
 import { IPropertyPaneGroup, PropertyPaneLabel, IPropertyPaneField, PropertyPaneToggle, PropertyPaneHorizontalRule } from "@microsoft/sp-property-pane";
 import { cloneDeep, isEmpty } from '@microsoft/sp-lodash-subset';
 import { MSGraphClientFactory } from "@microsoft/sp-http";
@@ -21,7 +21,7 @@ import { IMicrosoftSearchDataSourceData } from "../models/search/IMicrosoftSearc
 
 import * as React from "react";
 import { IMicrosoftSearchResponse } from "../models/search/IMicrosoftSearchResponse";
-import { IPropertyFieldToggleWithCalloutHostProps } from "@pnp/spfx-property-controls/lib/PropertyFieldToggleWithCallout";
+import { BuiltinDataSourceProviderKeys } from "./AvailableDataSources";
 
 export enum EntityType {
     Message = 'message',
@@ -232,6 +232,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                 key: 'queryText'
             }),
             new PropertyPaneNonReactiveTextField('dataSourceProperties.queryTemplate', {
+                componentKey: `${BuiltinDataSourceProviderKeys.MicrosoftSearch}-queryTemplate`,
                 defaultValue: this.properties.queryTemplate,
                 label: commonStrings.DataSources.MicrosoftSearch.QueryTemplateFieldLabel,
                 placeholderText: commonStrings.DataSources.MicrosoftSearch.QueryTemplatePlaceHolderText,

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -35,6 +35,7 @@ import { DataFilterHelper } from '../helpers/DataFilterHelper';
 import { ISortFieldConfiguration, SortFieldDirection } from '../models/search/ISortFieldConfiguration';
 
 import { EnumHelper } from '../helpers/EnumHelper';
+import { BuiltinDataSourceProviderKeys } from './AvailableDataSources';
 const TAXONOMY_REFINER_REGEX = /((L0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
 
 export enum BuiltinSourceIds {
@@ -245,6 +246,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                         key: 'queryText'
                     }),
                     new PropertyPaneNonReactiveTextField('dataSourceProperties.queryTemplate', {
+                        componentKey: `${BuiltinDataSourceProviderKeys.SharePointSearch}-queryTemplate`,
                         defaultValue: this.properties.queryTemplate,
                         label: commonStrings.DataSources.SharePointSearch.QueryTemplateFieldLabel,
                         placeholderText: commonStrings.DataSources.SharePointSearch.QueryTemplatePlaceHolderText,
@@ -349,6 +351,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                         ]
                     }),
                     new PropertyPaneNonReactiveTextField('dataSourceProperties.refinementFilters', {
+                        componentKey: `${BuiltinDataSourceProviderKeys.SharePointSearch}-refinementFilters`,
                         defaultValue: this.properties.refinementFilters,
                         label: commonStrings.DataSources.SharePointSearch.RefinementFilters,
                         placeholderText: `ex: FileType:equals("docx")`,


### PR DESCRIPTION
- Fixed an issue regarding the query template property pane field. The value wasn't reset after switching the data sourc due to missing key on the underlying React component.