### PR TITLE
Fix for web part showing empty when URL has two letter code

### DIFF
--- a/search-parts/src/helpers/DateHelper.ts
+++ b/search-parts/src/helpers/DateHelper.ts
@@ -40,8 +40,8 @@ export class DateHelper {
             ];
 
             // Moment is by default 'en-us'
-            if (!culture.startsWith('en-us') && culture !== "en") {
-                // check if culture must be used with two letter name in momentjs  
+            if (!culture.startsWith('en-us') && momentTwoLetterLanguageName.some((c) => c == culture)) {
+                // check if culture must be used with two letter name in momentjs
                 for (let i = 0; i < momentTwoLetterLanguageName.length; i++)
                     if (culture.startsWith(momentTwoLetterLanguageName[i])) {
                         culture = culture.split('-')[0];


### PR DESCRIPTION
When the URL of a web page contains a doc library with a two letter code that is not an ISO code supported by moment (sites/site-name/SitePages/xx/Page.aspx or sites/site-name/SitePages/aa/Page.aspx), the search web parts on this page would show empty.