### PR TITLE
Add "semver": "7.3.5" back

### DIFF
--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -79,6 +79,7 @@
         "eslint-plugin-react-hooks": "4.3.0",
         "fancy-log": "1.3.3",
         "gulp": "4.0.2",
+        "semver": "7.3.5",
         "typescript": "4.5.5",
         "spfx-fast-serve-helpers": "1.15.3",
         "string-replace-loader": "2.3.0",


### PR DESCRIPTION
Looks like it maybe was accidentally overwritten with merge of 1.15 branch.