### PR TITLE
2644: Bug fix to allow the search results WebPart use the pagination buttons in MS Teams APP and MS Teams Web

### DIFF
--- a/search-parts/src/components/PaginationComponent.module.scss
+++ b/search-parts/src/components/PaginationComponent.module.scss
@@ -2,24 +2,23 @@
     margin: 0;
 
     &__paginationContainer {
-        text-align: center;        
+        text-align: center;
 
         &__pagination {
             display: inline-block;
             text-align: center;
 
             .inverted a {
-                color:  #ffffff;
+                color: #ffffff;
             }
-    
+
             .standard a {
                 color: "[theme: themePrimary, default: #005a9e]";
             }
 
             ul {
-                display: inline-block;
-                padding-left: 0;
-                margin: 0;
+                display: flex;
+                cursor: pointer;
 
                 li {
                     display: inline;
@@ -28,6 +27,8 @@
                         float: left;
                         padding: 5px 5px;
                         text-decoration: none;
+                        pointer-events: none;
+
                         i {
                             font-size: 10px;
                         }
@@ -35,14 +36,14 @@
 
                     .active {
                         font-weight: bold;
-                        color:  "[theme: themePrimary, default: #005a9e]";
+                        color: "[theme: themePrimary, default: #005a9e]";
                     }
 
                     .active__inverted {
                         font-weight: bold;
                         color: #ffffff;
                     }
-        
+
                     a:visited {
                         color: inherit;
                     }


### PR DESCRIPTION
Currently the "PnP Search Results" component does not work correctly in MS Teams Desktop and MS Teams Web because when clicking on the pagination buttons, they do not work. This small change in the css resolves that error.

This commit resolves error [#2644](https://github.com/microsoft-search/pnp-modern-search/issues/2644)