### PR TITLE
Fix for #2643

### DIFF
--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -86,7 +86,6 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
      * @param queryText The query text entered by the user
      */
     public async _onSearch(queryText: string, isReset: boolean = false) {
-
         this.setState({
             searchInputValue: queryText,
             showClearButton: !isReset
@@ -120,7 +119,6 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
             // Notify the dynamic data controller
             this.props.onSearch(queryText);
         }
-        
     }
 
 

--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -87,43 +87,40 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
      */
     public async _onSearch(queryText: string, isReset: boolean = false) {
 
-        // Don't send empty value
-        if (queryText || isReset) {
+        this.setState({
+            searchInputValue: queryText,
+            showClearButton: !isReset
+        });
 
-            this.setState({
-                searchInputValue: queryText,
-                showClearButton: !isReset
-            });
+        if (this.props.searchInNewPage && !isReset && this.props.pageUrl) {
 
-            if (this.props.searchInNewPage && !isReset && this.props.pageUrl) {
+            this.props.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, queryText);
+            queryText = await this.props.tokenService.resolveTokens(this.props.inputTemplate);
+            const urlEncodedQueryText = encodeURIComponent(queryText);
 
-                this.props.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, queryText);
-                queryText = await this.props.tokenService.resolveTokens(this.props.inputTemplate);
-                const urlEncodedQueryText = encodeURIComponent(queryText);
+            const tokenizedPageUrl = await this.props.tokenService.resolveTokens(this.props.pageUrl);
+            const searchUrl = new URL(tokenizedPageUrl);
+            
+            let newUrl;
 
-                const tokenizedPageUrl = await this.props.tokenService.resolveTokens(this.props.pageUrl);
-                const searchUrl = new URL(tokenizedPageUrl);
-                
-                let newUrl;
-
-                if (this.props.queryPathBehavior === QueryPathBehavior.URLFragment) {
-                    searchUrl.hash = urlEncodedQueryText;
-                    newUrl = searchUrl.href;
-                }
-                else {
-                    newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, queryText);
-                }
-
-                // Send the query to the new page
-                const behavior = this.props.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
-                window.open(newUrl, behavior);
-
-            } else {
-
-                // Notify the dynamic data controller
-                this.props.onSearch(queryText);
+            if (this.props.queryPathBehavior === QueryPathBehavior.URLFragment) {
+                searchUrl.hash = urlEncodedQueryText;
+                newUrl = searchUrl.href;
             }
+            else {
+                newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, queryText);
+            }
+
+            // Send the query to the new page
+            const behavior = this.props.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
+            window.open(newUrl, behavior);
+
+        } else {
+
+            // Notify the dynamic data controller
+            this.props.onSearch(queryText);
         }
+        
     }
 
 


### PR DESCRIPTION
There is an issue where if search box suggestions is enabled, the search box does not reload the default query if you:

Search for something
Delete what you have searched for
You cannot reload the default data; with OOTB SharePoint or with search suggestions disabled, the default data is reloaded when you have an empty search box
This change resolves the problem by allowing users to reload the default search results when the search box is empty. This is a fix for https://github.com/microsoft-search/pnp-modern-search/issues/2643, and it has caused no issues in my testing.