### PR TITLE
Beta Entity Types Bookmark & Acronym

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,10 @@
     | _Calendars.Read_ | Allow search for user's calendar appointments using Graph API (Events).
     | _Sites.Read.All_ | Allow search for sites using Graph API (Sites / List Items).
     | _ExternalItem.Read.All_ | Allow search for connector items using Graph API (External Items).
+    | _Bookmark.Read.All_ | Allow search for Bookmarks in Microsoft Search in your organization.
+    | _Acronym.Read.All_ | Allow search for Acronyms in Microsoft Search in your organization.
+    | _Chat.Read_ | Allow search for Teams messages.
+    | _ChannelMessage.Read.All_ | Same as above.
 
 3. Add the Web Parts to a SharePoint and start building!
 

--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -11,7 +11,7 @@
             {
                 "resource": "Microsoft Graph",
                 "scope": "Presence.Read.All"
-            },            
+            },
             {
                 "resource": "Microsoft Graph",
                 "scope": "User.Read"
@@ -55,6 +55,14 @@
             {
                 "resource": "Microsoft Graph",
                 "scope": "ChannelMessage.Read.All"
+            },
+            {
+                "resource": "Microsoft Graph",
+                "scope": "Bookmark.Read.All"
+            },
+            {
+                "resource": "Microsoft Graph",
+                "scope": "Acronym.Read.All"
             }
         ],
         "metadata": {
@@ -68,12 +76,14 @@
             "videoUrl": "",
             "categories": []
         },
-        "features": [{
-            "title": "PnP Modern Search - Search Web Parts - v4",
-            "description": "Modern search web parts",
-            "id": "a69a8d49-63d4-49a5-becf-5d383c16bcad",
-            "version": "4.6.1.0"
-        }],
+        "features": [
+            {
+                "title": "PnP Modern Search - Search Web Parts - v4",
+                "description": "Modern search web parts",
+                "id": "a69a8d49-63d4-49a5-becf-5d383c16bcad",
+                "version": "4.6.1.0"
+            }
+        ],
         "developer": {
             "mpnId": "",
             "name": "PnP Team",

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -34,7 +34,9 @@ export enum EntityType {
     ListItem = 'listItem',
     Site = 'site',
     Person = 'person',
-    TeamsMessage = 'chatMessage'
+    TeamsMessage = 'chatMessage',
+    Bookmark = 'bookmark',
+    Acronym = 'acronym'
 }
 
 export interface IMicrosoftSearchDataSourceProperties {
@@ -149,6 +151,14 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         {
             key: EntityType.TeamsMessage,
             text: "Teams messages"
+        },
+        {
+            key: EntityType.Bookmark,
+            text: "Bookmarks"
+        },
+        {
+            key: EntityType.Acronym,
+            text: "Acronyms"
         }
     ];
 
@@ -234,7 +244,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         return results;
     }
 
-    public getPropertyPaneGroupsConfiguration(): IPropertyPaneGroup[] {      
+    public getPropertyPaneGroupsConfiguration(): IPropertyPaneGroup[] {
 
         const entityTypesDisplayValue = this._availableEntityTypeOptions.map((option) => {
             if (this.properties.entityTypes.indexOf(option.key as EntityType) !== -1) {
@@ -746,9 +756,13 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                 queryString: queryText,
                 queryTemplate: queryTemplate
             },
-            from: from,
             size: dataContext.itemsCountPerPage
         };
+
+        //If bookmark or Acronym, paging is not supported
+        if (this.properties.entityTypes.indexOf(EntityType.Bookmark) === -1 && this.properties.entityTypes.indexOf(EntityType.Acronym) === -1) {
+            searchRequest.from = from;
+        }
 
         if (this.properties.fields.length > 0) {
             searchRequest.fields = this.properties.fields.filter(a => a); // Fix to remove null values


### PR DESCRIPTION
Bookmark & Acronym work fine so far...

Bookmark & Acronym don't work together with Entity "DriveItem".
Some Properties have to be restricted when using Bookmark & Acronym, like "from" (Paging)... Those restrictions can be applied later?

Shouldn't we limit choosing those new Entity Types (Bookmark, Acronym, chatMessage...) to be only available if the "Use beta endpoint" switch is on? 

I would do this in another PR.

Althoug I don't know if those lists are up to date:

[1.0](https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0&preserve-view=true#scope-search-based-on-entity-types)

[beta](https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-beta&preserve-view=true#scope-search-based-on-entity-types)

|Entity|1.0|Beta|
|-|-|-|
|message|x|x|
|event|x|x|
|drive|x|x|
|driveItem|x|x|
|list|x|x|
|listItem|x|x|
|site|x|x|
|externalItem|x|x|
|person||x|
|chatMessage||x|
|bookmark||x|
|acronym||x|

