### PR TITLE
Fix search box icon on strong section backgrounds

### DIFF
--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -400,7 +400,6 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                             componentRef={searchBoxRef}
                             placeholder={this.props.placeholderText ? this.props.placeholderText : webPartStrings.SearchBox.DefaultPlaceholder}
                             ariaLabel={this.props.placeholderText ? this.props.placeholderText : webPartStrings.SearchBox.DefaultPlaceholder}
-                            theme={this.props.themeVariant as ITheme}
                             className={styles.searchTextField}
                             value={this.state.searchInputValue}
                             autoComplete="off"

--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -48,7 +48,6 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
                     componentRef={searchBoxRef}
                     placeholder={this.props.placeholderText ? this.props.placeholderText : webPartStrings.SearchBox.DefaultPlaceholder}
                     ariaLabel={this.props.placeholderText ? this.props.placeholderText : webPartStrings.SearchBox.DefaultPlaceholder}
-                    theme={this.props.themeVariant as ITheme}
                     className={styles.searchTextField}
                     value={this.state.searchInputValue}
                     autoComplete="off"


### PR DESCRIPTION
There is an issue with the search box web part, where the magnifying glass icon is not visible on dark section backgrounds. This seems to be related to the fact that it's configured to adapt to the theme (and inversion if section background is dark), even though the search box is always matted on the white background.

![image](https://github.com/microsoft-search/pnp-modern-search/assets/985283/12e02514-6644-4588-9ba1-9d1117c5757d)

To fix, I removed the theme property, which assumes the text input will always have a white background on it and therefore the magnifying glass icon doesn't have to change with theme inversion when section background is set to Strong.

With theme property removed from Fluent SearchBox instances:

![image](https://github.com/microsoft-search/pnp-modern-search/assets/985283/0ac56a57-42e8-4023-8d93-82300e64a516)
