### PR TITLE
Fixed #2212 regarding localization flag and owstaxidmetadataalltagsinfo managed property

### DIFF
--- a/search-parts/.vscode/launch.json
+++ b/search-parts/.vscode/launch.json
@@ -25,7 +25,7 @@
       "name": "Hosted workbench",
       "type": "chrome",
       "request": "launch",
-      "url": "https://sonbaedev.sharepoint.com/sites/SPOCC-TestTeam1/_layouts/15/workbench.aspx",
+      "url": "https://sonbaedev.sharepoint.com/sites/ThePerspective/_layouts/15/workbench.aspx",
       "webRoot": "${workspaceRoot}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -1173,7 +1173,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                             const termPrefix = matches[2]; // 'L0'
                             if (termPrefix.localeCompare("L0") === 0) {
                                 const termFilterWithoutTranslations = `GP0|#${termId.toString()}`;
-                                const termTextFilter = `L0|#${termId.toString()}`;
+                                const termTextFilter = `L0|#0${termId.toString()}`;
 
                                 // https://docs.microsoft.com/en-us/sharepoint/technical-reference/automatically-created-managed-properties-in-sharepoint
 


### PR DESCRIPTION
Fixed a filtering issue when localization was enabled by adding a '0' as prefix for L0|# values used by the owstaxidmetadataalltagsinfo managed property.