### PR TITLE
Fix for enabling results grouping for newly added results webpart

### DIFF
--- a/search-extensibility/src/models/layouts/ILayout.ts
+++ b/search-extensibility/src/models/layouts/ILayout.ts
@@ -17,7 +17,7 @@ export interface ILayout {
     /**
     * Check if web part is in display or edit mode
     */
-    editMode: boolean
+    editMode: boolean;
 
     /**
      * Method called during the Web Part initialization.

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -28,7 +28,7 @@
                 "@microsoft/sp-property-pane": "1.20.0",
                 "@microsoft/sp-webpart-base": "1.20.0",
                 "@pnp/common": "2.0.13",
-                "@pnp/modern-search-extensibility": "1.20.0",
+                "@pnp/modern-search-extensibility": "1.20.1",
                 "@pnp/spfx-controls-react": "3.20.0",
                 "@pnp/spfx-property-controls": "3.19.0",
                 "@pnp/telemetry-js": "2.0.0",
@@ -8412,9 +8412,9 @@
             "license": "0BSD"
         },
         "node_modules/@pnp/modern-search-extensibility": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@pnp/modern-search-extensibility/-/modern-search-extensibility-1.20.0.tgz",
-            "integrity": "sha512-1Qzvn3jwjK/b0GwgTHiEjBA0Vw7JOGXfHO5gc0ew+OYSXYw6+/83CFf4k8mZ7JPMN/vQY7GacWxamvXQYwmwTA==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/@pnp/modern-search-extensibility/-/modern-search-extensibility-1.20.1.tgz",
+            "integrity": "sha512-DJPGZo5mA7srxobvbjbFQkxHItB8TOnnq2rMxZOQSYb9V/dNezK5p9PYg6UkZqAuRR85CTb1yy4IgezJKtXCuA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react": "8.106.4",

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -32,7 +32,7 @@
         "@microsoft/sp-property-pane": "1.20.0",
         "@microsoft/sp-webpart-base": "1.20.0",
         "@pnp/common": "2.0.13",
-        "@pnp/modern-search-extensibility": "1.20.0",
+        "@pnp/modern-search-extensibility": "1.20.1",
         "@pnp/spfx-controls-react": "3.20.0",
         "@pnp/spfx-property-controls": "3.19.0",
         "@pnp/telemetry-js": "2.0.0",

--- a/search-parts/src/helpers/LayoutHelper.ts
+++ b/search-parts/src/helpers/LayoutHelper.ts
@@ -1,6 +1,6 @@
 import { ILayoutDefinition, ILayout, BaseLayout, LayoutRenderType } from '@pnp/modern-search-extensibility';
 import { BuiltinLayoutsKeys } from '../layouts/AvailableLayouts';
-import { ServiceKey, ServiceScope, Text } from '@microsoft/sp-core-library';
+import { DisplayMode, ServiceKey, ServiceScope, Text } from '@microsoft/sp-core-library';
 import { ServiceScopeHelper } from './ServiceScopeHelper';
 import { IPropertyPaneChoiceGroupOption } from '@microsoft/sp-property-pane';
 import ISearchFiltersWebPartProps from '../webparts/searchFilters/ISearchFiltersWebPartProps';
@@ -19,7 +19,7 @@ export class LayoutHelper {
      * @param layoutDefinitions the available layout definitions
      * @returns the data source provider instance
      */
-    public static async getLayoutInstance(rootScope: ServiceScope, context: WebPartContext, properties: ISearchFiltersWebPartProps | ISearchResultsWebPartProps, layoutKey: string, layoutDefinitions: ILayoutDefinition[]): Promise<ILayout> {
+    public static async getLayoutInstance(rootScope: ServiceScope, context: WebPartContext, properties: ISearchFiltersWebPartProps | ISearchResultsWebPartProps, layoutKey: string, layoutDefinitions: ILayoutDefinition[], displayMode: DisplayMode): Promise<ILayout> {
 
         let layout: ILayout = undefined;
         let serviceKey: ServiceKey<ILayout> = undefined;
@@ -233,6 +233,7 @@ export class LayoutHelper {
 
                         layout.properties = properties.layoutProperties; // Web Parts using layouts must define this sub property
                         layout.context = context;
+                        layout.editMode = displayMode === DisplayMode.Edit;
                         await layout.onInit();
                         resolve(layout);
                     }

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -131,11 +131,13 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         );
         this._propertyFieldCollectionData = PropertyFieldCollectionData;
 
-        const { PropertyPaneWebPartInformation } = await import(
+        if (this.editMode) {
+          const { PropertyPaneWebPartInformation } = await import(
             /* webpackChunkName: 'pnp-modern-search-property-pane' */
             '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'
-        );
-        this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
+          );
+          this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
+        }
 
         this._customCollectionFieldType = CustomCollectionFieldType;
     }

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -125,21 +125,20 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         this.properties.additionalGroupByFields = this.properties.additionalGroupByFields ? this.properties.additionalGroupByFields : [];
         this.properties.groupsCollapsed = this.properties.groupsCollapsed !== null && this.properties.groupsCollapsed !== undefined ? this.properties.groupsCollapsed : true;
 
-        const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
+        if (this.editMode) {
+          const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
             /* webpackChunkName: 'pnp-modern-search-results-detailslist-layout' */
             '@pnp/spfx-property-controls/lib/PropertyFieldCollectionData'
-        );
-        this._propertyFieldCollectionData = PropertyFieldCollectionData;
+          );
+          this._propertyFieldCollectionData = PropertyFieldCollectionData;
+          this._customCollectionFieldType = CustomCollectionFieldType;
 
-        if (this.editMode) {
           const { PropertyPaneWebPartInformation } = await import(
             /* webpackChunkName: 'pnp-modern-search-property-pane' */
             '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'
           );
           this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
         }
-
-        this._customCollectionFieldType = CustomCollectionFieldType;
     }
 
     public getPropertyPaneFieldsConfiguration(availableFields: string[], dataContext?: IDataContext): IPropertyPaneField<any>[] {

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -131,13 +131,11 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         );
         this._propertyFieldCollectionData = PropertyFieldCollectionData;
 
-        if (this.properties.enableGrouping) {
-            const { PropertyPaneWebPartInformation } = await import(
-                /* webpackChunkName: 'pnp-modern-search-property-pane' */
-                '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'
-            );
-            this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
-        }
+        const { PropertyPaneWebPartInformation } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'
+        );
+        this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
 
         this._customCollectionFieldType = CustomCollectionFieldType;
     }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -165,7 +165,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         // Get and initialize layout instance if different (i.e avoid to create a new instance every time)
         if (this.lastLayoutKey !== this.properties.selectedLayoutKey) {
-            this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions);
+            this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions, this.displayMode);
             this.lastLayoutKey = this.properties.selectedLayoutKey;
         }
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -253,7 +253,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             // Get and initialize layout instance if different (i.e avoid to create a new instance every time)
             if (this.lastLayoutKey !== this.properties.selectedLayoutKey) {
-                this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions);
+                this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions, this.displayMode);
                 this.lastLayoutKey = this.properties.selectedLayoutKey;
             }
 


### PR DESCRIPTION
Fixes an issue that would occur when enabling results grouping in the details list layout for a newly added results webpart. After adding a results webpart and switching to details list layout the grouping toggle was did not change state until you first exited webpart properties and then edited it again.