### PR TITLE
Fix for layout slots settings dialog

### DIFF
--- a/search-parts/src/controls/PropertyPaneAsyncCombo/components/AsyncCombo.tsx
+++ b/search-parts/src/controls/PropertyPaneAsyncCombo/components/AsyncCombo.tsx
@@ -180,7 +180,10 @@ export class AsyncCombo extends React.Component<IAsyncComboProps, IAsyncComboSta
     }
 
     public componentDidUpdate(prevProps: IAsyncComboProps, prevState: IAsyncComboState) {
-
+        if (!isEqual(this.props.textDisplayValue, prevProps.textDisplayValue) && !isEqual(this.props.textDisplayValue, this.state.textDisplayValue)) {
+          this.setState({textDisplayValue: this.getTextDisplayValue()});
+        }
+        
         if (this.props.availableOptions && !isEqual(this.props.availableOptions, prevProps.availableOptions) 
             || !isEqual(this.props.stateKey, prevProps.stateKey)) {
 


### PR DESCRIPTION
Fix for an issue that appears when removing a row from the layout slots settings dialog. When removing a row from the layout slots settings dialog the names are shifted upwards but the field drop-downs are not shifted upwards which makes the layout slots look mismatched even though they are saved correctly when clicking Save. This fix makes the drop-downs update correctly.