### PR TITLE
#3157: Bugfix Filters read from url are not set in the filter web part

### DIFF
--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -133,7 +133,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
     // When new filters are received from the data source
     if (!isEqual(prevProps.availableFilters, this.props.availableFilters)
-       || !isEqual(prevState.currentUiFilters, this.state.currentUiFilters)) {
+       || (!isEqual(prevState.currentUiFilters, this.state.currentUiFilters)) && prevState.currentUiFilters.length > 0) {
 
       this.getFiltersDeepLink();
       this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);


### PR DESCRIPTION
This bug happened due to the regression of #2624