### PR TITLE
Scroll to view top of results

### DIFF
--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -53,6 +53,8 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
     private _lastPageNumber: number;
     private _lastPageSelectedKeys: string[] = [];
 
+    private _searchWebPartRef: HTMLElement;
+
     public constructor(props: ISearchResultsContainerProps) {
 
         super(props);
@@ -184,6 +186,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
         return <main><div data-instance-id={this.props.instanceId}
             data-ui-test-id={TestConstants.SearchResultsWebPart}>
+            <div tabIndex={-1} ref={(ref) => { this._searchWebPartRef = ref; }}></div>
             {renderOverlay}
             {renderInfoMessage}
             {renderTitle}
@@ -206,6 +209,14 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
             if (!isEqual(prevProps.dataContext.pageNumber, this.props.dataContext.pageNumber)) {
                 // Save the last selected keys for the current selection to be able to track items across pages
                 this._lastPageSelectedKeys =  this._selection.getSelection().map(item => item.key as string);
+
+                // This is WebKit only, so defensively code and fallback to "scrollIntoView"
+                if ((this._searchWebPartRef as any).scrollIntoViewIfNeeded) {                          
+                    (this._searchWebPartRef as any).scrollIntoViewIfNeeded(false);
+                  } else {
+                    // Scroll to the top of the component
+                    this._searchWebPartRef.scrollIntoView(true);
+                  }
             }
 
             await this.getDataFromDataSource(this.props.dataContext.pageNumber);


### PR DESCRIPTION
This PR restores a [fix made in v3](https://github.com/microsoft-search/pnp-modern-search/pull/709) of the Modern Search web parts.

When navigating through the pages of results, the view will scroll to the top of the search web part if not in the viewport.