### PR TITLE
Fixed #2151 - Fixed preview pane for 'List' and 'Cards' layouts when item selection is enabled

### DIFF
--- a/search-parts/src/components/DocumentCardComponent.tsx
+++ b/search-parts/src/components/DocumentCardComponent.tsx
@@ -217,7 +217,7 @@ export class DocumentCardComponent extends React.Component<IDocumentCardComponen
                         styles={documentCardStyles}
                         type={this.props.isCompact ? DocumentCardType.compact : DocumentCardType.normal}
                     >
-                        <div ref={this.documentCardPreviewRef} style={{ position: 'relative', height: '100%' }}>
+                        <div ref={this.documentCardPreviewRef} style={{ position: 'relative', height: '100%' }} data-selection-disabled="true">
                             {renderItemCheck}
                             <DocumentCardPreview {...previewProps} />
                             {this.props.showFileIcon ?

--- a/search-parts/src/layouts/results/simpleList/simple-list.html
+++ b/search-parts/src/layouts/results/simpleList/simple-list.html
@@ -111,7 +111,7 @@
                                 </div>
                             </div>
                             {{#if @root.properties.layoutProperties.showItemThumbnail}}
-                            <div class="template--listItem--thumbnailContainer">
+                            <div class="template--listItem--thumbnailContainer" data-selection-disabled="true">
                                 <div class="thumbnail--image">
                                     <pnp-filepreview data-preview-url="{{slot item @root.slots.PreviewUrl}}" data-preview-image-url="{{slot item @root.slots.PreviewImageUrl}}" data-theme-variant="{{JSONstringify @root.theme}}">
                                         <pnp-img alt='preview-image' width="120" src="{{slot item @root.slots.PreviewImageUrl}}" loading="lazy" data-error-image="{{@root.utils.defaultImage}}" />

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -20,8 +20,6 @@ import * as handlebarsHelpers from 'handlebars-helpers';
 import { ServiceScopeHelper } from "../../helpers/ServiceScopeHelper";
 import { DomPurifyHelper } from "../../helpers/DomPurifyHelper";
 import * as DOMPurify from 'dompurify';
-import { AdaptiveCard, CardElement, Container, TextBlock } from "adaptivecards";
-import { Template } from "adaptivecards-templating";
 
 const TemplateService_ServiceKey = 'PnPModernSearchTemplateService';
 


### PR DESCRIPTION
Use of the `data-selection-disabled="true"` attribute accordin to the Office UI Fluent documentation https://developer.microsoft.com/en-us/fluentui#/controls/web/selection