### PR TITLE
add breadcrumb component for spo entities

### DIFF
--- a/search-parts/src/components/AvailableComponents.ts
+++ b/search-parts/src/components/AvailableComponents.ts
@@ -22,7 +22,7 @@ import { ImageWebComponent} from './ImageComponent';
 import { ItemSelectionWebComponent } from './ItemSelectionComponent';
 import { FilterSearchBoxWebComponent } from './filters/FilterSearchBoxComponent';
 import { FilterValueOperatorWebComponent } from './filters/FilterValueOperatorComponent';
-import { FilePathBreadcrumbWebComponent } from './FilePathBreadcrumbComponent';
+import { SpoPathBreadcrumbWebComponent } from './SpoPathBreadcrumbComponent';
 import { SortWebComponent } from './SortComponent';
 
 export class AvailableComponents {
@@ -125,7 +125,7 @@ export class AvailableComponents {
         },
         {
             componentName: "pnp-breadcrumb",
-            componentClass: FilePathBreadcrumbWebComponent
+            componentClass: SpoPathBreadcrumbWebComponent
         },
         {
             componentName: 'pnp-sortfield',

--- a/search-parts/src/components/AvailableComponents.ts
+++ b/search-parts/src/components/AvailableComponents.ts
@@ -22,6 +22,7 @@ import { ImageWebComponent} from './ImageComponent';
 import { ItemSelectionWebComponent } from './ItemSelectionComponent';
 import { FilterSearchBoxWebComponent } from './filters/FilterSearchBoxComponent';
 import { FilterValueOperatorWebComponent } from './filters/FilterValueOperatorComponent';
+import { FilePathBreadcrumbWebComponent } from './FilePathBreadcrumbComponent';
 import { SortWebComponent } from './SortComponent';
 
 export class AvailableComponents {
@@ -121,6 +122,10 @@ export class AvailableComponents {
         {
             componentName: "pnp-filteroperator",
             componentClass: FilterValueOperatorWebComponent
+        },
+        {
+            componentName: "pnp-breadcrumb",
+            componentClass: FilePathBreadcrumbWebComponent
         },
         {
             componentName: 'pnp-sortfield',

--- a/search-parts/src/components/FilePathBreadcrumbComponent.tsx
+++ b/search-parts/src/components/FilePathBreadcrumbComponent.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { BaseWebComponent } from '@pnp/modern-search-extensibility';
+import * as ReactDOM from 'react-dom';
+import { ITheme } from '@fluentui/react';
+import { Breadcrumb, IBreadcrumbItem } from '@fluentui/react';
+import { IReadonlyTheme } from '@microsoft/sp-component-base';
+
+export interface IBreadcrumbProps {
+    /**
+     * Path from which breadcrumbs are formed from. This should ideally be the OriginalPath property of a SharePoint document, list item, folder, etc.
+     */
+    path?: string;
+
+    /**
+     * Determines whether the site name should be included in the breadcrumbs.
+     */
+    includeSiteName?: boolean;
+
+    /**
+     * Determines whether the item name should be included in the breadcrumbs.
+     */
+    includeItemName?: boolean;
+
+    /**
+     * Determines whether the breadcrumbs should be clickable links to the path they represent.
+     */
+    breadcrumbItemsAsLinks?: boolean;
+
+    /**
+     * The maximum number of breadcrumbs to display before coalescing. If not specified, all breadcrumbs will be rendered.
+     */
+    maxDisplayedItems?: number;
+
+    /**
+     * Index where overflow items will be collapsed.
+     */
+    overflowIndex?: number;
+
+    /**
+     * Font size for breadcrumbs.
+     */
+    fontSize?: number;
+
+    /**
+     * The current theme settings.
+     */
+    themeVariant?: IReadonlyTheme;
+}
+
+export interface IBreadcrumbState { }
+
+const SITE_REGEX = /https:\/\/\w+\.sharepoint\.com\/sites\//;
+
+export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBreadcrumbState> {
+
+    static defaultProps = {
+        includeSiteName: true,
+        includeItemName: true,
+        breadcrumbItemsAsLinks: true,
+        maxDisplayedItems: 3,
+        overflowIndex: 0,
+        fontSize: 12
+    };
+    
+    public render() {
+        const { includeSiteName, includeItemName, breadcrumbItemsAsLinks, maxDisplayedItems, overflowIndex, fontSize, path, themeVariant } = this.props;
+
+        const breadcrumbStyles = {
+            root: {
+                margin: '0',
+            },
+            item: {
+                fontSize: `${fontSize}px`,
+                padding: '1px',
+            },
+            itemLink: {
+                fontSize: `${fontSize}px`,
+                padding: '1px',
+                selectors: {
+                    ':hover': {
+                        backgroundColor: 'unset'
+                    },
+                },
+            },
+        };
+
+        return (
+            <>
+            {path !== undefined && this.validateFilePath(path) &&
+                <Breadcrumb
+                    items={this.getBreadcrumbItems(path, includeSiteName, includeItemName, breadcrumbItemsAsLinks)}
+                    maxDisplayedItems={maxDisplayedItems}
+                    overflowIndex={overflowIndex}
+                    styles={breadcrumbStyles}
+                    ariaLabel="Breadcrumb path"
+                    overflowAriaLabel="More links"
+                    theme={themeVariant as ITheme}
+                />
+            }
+            </>
+        )
+    }
+
+    // Validate that item path is SharePoint item path and not for example personal OneDrive item path.
+    // For example:
+    // SharePoint: https://m365xXYZ.sharepoint.com/sites/dev/SomeFolder/SomeFile.docx
+    // OneDrive: https://m365xXYZ-my.sharepoint.com/personal/admin_m365xXYZ_onmicrosoft_com/Documents
+    private validateFilePath = (path: string): boolean => {
+        return SITE_REGEX.test(path);
+    }
+
+    private getBreadcrumbItems = (path: string, includeSiteName: boolean, includeItemName: boolean, breadcrumbItemsAsLinks: boolean): IBreadcrumbItem[] => {
+        const frags = path.split('/');
+        const index = frags.indexOf('sites');
+        const basePath = frags.slice(0, index + 1).join('/');
+        
+        const breadcrumbNodes = this.getBreadcrumbNodes(frags, index, includeSiteName, includeItemName);
+        
+        const breadcrumbItems = breadcrumbNodes.map((frag, index) => {
+            const item: IBreadcrumbItem = {
+                text: frag,
+                key: `item${index + 1}`,
+                isCurrentItem: false
+            };
+
+            if (breadcrumbItemsAsLinks) {
+                item.href = basePath + '/' + breadcrumbNodes.slice(0, index + 1).join('/');
+            }
+
+            return item;
+        });
+         
+        return breadcrumbItems;
+    }
+
+    private getBreadcrumbNodes = (frags: string[], index: number, includeSiteName: boolean, includeItemName: boolean) => {
+        const breadcrumbNodes = includeSiteName ? frags.slice(index + 1) : frags.slice(index + 2);
+        
+        return includeItemName ? breadcrumbNodes : breadcrumbNodes.slice(0, breadcrumbNodes.length - 1);
+    }
+}
+
+export class FilePathBreadcrumbWebComponent extends BaseWebComponent {
+
+    public constructor() {
+        super();
+    }
+
+    public async connectedCallback() {
+        let props = this.resolveAttributes();
+        const filePathBreadcrumb = <div style={{ display: 'flex' }}><FilePathBreadcrumb {...props} /></div>;
+        ReactDOM.render(filePathBreadcrumb, this);
+    }
+
+    protected onDispose(): void {
+        ReactDOM.unmountComponentAtNode(this);
+    }
+}

--- a/search-parts/src/components/SpoPathBreadcrumbComponent.tsx
+++ b/search-parts/src/components/SpoPathBreadcrumbComponent.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { ITheme } from '@fluentui/react';
-import { Breadcrumb, IBreadcrumbItem } from '@fluentui/react';
+import { ITheme, Breadcrumb, IBreadcrumbItem } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 
 export interface IBreadcrumbProps {

--- a/search-parts/src/components/SpoPathBreadcrumbComponent.tsx
+++ b/search-parts/src/components/SpoPathBreadcrumbComponent.tsx
@@ -7,27 +7,27 @@ import { IReadonlyTheme } from '@microsoft/sp-component-base';
 
 export interface IBreadcrumbProps {
     /**
-     * Path from which breadcrumbs are formed from. This should ideally be the OriginalPath property of a SharePoint document, list item, folder, etc.
+     * Path from which breadcrumb items are formed from. Ideally use the OriginalPath property of a SharePoint document, list item, folder, etc.
      */
     path?: string;
 
     /**
-     * Determines whether the site name should be included in the breadcrumbs.
+     * Determines whether the site name should be included in the breadcrumb items.
      */
     includeSiteName?: boolean;
 
     /**
-     * Determines whether the item name should be included in the breadcrumbs.
+     * Determines whether the entity name should be included in the breadcrumb items.
      */
-    includeItemName?: boolean;
+    includeEntityName?: boolean;
 
     /**
-     * Determines whether the breadcrumbs should be clickable links to the path they represent.
+     * Determines whether the breadcrumb items should be clickable links to the path they represent.
      */
     breadcrumbItemsAsLinks?: boolean;
 
     /**
-     * The maximum number of breadcrumbs to display before coalescing. If not specified, all breadcrumbs will be rendered.
+     * The maximum number of breadcrumb items to display before coalescing. If not specified, all breadcrumbs will be rendered.
      */
     maxDisplayedItems?: number;
 
@@ -37,7 +37,7 @@ export interface IBreadcrumbProps {
     overflowIndex?: number;
 
     /**
-     * Font size for breadcrumbs.
+     * Font size of breadcrumb items.
      */
     fontSize?: number;
 
@@ -51,7 +51,7 @@ export interface IBreadcrumbState { }
 
 const SITE_REGEX = /https:\/\/\w+\.sharepoint\.com\/sites\//;
 
-export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBreadcrumbState> {
+export class SpoPathBreadcrumb extends React.Component<IBreadcrumbProps, IBreadcrumbState> {
 
     static defaultProps = {
         includeSiteName: true,
@@ -63,7 +63,7 @@ export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBread
     };
     
     public render() {
-        const { includeSiteName, includeItemName, breadcrumbItemsAsLinks, maxDisplayedItems, overflowIndex, fontSize, path, themeVariant } = this.props;
+        const { includeSiteName, includeEntityName, breadcrumbItemsAsLinks, maxDisplayedItems, overflowIndex, fontSize, path, themeVariant } = this.props;
 
         const breadcrumbStyles = {
             root: {
@@ -88,7 +88,7 @@ export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBread
             <>
             {path !== undefined && this.validateFilePath(path) &&
                 <Breadcrumb
-                    items={this.getBreadcrumbItems(path, includeSiteName, includeItemName, breadcrumbItemsAsLinks)}
+                    items={this.getBreadcrumbItems(path, includeSiteName, includeEntityName, breadcrumbItemsAsLinks)}
                     maxDisplayedItems={maxDisplayedItems}
                     overflowIndex={overflowIndex}
                     styles={breadcrumbStyles}
@@ -101,7 +101,7 @@ export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBread
         )
     }
 
-    // Validate that item path is SharePoint item path and not for example personal OneDrive item path.
+    // Validate that item path is SharePoint entity path and not for example personal OneDrive entity path.
     // For example:
     // SharePoint: https://m365xXYZ.sharepoint.com/sites/dev/SomeFolder/SomeFile.docx
     // OneDrive: https://m365xXYZ-my.sharepoint.com/personal/admin_m365xXYZ_onmicrosoft_com/Documents
@@ -109,12 +109,12 @@ export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBread
         return SITE_REGEX.test(path);
     }
 
-    private getBreadcrumbItems = (path: string, includeSiteName: boolean, includeItemName: boolean, breadcrumbItemsAsLinks: boolean): IBreadcrumbItem[] => {
+    private getBreadcrumbItems = (path: string, includeSiteName: boolean, includeEntityName: boolean, breadcrumbItemsAsLinks: boolean): IBreadcrumbItem[] => {
         const frags = path.split('/');
         const index = frags.indexOf('sites');
         const basePath = frags.slice(0, index + 1).join('/');
         
-        const breadcrumbNodes = this.getBreadcrumbNodes(frags, index, includeSiteName, includeItemName);
+        const breadcrumbNodes = this.getBreadcrumbNodes(frags, index, includeSiteName, includeEntityName);
         
         const breadcrumbItems = breadcrumbNodes.map((frag, index) => {
             const item: IBreadcrumbItem = {
@@ -133,14 +133,14 @@ export class FilePathBreadcrumb extends React.Component<IBreadcrumbProps, IBread
         return breadcrumbItems;
     }
 
-    private getBreadcrumbNodes = (frags: string[], index: number, includeSiteName: boolean, includeItemName: boolean) => {
+    private getBreadcrumbNodes = (frags: string[], index: number, includeSiteName: boolean, includeEntityName: boolean) => {
         const breadcrumbNodes = includeSiteName ? frags.slice(index + 1) : frags.slice(index + 2);
         
-        return includeItemName ? breadcrumbNodes : breadcrumbNodes.slice(0, breadcrumbNodes.length - 1);
+        return includeEntityName ? breadcrumbNodes : breadcrumbNodes.slice(0, breadcrumbNodes.length - 1);
     }
 }
 
-export class FilePathBreadcrumbWebComponent extends BaseWebComponent {
+export class SpoPathBreadcrumbWebComponent extends BaseWebComponent {
 
     public constructor() {
         super();
@@ -148,8 +148,8 @@ export class FilePathBreadcrumbWebComponent extends BaseWebComponent {
 
     public async connectedCallback() {
         let props = this.resolveAttributes();
-        const filePathBreadcrumb = <div style={{ display: 'flex' }}><FilePathBreadcrumb {...props} /></div>;
-        ReactDOM.render(filePathBreadcrumb, this);
+        const spoPathBreadcrumb = <div style={{ display: 'flex' }}><SpoPathBreadcrumb {...props} /></div>;
+        ReactDOM.render(spoPathBreadcrumb, this);
     }
 
     protected onDispose(): void {


### PR DESCRIPTION
## Breadcrumb component for SharePoint entities

Component creates a breadcrumb path, ideally using `OriginalPath` property from a SharePoint file, item, folder, document library. The path is divided using the `/` character, and it omits the domain and `/sites/` from the breadcrumb path (basically this: `https://m365xXYZ.sharepoint.com/sites/`). Component includes a regex check ( `/https:\/\/\w+\.sharepoint\.com\/sites\//`) to verify that the provided path is indeed a SharePoint path. Validation is done as OneDrive paths are less user-friendly. For example:

- SharePoint path: `https://m365xXYZ.sharepoint.com/sites/dev/SomeFolder/SomeFile.docx`
- OneDrive path: `https://m365xXYZ-my.sharepoint.com/personal/admin_m365xXYZ_onmicrosoft_com/Documents`

The actual breadcrumb is constructed using the [Fluent UI breadcrumb](https://developer.microsoft.com/en-us/fluentui#/controls/web/breadcrumb). The user has the capability to influence following via props:

- If the site name should be included in the breadcrumb items.
- If the entity name should be included in the breadcrumb items.
- If the breadcrumb items should be clickable links to the path they represent.
- The maximum number of breadcrumbs to display before coalescing. If not specified, all breadcrumbs will be rendered.
- Index where overflow items will be collapsed.
- Font size of breadcrumb items.

**Using the component:** 
`<pnp-breadcrumb data-path="{{OriginalPath}}" />`

`<pnp-breadcrumb 
    data-path="{{OriginalPath}}" 
    data-include-site-name="true" 
    data-include-entity-name="true"
    data-max-displayed-items="5"
    data-overflow-index="1"
    data-font-size="14"
/>`

**Example in usage:**
![breadcrumb-component](https://github.com/microsoft-search/pnp-modern-search/assets/46068076/751a42ce-adcf-4bce-99a5-e10b33025ce4)