### PR TITLE
Proper support of query template in Microsoft Search

### DIFF
--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -2,7 +2,7 @@ import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, Bui
 import { IPropertyPaneGroup, PropertyPaneLabel, IPropertyPaneField, PropertyPaneToggle, PropertyPaneHorizontalRule } from "@microsoft/sp-property-pane";
 import { cloneDeep, isEmpty, find } from '@microsoft/sp-lodash-subset';
 import { MSGraphClientFactory } from "@microsoft/sp-http";
-import { TokenService } from "../services/tokenService/TokenService";
+import { BuiltinTokenNames, TokenService } from "../services/tokenService/TokenService";
 import { ServiceScope } from '@microsoft/sp-core-library';
 import { Dropdown, IComboBoxOption, IDropdownProps, ITextFieldProps, TextField } from '@fluentui/react';
 import { PropertyPaneAsyncCombo } from "../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo";
@@ -378,7 +378,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         if (this.properties.entityTypes.indexOf(EntityType.DriveItem) !== -1 ||
             this.properties.entityTypes.indexOf(EntityType.ListItem) !== -1 ||
             this.properties.entityTypes.indexOf(EntityType.Site) !== -1 ||
-            this.properties.entityTypes.indexOf(EntityType.List) !== -1 || 
+            this.properties.entityTypes.indexOf(EntityType.List) !== -1 ||
             this.properties.entityTypes.indexOf(EntityType.ExternalItem) !== -1) {
 
             sortPropertiesFields.push(
@@ -687,13 +687,11 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         }
 
         // Query modification
+        // As of 04/08/2024 query template is supported in v1.0 version. 
+        // The {searchTerms} token may not be replaced in query template, otherwise wrong results may be returned.
+        // see (https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http, Example 2)
+        this._tokenService.setTokenValue(BuiltinTokenNames.searchTerms, undefined);
         let queryTemplate = await this._tokenService.resolveTokens(this.properties.queryTemplate);
-        if (!isEmpty(queryTemplate.trim()) && !this.properties.useBetaEndpoint) {
-
-            // Use {searchTerms} or {inputQueryText} to use orginal value
-            // As of 06/06/2022 the query template is still in beta so we use the query text instead
-            queryText = queryTemplate.trim();
-        }
 
         // Paging
         if (dataContext.pageNumber > 1) {
@@ -778,8 +776,8 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         }
 
         // Sort is only available for 'ListItem' and ExternalItem
-        if (this.properties.entityTypes.indexOf(EntityType.ListItem) !== -1 ||  
-        this.properties.entityTypes.indexOf(EntityType.ExternalItem) !== -1) {
+        if (this.properties.entityTypes.indexOf(EntityType.ListItem) !== -1 ||
+            this.properties.entityTypes.indexOf(EntityType.ExternalItem) !== -1) {
 
             if (dataContext.sorting?.selectedSortFieldName
                 && dataContext.sorting?.selectedSortDirection) {

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -2,7 +2,7 @@ import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, Bui
 import { IPropertyPaneGroup, PropertyPaneLabel, IPropertyPaneField, PropertyPaneToggle, PropertyPaneHorizontalRule } from "@microsoft/sp-property-pane";
 import { cloneDeep, isEmpty, find } from '@microsoft/sp-lodash-subset';
 import { MSGraphClientFactory } from "@microsoft/sp-http";
-import { BuiltinTokenNames, TokenService } from "../services/tokenService/TokenService";
+import { TokenService } from "../services/tokenService/TokenService";
 import { ServiceScope } from '@microsoft/sp-core-library';
 import { Dropdown, IComboBoxOption, IDropdownProps, ITextFieldProps, TextField } from '@fluentui/react';
 import { PropertyPaneAsyncCombo } from "../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo";
@@ -686,11 +686,6 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             queryText = await this._tokenService.resolveTokens(dataContext.inputQueryText);
         }
 
-        // Query modification
-        // As of 04/08/2024 query template is supported in v1.0 version. 
-        // The {searchTerms} token may not be replaced in query template, otherwise wrong results may be returned.
-        // see (https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http, Example 2)
-        this._tokenService.setTokenValue(BuiltinTokenNames.searchTerms, undefined);
         let queryTemplate = await this._tokenService.resolveTokens(this.properties.queryTemplate);
 
         // Paging

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -686,6 +686,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             queryText = await this._tokenService.resolveTokens(dataContext.inputQueryText);
         }
 
+        // Query modification
         let queryTemplate = await this._tokenService.resolveTokens(this.properties.queryTemplate);
 
         // Paging

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2208,11 +2208,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.tokenService.setTokenValue(BuiltinTokenNames.inputQueryText, inputQueryText);
             this.tokenService.setTokenValue(BuiltinTokenNames.originalInputQueryText, inputQueryText);   
 
-            //Set searchTerms value from inputQueryText, but set initial token value, undefined, if empty
-            const searchTerms = inputQueryText ?? undefined;
-            // Legacy token for SharePoint and Microsoft Search data sources
-            this.tokenService.setTokenValue(BuiltinTokenNames.searchTerms, searchTerms);    
-
             // Selected filters
             if (this._filtersConnectionSourceData) {
 


### PR DESCRIPTION
Both 'queryString' and 'queryTemplate' in search query request contain the same data. This leads to wrong result sets. Graph Api now supports both properties with API v1.0. If correctly implemented, the result set is in accordance to search in graph explorer.

![image](https://github.com/microsoft-search/pnp-modern-search/assets/10222824/a14426be-393c-4cc3-8420-711ff14b5bc0)

Having fixed the token replacement, the query part looks as follows:

![image](https://github.com/microsoft-search/pnp-modern-search/assets/10222824/0eb9bd54-f1a2-46e1-83a8-f3df79b10021)

see also Graph API [docu ](https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http#example-2-basic-call-to-use-querytemplate)