### PR TITLE
[Urgent - Hotfix required] Added moment  transformation  de-de => de for locale.js

### DIFF
--- a/search-parts/src/helpers/DateHelper.ts
+++ b/search-parts/src/helpers/DateHelper.ts
@@ -31,7 +31,7 @@ export class DateHelper {
             // if culture starts with or is any of this, two letter locale must be used in momentjs (culture es-es must load es.js file)
             let momentTwoLetterLanguageName = [
                 "af", "az", "be", "bg", "bm", "bo", "br", "bs", "ca", "cs", "cv",
-                "cy", "da", "dv", "el", "eo", "es-es", "et", "eu", "fa", "fi", "fil",
+                "cy", "da", "de-de", "dv", "el", "eo", "es-es", "et", "eu", "fa", "fi", "fil",
                 "fo", "fy", "fr-fr", "ga", "gd", "gl", "gu", "he", "hi", "hr", "hu", "id", "is",
                 "ja", "jv", "ka", "kk", "km", "kn", "ko", "ku", "ky", "lb", "lo", "lt",
                 "lv", "me", "mi", "mk", "ml", "mn", "mr", "mt", "my", "nb", "ne",


### PR DESCRIPTION
Hi,
Somehow i missed the necessary moment.js locale setting for de.
Moment tries to load de-de.js, (as sp local is de-de) but we have only the "de.js".
Due to this bug german users won't be able to use the new version! 
So I guess a hotfix is necessary.

Sorry should have tested that.
