### PR TITLE
2643: Bug fix to allow the search results WebPart to display default search results when the search box is empty and search suggestions is enabled

### DIFF
--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -87,43 +87,40 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
      */
     public async _onSearch(queryText: string, isReset: boolean = false) {
 
-        // Don't send empty value
-        if (queryText || isReset) {
+        this.setState({
+            searchInputValue: queryText,
+            showClearButton: !isReset
+        });
 
-            this.setState({
-                searchInputValue: queryText,
-                showClearButton: !isReset
-            });
+        if (this.props.searchInNewPage && !isReset && this.props.pageUrl) {
 
-            if (this.props.searchInNewPage && !isReset && this.props.pageUrl) {
+            this.props.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, queryText);
+            queryText = await this.props.tokenService.resolveTokens(this.props.inputTemplate);
+            const urlEncodedQueryText = encodeURIComponent(queryText);
 
-                this.props.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, queryText);
-                queryText = await this.props.tokenService.resolveTokens(this.props.inputTemplate);
-                const urlEncodedQueryText = encodeURIComponent(queryText);
+            const tokenizedPageUrl = await this.props.tokenService.resolveTokens(this.props.pageUrl);
+            const searchUrl = new URL(tokenizedPageUrl);
+            
+            let newUrl;
 
-                const tokenizedPageUrl = await this.props.tokenService.resolveTokens(this.props.pageUrl);
-                const searchUrl = new URL(tokenizedPageUrl);
-                
-                let newUrl;
-
-                if (this.props.queryPathBehavior === QueryPathBehavior.URLFragment) {
-                    searchUrl.hash = urlEncodedQueryText;
-                    newUrl = searchUrl.href;
-                }
-                else {
-                    newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, queryText);
-                }
-
-                // Send the query to the new page
-                const behavior = this.props.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
-                window.open(newUrl, behavior);
-
-            } else {
-
-                // Notify the dynamic data controller
-                this.props.onSearch(queryText);
+            if (this.props.queryPathBehavior === QueryPathBehavior.URLFragment) {
+                searchUrl.hash = urlEncodedQueryText;
+                newUrl = searchUrl.href;
             }
+            else {
+                newUrl = UrlHelper.addOrReplaceQueryStringParam(searchUrl.href, this.props.queryStringParameter, queryText);
+            }
+
+            // Send the query to the new page
+            const behavior = this.props.openBehavior === PageOpenBehavior.NewTab ? '_blank' : '_self';
+            window.open(newUrl, behavior);
+
+        } else {
+
+            // Notify the dynamic data controller
+            this.props.onSearch(queryText);
         }
+        
     }
 
 


### PR DESCRIPTION
There is an issue in the V4.8 Search Box WebPart when you enable search box suggestions; the search box does not reload the default query if you:

**Repro steps:**
1. Ensure Search suggestions is enabled on the Search Box WebPart
2. Add a search term into the search box then press enter
3. Delete your search term from the search box then press enter

**Expected results**
1. You would expect the default data to load as this is what happens with OOTB SharePoint
2. With search suggestions disabled, the functionality works as expected: the default data is loaded when you have an empty search box


This change resolves the problem by allowing users to reload the default search results when the search box is empty. This is a fix for https://github.com/microsoft-search/pnp-modern-search/issues/2643, and it has caused no issues in my testing.