### PR TITLE
Fix momentjs locale

### DIFF
--- a/search-parts/gulpfile.js
+++ b/search-parts/gulpfile.js
@@ -76,10 +76,12 @@ const envCheck = build.subTask('environmentCheck', (gulp, config, done) => {
                 }
             });
 
-            // Exclude moment.js locale for performance purpose
-            generatedConfiguration.plugins.push(
-                new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
-            );
+            // Exclude moment.js locale for performance purpose during development
+            if (!config.production) {
+                generatedConfiguration.plugins.push(
+                    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
+                );
+            }
 
             if (config.production) {
                 const lastDirName = path.basename(__dirname);

--- a/search-parts/src/helpers/DateHelper.ts
+++ b/search-parts/src/helpers/DateHelper.ts
@@ -27,11 +27,29 @@ export class DateHelper {
             );
 
             let culture = this.pageContext.cultureInfo.currentUICultureName.toLowerCase();
+
+            // if culture starts with or is any of this, two letter locale must be used in momentjs (culture es-es must load es.js file)
+            let momentTwoLetterLanguageName = [
+                "af", "az", "be", "bg", "bm", "bo", "br", "bs", "ca", "cs", "cv",
+                "cy", "da", "dv", "el", "eo", "es-es", "et", "eu", "fa", "fi", "fil",
+                "fo", "fy", "ga", "gd", "gl", "gu", "he", "hi", "hr", "hu", "id", "is",
+                "ja", "jv", "ka", "kk", "km", "kn", "ko", "ku", "ky", "lb", "lo", "lt",
+                "lv", "me", "mi", "mk", "ml", "mn", "mr", "mt", "my", "nb", "ne",
+                "nn", "pl", "ro", "ru", "sd", "se", "si", "sk", "sl", "sq",
+                "ss", "sv", "sw", "ta", "te", "tet", "tg", "th", "tk", "tlh",
+                "tr", "tzl", "uk", "ur", "vi", "yo"
+            ];
+
             // Moment is by default 'en-us'
-            if (['en-us', 'en'].indexOf(culture) === -1) {
-                if (culture.indexOf("zh") === -1) {
-                    culture = culture.split('-')[0];
-                }
+            if (!culture.startsWith('en-us')) {
+                // check if culture must be used with two letter name in momentjs  
+                for (let i = 0; i < momentTwoLetterLanguageName.length; i++)
+                    if (culture.startsWith(momentTwoLetterLanguageName[i])) {
+                        culture = culture.split('-')[0];
+                        break;
+                    }
+
+
                 await import(
                     /* webpackChunkName: 'pnp-modern-search-moment' */
                     `moment/locale/${culture}.js`
@@ -42,7 +60,7 @@ export class DateHelper {
             this.momentLibrary = moment.default;
 
             // Set default locale
-            this.momentLibrary.locale(this.pageContext.cultureInfo.currentUICultureName ? this.pageContext.cultureInfo.currentUICultureName : 'en');
+            this.momentLibrary.locale(culture);
             return this.momentLibrary;
         }
     }

--- a/search-parts/src/helpers/DateHelper.ts
+++ b/search-parts/src/helpers/DateHelper.ts
@@ -32,10 +32,10 @@ export class DateHelper {
             let momentTwoLetterLanguageName = [
                 "af", "az", "be", "bg", "bm", "bo", "br", "bs", "ca", "cs", "cv",
                 "cy", "da", "dv", "el", "eo", "es-es", "et", "eu", "fa", "fi", "fil",
-                "fo", "fy", "ga", "gd", "gl", "gu", "he", "hi", "hr", "hu", "id", "is",
+                "fo", "fy", "fr-fr", "ga", "gd", "gl", "gu", "he", "hi", "hr", "hu", "id", "is",
                 "ja", "jv", "ka", "kk", "km", "kn", "ko", "ku", "ky", "lb", "lo", "lt",
                 "lv", "me", "mi", "mk", "ml", "mn", "mr", "mt", "my", "nb", "ne",
-                "nn", "pl", "ro", "ru", "sd", "se", "si", "sk", "sl", "sq",
+                "nn", "nl-nl", "pl", "ro", "ru", "sd", "se", "si", "sk", "sl", "sq",
                 "ss", "sv", "sw", "ta", "te", "tet", "tg", "th", "tk", "tlh",
                 "tr", "tzl", "uk", "ur", "vi", "yo"
             ];


### PR DESCRIPTION
- Momentjs locale files now included in production bundle.
- Fixed several languages in momentjs that are using two letter file name (nb-NO, es-es,...) instead SP ISO format. 
- This PR should close [this](https://github.com/microsoft-search/pnp-modern-search/issues/1372) as it's working with 'es-es'.