### PR TITLE
Removed forbid_tags (style) from dompurify - PersonaComponent

### DIFF
--- a/search-parts/src/components/PersonaComponent.tsx
+++ b/search-parts/src/components/PersonaComponent.tsx
@@ -85,7 +85,6 @@ export class PersonaComponent extends React.Component<IPersonaComponentProps, IP
         this._domPurify = DOMPurify.default;
 
         this._domPurify.setConfig({
-            FORBID_TAGS: ['style'],
             WHOLE_DOCUMENT: true
         });
 


### PR DESCRIPTION
Issue mentioned in https://github.com/microsoft-search/pnp-modern-search/issues/1623
If PersonaComponent is used, domPurify removes the style component in the template after first paging event or new search.

After removal of the FORBID_TAGS:['style'] config line the issue is fixed.

It still is a mystery to me why this bug occurs. I think the bug iteself is on a higher level, so actually what you guys want is to purify everything that the component renders but it actually purifies the html code surrounding the component as well.

Probably "someone ;-)" needs to check if this works as you guys intended because the generel usage of dompurify is equal in all components - so it works but actually does more than it should?
