### PR TITLE
Fix for Select All button in DetailsList

### DIFF
--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -519,6 +519,12 @@ export class DetailsListComponent extends React.Component<IDetailsListComponentP
                 }
             };
 
+            //Add data-selection-all-toggle = true to "Select all" radio button div to have the results container Selection object update on clicking the radio button
+            const child: any = React.Children.only(tooltipHostProps.children);
+            if (child.props.id?.endsWith("-check")) {
+              tooltipHostProps.children = React.cloneElement(child, {"data-selection-all-toggle": true});
+            }
+
             return <TooltipHost {...tooltipHostProps} theme={this.props.themeVariant as ITheme} styles={customStyles} />;
         };
 


### PR DESCRIPTION
There is an issue with how the SelectionZone in the search results container is implemented together with the DetailsList internal selection handling. Clicking Select All in the DetailsList selects all items in the list but does not update selectedKeys in the templateContext.

This is also the issue behind #2289 so that should also be fixed after this.

This fix adds the ```data-selection-all-toggle=true``` property to the div element containing the Select All button which makes the search results container SelectionZone also trigger on the button click.