### PR TITLE
Fixed `{inputQueryText}` token initialization

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -855,6 +855,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             if (this.properties.useDefaultQueryText) {
                 inputQueryText = this.properties.defaultQueryText;
+            } else if (inputQueryFromDataSource !== undefined) {
+                inputQueryText = inputQueryFromDataSource;
             }
 
         } else if (typeof (inputQueryFromDataSource) === 'string') {


### PR DESCRIPTION
- Fixed an issue where the `{inputQueryText}` token was resolved as 'undefined' if empty and treated as a literal expression in query template.Now initialized as an empty string.