### PR TITLE
#2624: Bug fix to unhide disappearing filters without page refresh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,24 +10,25 @@ assignees: ''
 ### Check existing issues before logging new ones
 If you are not using the latest version, triage your issue with the latest version before logging as we won't provide patches to older versions.
 
-### Issues related to data mapping, e.g. SharePoint columns to crawled properties to managed properties should be asked in the discussion section.
+### Issues related to data mapping, web part setup etc, and SharePoint columns to crawled properties to managed properties should be asked in the discussion section.
 
 **For any question regarding Web Parts usage, please use the ["Discussions"](https://github.com/microsoft-search/pnp-modern-search/discussions) tab instead of creating a new issue.**.
 
 __Remove the above section before submitting, and removal of the below template will result in the issue being closed.__
 
 **Version used**
-Ex: 4.5
+Ex: 4.8
 
 **Describe the bug**
 A clear and concise description of what the bug is. Keep questions and bugs related to the web parts. If the issue relates to KQL or question around crawled and managed properties please use [Microsoft TechCommunity](https://techcommunity.microsoft.com/t5/sharepoint-developer/bd-p/SharePointDev). Which means, if you experience the same behavior in classic web parts, then it's not an issue with PnP Modern Search 😉
 
 **To Reproduce**
-Steps to reproduce the behavior:
+Detailed steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. Enter setting A, B, C
+5. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
This fix is for the bug explained here: https://github.com/microsoft-search/pnp-modern-search/issues/2624