### PR TITLE
Fix tld length

### DIFF
--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -751,7 +751,7 @@ export class TemplateService implements ITemplateService {
 
             if (!isEmpty(expr)) {
 
-                const matches = expr.match(/([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,62})/gi);
+                const matches = expr.match(/([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,63})/gi);
                 if (matches) {
                     return matches[0]; // Return the full match
                 } else {

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -751,7 +751,7 @@ export class TemplateService implements ITemplateService {
 
             if (!isEmpty(expr)) {
 
-                const matches = expr.match(/([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})/gi);
+                const matches = expr.match(/([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,62})/gi);
                 if (matches) {
                     return matches[0]; // Return the full match
                 } else {


### PR DESCRIPTION
Updated the Regex expression to allow for 2-63 octets. As I understand it, 63 octets is the max per label according to RFC 1034 but I'm not very familiar with Regex so please let me know if the change is feasible.

#2933 