### PR TITLE
Fix to not use input query text after disabling

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -890,7 +890,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         // tryGetValue() will resolve to '' if no Web Part is connected or if the connection is removed
         // The value can be also 'undefined' if the data source is not already loaded on the page.
         let inputQueryFromDataSource = "";
-        if (this.properties.queryText) {
+        if (this.properties.queryText && this.properties.useInputQueryText) {
             try {
                 inputQueryFromDataSource = DynamicPropertyHelper.tryGetValueSafe(this.properties.queryText);
                 if (inputQueryFromDataSource !== undefined && typeof (inputQueryFromDataSource) === 'string') {


### PR DESCRIPTION
This PR contains a fix for an issue that occurs after having a input query text assigned and then disabling it and the query text will still be sent.

Steps to reproduce:

1. Add a search results webpart to a page
2. Configure it with SharePoint Data Source
3. Enable "Use input query text" and assign a static value query text
4. Disable "Use input query text" and you will see that the assigned static value is still used in the query

This PR makes sure that the assigned static value is not sent if disabled but there is still no way of resetting back to a "null" static value which I think should be possible. One way of resolving this would be to set the property as not required and instead do a check so that a null value would not be used in the query. I can do a PR for this also if you agree that this is the way forward.