### PR TITLE
Update nb-no.js

### DIFF
--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -181,7 +181,7 @@ define([], function () {
         AddStaticDataLabel: "Legg til statisk data",
         TextFieldApplyButtonText: "Lagre",
         SortByPlaceholderText: "Sorter etter",
-        SortByDefaultOptionText: "Misligholde"
+        SortByDefaultOptionText: "Default"
       },
       Layouts: {
         Debug: {

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -181,7 +181,7 @@ define([], function () {
         AddStaticDataLabel: "Legg til statisk data",
         TextFieldApplyButtonText: "Lagre",
         SortByPlaceholderText: "Sorter etter",
-        SortByDefaultOptionText: "Default"
+        SortByDefaultOptionText: "Standard"
       },
       Layouts: {
         Debug: {


### PR DESCRIPTION
The norwegian translation of default search option is wrong. Changed it to "Default" instead of "Misligholde" which makes no sense with regards to sorting.