### PR TITLE
Fix for #3711

### DIFF
--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -425,7 +425,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
      * @param pictureThumbnailUrl
      */
         private isM365Source(url: string) {
-            const cdnDomains:string[] = ["https://cdn.hubblecontent.osi.office.net/m365content","https://publiccdn.sharepointonline.com"] //M365 CDNs
+            const cdnDomains:string[] = ["https://cdn.hubblecontent.osi.office.net/m365content","https://publiccdn.sharepointonline.com","https://privatecdn.sharepointonline.com"] //M365 CDNs
             return !isEmpty(url) && cdnDomains.some(cdnDomain => url.startsWith(cdnDomain));
         }
 

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -426,7 +426,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
      */
         private isM365Source(url: string) {
             const cdnDomains:string[] = ["https://cdn.hubblecontent.osi.office.net/m365content","https://publiccdn.sharepointonline.com"] //M365 CDNs
-            return cdnDomains.some(cdnDomain => url.startsWith(cdnDomain));
+            return !isEmpty(url) && cdnDomains.some(cdnDomain => url.startsWith(cdnDomain));
         }
 
     /**

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -425,10 +425,10 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
      * @param url
      */
         private isM365Source(url: string) {
-            const cdnDomains:RegExp[] = [/^https?:\/\/(?:[\w\-_]+\.)+office\.net.*/,
-            /^https?:\/\/(?:[\w\-_]+\.)+sharepointonline\.com.*/,
-            /^https?:\/\/(?:[\w\-_]+\.)+sharepoint\.us.*/,
-            /^https?:\/\/(?:[\w\-_]+\.)+sharepoint-mil\.us.*/,
+            const cdnDomains:RegExp[] = [/^https?:\/\/(?:[\w]+\.)+office\.net.*/,
+            /^https?:\/\/(?:[\w]+\.)+sharepointonline\.com.*/,
+            /^https?:\/\/(?:[\w]+\.)+sharepoint\.us.*/,
+            /^https?:\/\/(?:[\w]+\.)+sharepoint-mil\.us.*/,
             ];
             return cdnDomains.some(regex => regex.test(url))
         }

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -402,7 +402,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
                         }
                 }
 
-                if (!this.isOnlineDomain(item[AutoCalculatedDataSourceFields.AutoPreviewImageUrl])) {
+                if (!this.isM365Source(item[AutoCalculatedDataSourceFields.AutoPreviewImageUrl]) && !this.isOnlineDomain(item[AutoCalculatedDataSourceFields.AutoPreviewImageUrl])) {
                     item[AutoCalculatedDataSourceFields.AutoPreviewImageUrl] = null;
                 }
                 return item;
@@ -419,6 +419,15 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
     private isOnlineDomain(url: string) {
         return !isEmpty(url) && url.toLocaleLowerCase().indexOf(window.location.hostname.split('.').slice(-2).join('.').toLocaleLowerCase()) !== -1;
     }
+
+    /**
+     * Check if picture is deliverd from a M365 Source
+     * @param pictureThumbnailUrl
+     */
+        private isM365Source(url: string) {
+            const cdnDomains:string[] = ["https://cdn.hubblecontent.osi.office.net/m365content","https://publiccdn.sharepointonline.com"] //M365 CDNs
+            return cdnDomains.some(cdnDomain => url.startsWith(cdnDomain));
+        }
 
     /**
      * Extracts the GUID value from a string

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -425,10 +425,10 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
      * @param url
      */
         private isM365Source(url: string) {
-            const cdnDomains:RegExp[] = [/^https?:\/\/(?:[\w]+\.)+office\.net.*/,
-            /^https?:\/\/(?:[\w]+\.)+sharepointonline\.com.*/,
-            /^https?:\/\/(?:[\w]+\.)+sharepoint\.us.*/,
-            /^https?:\/\/(?:[\w]+\.)+sharepoint-mil\.us.*/,
+            const cdnDomains:RegExp[] = [/^https?:\/\/(?:[A-Za-z0-9,-]+\.)+office\.net.*/,
+            /^https?:\/\/(?:[A-Za-z0-9,-]+\.)+sharepointonline\.com.*/,
+            /^https?:\/\/(?:[A-Za-z0-9,-]+\.)+sharepoint\.us.*/,
+            /^https?:\/\/(?:[A-Za-z0-9,-]+\.)+sharepoint-mil\.us.*/,
             ];
             return cdnDomains.some(regex => regex.test(url))
         }

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -422,11 +422,15 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
     /**
      * Check if picture is deliverd from a M365 Source
-     * @param pictureThumbnailUrl
+     * @param url
      */
         private isM365Source(url: string) {
-            const cdnDomains:string[] = ["https://cdn.hubblecontent.osi.office.net/m365content","https://publiccdn.sharepointonline.com","https://privatecdn.sharepointonline.com"] //M365 CDNs
-            return !isEmpty(url) && cdnDomains.some(cdnDomain => url.startsWith(cdnDomain));
+            const cdnDomains:RegExp[] = [/^https?:\/\/(?:[\w\-_]+\.)+office\.net.*/,
+            /^https?:\/\/(?:[\w\-_]+\.)+sharepointonline\.com.*/,
+            /^https?:\/\/(?:[\w\-_]+\.)+sharepoint\.us.*/,
+            /^https?:\/\/(?:[\w\-_]+\.)+sharepoint-mil\.us.*/,
+            ];
+            return cdnDomains.some(regex => regex.test(url))
         }
 
     /**


### PR DESCRIPTION
Added a check if images are delivered by a Microsoft public CDN (M365 stock image library) or by the public CDN at the tenant level.

#3711 

