### PR TITLE
 - Fixed #1797

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -1096,12 +1096,12 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                             const termPrefix = matches[2]; // 'L0'
                             if (termPrefix.localeCompare("L0") === 0) {
                                 const termFilterWithoutTranslations =  `"ǂǂ${StringHelper._bytesToHex(StringHelper._stringToUTF8Bytes(`GP0|#${termId.toString()}`))}"`;
-                                const termTextFilter = `"L0|#${termId.toString()}"`;
+                                const termTextFilter = `string("L0|#${termId.toString()}")`
 
                                 // value.value: HEX encoded value => original refiner value 
                                 // termFilterWithoutTranslations => language agnostic term value
                                 // termTextFilter => Text value in case the value is a string (ex: a property bag value or a text column)
-                                value.value = `or(${value.value},${termFilterWithoutTranslations},string(${termTextFilter}))`;
+                                value.value = `or(${value.value},${termFilterWithoutTranslations},${termTextFilter})`;
                             }
                         }
 


### PR DESCRIPTION
Only enclosed term text valuw with the string() operator. Other values remain HEX encoded