### PR TITLE
parseFloat to Number

### DIFF
--- a/search-parts/src/helpers/LocalizationHelper.ts
+++ b/search-parts/src/helpers/LocalizationHelper.ts
@@ -77,7 +77,7 @@ class LocalizationHelper {
     }
 
     private static isInt(value: any): boolean {
-        const x = parseFloat(value);
+        const x = Number(value);
         return Number.isInteger(x);
     }
 


### PR DESCRIPTION
https://github.com/microsoft-search/pnp-modern-search/pull/3187

In my solution, I noticed that the parseFloat part could return incorrect values, and I reorganized it as follows:

parseFloat("1s"); //output: 1
parseFloat("1hello"); //output: 1

Number("1s") //output: NaN
Number("1hello"); //output: NaN

I'm sorry for this, it slipped my mind.