### PR TITLE
Enable custom data source extensibility

### DIFF
--- a/docs/extensibility/custom_data_sources.md
+++ b/docs/extensibility/custom_data_sources.md
@@ -1,0 +1,74 @@
+# Create a custom data source
+
+Custom data sources can be added to a search results Web Part to get results from your custom source.
+
+## Custom data source creation process
+
+Custom data source creation process comes in two distinct steps:
+
+1. [Create the data source logic](#create-the-component-logic-and-sub-components).
+2. [Register the data source information for discovery](#register-component-information).
+
+### Create the data source logic
+
+* In your extensibility library project, create a new `CustomDataSource.ts` TypeScript file.
+* Create an interface for your data source properties, typically the ones you want to persist in the Web Part property bag. Data source properties are isolated from the other general Web Part properties under the property `dataSourceProperties` in the property bag object.
+```typescript
+    export interface ICustomDataSourceProperties {
+        possibleResults: string;
+    }
+```
+
+* Implement the `BaseDataSource` abstract class using your properties interface:
+```typescript
+    export class CustomDataSource extends BaseDataSource<ICustomDataSourceProperties> {
+        ...
+    }
+```
+
+* Implement your data source logic according to the available methods and properties.
+
+### BaseDataSource - Methods
+
+| Method | Description |
+| --------- | ---------- |
+| `onInit()`| The initialization method of your data source (ex: initialize your properties, etc.). You can perform asynchronous calls here. This method will be called when the data source is instantiated by the main Web Part.
+| `getPropertyPaneGroupsConfiguration()` | Returns the property pane fields to display when your data source is selected. These are regular SPFx property fields and groups. Data source properties are isolated from the other general Web Part properties under the property `dataSourceProperties`. It means you must include that path in your property pane controls to get the value persisted. Defining fields or groups is not mandatory for a provider. If you don't want to expose any option, just return an empty array.
+| `onPropertyUpdate()` | The method will be called when a property pane value is updated. The main Web Part in `Reactive` mode for property pane fields.
+| `getPagingBehavior()` | The method should return the desired paging behavior for the data source. Will be 'None' if not specified.
+| `getFilterBehavior()` | The method should return the desired filter behavior for the data source. Will be 'Static' if not specified.
+| `getAppliedFilters()` | If any, this method should return the list of filters (i.e data source fields) applied by the data source to filter results.
+| `getItemCount()` | The method should return the total number of items. This information will be used to generate page numbers.
+| `getTemplateSlots()` | The method should return the available template slots for this data source.
+| `getSortableFields()` | The method should return the list of sortable fields for the data source if applicable
+
+
+### BaseDataSource - Properties
+
+| Property | Description |
+| --------- | ---------- |
+| `properties` | The Web Part properties in the property bag. Corresponds to the isolated `dataSourceProperties` property in the global property bag. You won't be able to access any other general properties of the Web Part.
+
+### Register provider information
+
+The next step is to provide information about your new data source. In the library main entry point (i.e. the class implementing the `IExtensibilityLibrary` in interface) return a new `IDataSourceDefinition` array in the `getCustomDataSources()` method using these properties: 
+
+| Property | Description |
+| --------- | ---------- |
+| `name` | The friendly name of your data source that will show up in the configuration panel.
+| `iconName` | The name of an icon from Office UI Fabric/Fluent UI that will be shown in the data source options.
+| `key` | An unique internal key for your data source.
+| `serviceKey` | A service key used to instantiate your data source class. Builtin or custom data sources are instantiated dynamically using [SPFx service scopes](https://docs.microsoft.com/en-us/javascript/api/sp-core-library/servicescope?view=sp-typescript-latest).
+
+```typescript
+  public getCustomDataSources(): IDataSourceDefinition[] {
+    return [
+      {
+          name: 'Custom Data Source',
+          iconName: 'Database',
+          key: 'CustomDataSource',
+          serviceKey: ServiceKey.create<IDataSource>('CustomDataSource', CustomDataSource)
+      }
+    ];
+  }
+```

--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -37,7 +37,7 @@ Each Web Part type in the solution supports several extensions or no extension a
 
 | Web Part type | Supported extensions |
 | ------------- | -------------------- |
-| **Search Results** | <ul><li>Custom web components.</li><li>Custom Handlebars [customizations](https://handlebarsjs.com/api-reference/runtime.html) (ex: helpers, partials ,etc.).</li><li>Custom event handlers for adaptive cards actions</li></ul>
+| **Search Results** | <ul><li>Custom web components.</li><li>Custom Handlebars [customizations](https://handlebarsjs.com/api-reference/runtime.html) (ex: helpers, partials ,etc.).</li><li>Custom event handlers for adaptive cards actions</li><li>Custom Data Sources</li></ul>
 | **Search Filters** |  <ul><li>Custom web components (_not directly but via the 'Search Results' Web Part extensibility library registration_).</li></ul>
 | **Search box** | <ul><li>Custom suggestions providers.</li></ul>
 | **Search Verticals** | None.
@@ -70,6 +70,8 @@ To create an extensibility library, you have the choice to reuse the one provide
     - [Suggestions providers](./custom_suggestions_provider.md)
     - [Handlebars customizations](./handlebars_customizations.md)
     - [Adaptive Cards Actions handlers](./adaptivecards_customizations.md)
+    - [Data Sources](./custom_data_sources.md)
+
 
     Creation process always follows more or less the same pattern:
 
@@ -153,6 +155,18 @@ export class MyCustomLibraryComponent implements IExtensibilityLibrary {
           break;
       }
     }
+  }
+
+  public getCustomDataSources(): IDataSourceDefinition[]
+  {
+    return [
+      {
+          name: 'Custom Data Source',
+          iconName: 'Database',
+          key: 'CustomDataSource',
+          serviceKey: ServiceKey.create<IDataSource>('CustomDataSource', CustomDataSource)
+      }
+    ];
   }
 
   public name(): string {

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,8 @@ By getting this solution, you also benefit from an advanced [extensibility model
 - [Custom suggestions providers](./extensibility/custom_suggestions_provider.md).
 - [Custom Handlebars customization (helpers, partials, etc.)](./extensibility/handlebars_customizations.md).
 - [Custom event handlers for adaptive cards actions](./extensibility/adaptivecards_customizations.md).
+- [Custom Data Sources](./extensibility/custom_data_sources.md).
+
 
 With these available customizations options, you can do pretty much anything!
 

--- a/search-extensibility/src/models/IExtensibilityLibrary.ts
+++ b/search-extensibility/src/models/IExtensibilityLibrary.ts
@@ -3,6 +3,7 @@ import { ILayoutDefinition } from './layouts/ILayoutDefinition';
 import { ISuggestionProviderDefinition } from './suggestions/ISuggestionProviderDefinition';
 import * as Handlebars from 'handlebars';
 import { IAdaptiveCardAction } from './IAdaptiveCardAction';
+import { IDataSourceDefinition } from './dataSources/IDataSourceDefinition';
 
 export interface IExtensibilityLibrary {
 
@@ -32,4 +33,9 @@ export interface IExtensibilityLibrary {
      * @param action the information about the action activated by the user
      */
     invokeCardAction(action: IAdaptiveCardAction): void;
+
+    /**
+     * Returns custom data sources
+     */
+     getCustomDataSources?(): IDataSourceDefinition[];
 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -962,6 +962,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 // Registers event handler for custom action in Adaptive Cards
                 if (extensibilityLibrary.invokeCardAction)
                     this.templateService.AdaptiveCardsExtensibilityLibraries = this.templateService.AdaptiveCardsExtensibilityLibraries.concat(extensibilityLibrary); 
+
+                // Add custom data sources if any
+                if (extensibilityLibrary.getCustomDataSources)
+                    this.availableDataSourceDefinitions = this.availableDataSourceDefinitions.concat(extensibilityLibrary.getCustomDataSources());
             });
         }
     }
@@ -1968,7 +1972,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     break;
 
                 default:
-                    break;
+                  const source = this.availableDataSourceDefinitions.find(definition => definition.key === dataSourceKey);
+                  serviceKey = source.serviceKey;
+                  break;
             }
 
             return new Promise<IDataSource>((resolve, reject) => {


### PR DESCRIPTION
Enables custom data source extensibility as discussed in #2397.
Also includes documentation for the feature.
A separate PR with example usage has been submitted to [https://github.com/microsoft-search/pnp-modern-search-extensibility-samples](https://github.com/microsoft-search/pnp-modern-search-extensibility-samples).