### PR TITLE
Support SharePoint soft navigation

### DIFF
--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -95,7 +95,17 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
           const behavior = vertical.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
           this.props.tokenService.resolveTokens(vertical.linkUrl).then((resolvedUrl: string) => {           
             resolvedUrl = resolvedUrl.replace(/\{searchTerms\}|\{SearchBoxQuery\}/gi, GlobalSettings.getValue(BuiltinTokenNames.inputQueryText));
-            window.open(resolvedUrl, behavior);
+
+            if(behavior === "_blank"){
+              window.open(resolvedUrl, behavior);
+            }else{
+              // Allow SharePoint to intercept the click and do a soft navigation
+              document.body.insertAdjacentHTML('beforeend', `<a target="${behavior}" href="${resolvedUrl}" style="display:none;"></a>`);
+              const anchor = document.body.lastElementChild as HTMLElement; 
+              anchor.click();
+              document.body.removeChild(anchor);
+            }
+
           });
           
       } else {

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -92,15 +92,14 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
       const vertical = this.props.verticals[verticalIdx];
       if (vertical.isLink) {
           // Send the query to the new page
-          const behavior = vertical.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
           this.props.tokenService.resolveTokens(vertical.linkUrl).then((resolvedUrl: string) => {           
             resolvedUrl = resolvedUrl.replace(/\{searchTerms\}|\{SearchBoxQuery\}/gi, GlobalSettings.getValue(BuiltinTokenNames.inputQueryText));
 
-            if(behavior === "_blank"){
-              window.open(resolvedUrl, behavior);
+            if(vertical.openBehavior === PageOpenBehavior.NewTab){
+              window.open(resolvedUrl, "_blank");
             }else{
               // Allow SharePoint to intercept the click and do a soft navigation
-              document.body.insertAdjacentHTML('beforeend', `<a target="${behavior}" href="${resolvedUrl}" style="display:none;"></a>`);
+              document.body.insertAdjacentHTML('beforeend', `<a href="${resolvedUrl}" style="display:none;"></a>`);
               const anchor = document.body.lastElementChild as HTMLElement; 
               anchor.click();
               document.body.removeChild(anchor);


### PR DESCRIPTION
See [#2059](https://github.com/microsoft-search/pnp-modern-search/issues/2059)

**To test the solution:**
- Create 2 pages in a SharePoint site collection
- Add the PnP -Search Verticals web part to each
- In one page, configure 2 verticals, one for each page
  - The verticals should be hyperlinks
  - The hyperlink should be configured to open on the current tab
- Copy the settings from the web part and apply them on the second page
- Publish both pages
- Click on the tabs. Only the content area should refresh