### PR TITLE
Fixed #2080 . 

### DIFF
--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -388,7 +388,7 @@ export class TemplateService implements ITemplateService {
                 param2 = null;
             }
 
-            const baseCondition = `{{#${operator} ${param1} ${param2 || ""}}}
+            const baseCondition = `{{#${operator} (slot item '${param1}') ${param2 || ""}}}
                                         ${templateContent}`;
 
             if (currentIdx === resultTypes.length - 1) {


### PR DESCRIPTION
Udpdating the result types Handlebars expression to use the `slot` function and handle complex property paths (like resource."@odata.type").