### PR TITLE
Fix searchTerms after clearing search box

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2209,7 +2209,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.tokenService.setTokenValue(BuiltinTokenNames.originalInputQueryText, inputQueryText);   
 
             //Set searchTerms value from inputQueryText, but set initial token value, undefined, if empty
-            const searchTerms = inputQueryText ? inputQueryText : undefined;
+            const searchTerms = inputQueryText ?? undefined;
             // Legacy token for SharePoint and Microsoft Search data sources
             this.tokenService.setTokenValue(BuiltinTokenNames.searchTerms, searchTerms);    
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2208,10 +2208,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, inputQueryText);
             this.tokenService.setTokenValue(BuiltinTokenNames.originalInputQueryText, inputQueryText);   
 
-            if (inputQueryText) {
-                // Legacy token for SharePoint and Microsoft Search data sources
-                this.tokenService.setTokenValue(BuiltinTokenNames.searchTerms, inputQueryText);
-            }
+            //Set searchTerms value from inputQueryText, but set initial token value, undefined, if empty
+            const searchTerms = inputQueryText ? inputQueryText : undefined;
+            // Legacy token for SharePoint and Microsoft Search data sources
+            this.tokenService.setTokenValue(BuiltinTokenNames.searchTerms, searchTerms);    
 
             // Selected filters
             if (this._filtersConnectionSourceData) {


### PR DESCRIPTION
Fixes #3197

This fix changes the logic to set the original token value undefined for searchTerms if you clear your search box and thus inputQueryText is falsy.

