### PR TITLE
Correct data-selection-all-toggle documentation

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -202,7 +202,7 @@ The available data attributes you can use in your HTML template are:
 
 - `data-selection-toggle`: this boolean flag would be set on the element which should handle toggles.This could be a checkbox or a div.
 
-- `data-selection-toggle-all`: this boolean flag indicates that clicking it should toggle all selection.
+- `data-selection-all-toggle`: this boolean flag indicates that clicking it should toggle all selection.
 
 - `data-selection-disabled`: allows a branch of the DOM to be marked to ignore input events that alter selections.
 


### PR DESCRIPTION
Corrects the documentation for the ```data-selection-all-toggle``` property. The Fluent UI documentation is also incorrect on this, see [code](https://github.com/microsoft/fluentui/blob/4afa85e9437c0ccdf33cdccce48f5b3aa8da138a/packages/react/src/utilities/selection/SelectionZone.tsx#L40).