### PR TITLE
BUG: Fixed paging error in "MS Teams Mobile".

### DIFF
--- a/search-parts/src/components/PaginationComponent.module.scss
+++ b/search-parts/src/components/PaginationComponent.module.scss
@@ -18,7 +18,10 @@
 
             ul {
                 display: flex;
+                flex-wrap: wrap;
                 cursor: pointer;
+                margin: 0;
+                padding: 0;
 
                 li {
                     display: inline;


### PR DESCRIPTION
As there were many pages with 3 or 4 digit numbers in MS Teams Mobile, the numbers at the end were not displayed, so they have been moved down to the next row.

For example: << < 281 282 282 283 284 .... 290 ... 310 > >> in Teams Mobile was cut off and you could not click on 310 for example.

With this solution in MS Teams Mobile it will be: 

<< < 281 282 283 284 ...
290 ...301 ..
310 > >>

BUG:
![image](https://user-images.githubusercontent.com/24574303/210530387-ecf59621-012f-4c0c-a91d-2af1125a300d.png)


Solution: 

![image](https://user-images.githubusercontent.com/24574303/210530229-d87a9622-dfaf-45af-9324-e0157a52cac6.png)

