### PR TITLE
Fix for details list selection and focus

### DIFF
--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -430,13 +430,6 @@ export class DetailsListComponent extends React.Component<IDetailsListComponentP
 
         const { columns, items } = this.state;
 
-        let focusIndex = -1;
-        if (this.props.selectedKeys && this.props.selectedKeys.length > 0) {
-            const key = this.props.selectedKeys[0];
-            focusIndex = items.findIndex(item => item.key == key);
-        }
-
-
         let shimmeredDetailsListProps: IShimmeredDetailsListProps = {
             theme: this.props.themeVariant as ITheme,
             items: items,
@@ -446,7 +439,6 @@ export class DetailsListComponent extends React.Component<IDetailsListComponentP
             selection: this._selection,
             layoutMode: DetailsListLayoutMode.justified,
             isHeaderVisible: true,
-            initialFocusedIndex: focusIndex,
             enableShimmer: this.props.showShimmers,
             selectionPreservedOnEmptyClick: true,
             enterModalSelectionOnTouch: true,


### PR DESCRIPTION
Fixes an issue that occurs when you have enabled multi-selection for the details list layout. When you have many result items so that the list covers more than the browser view, select the first item then scroll down so the first item is scrolled out of view, try to select another item and the view is scrolled to the top of the list and all items are de-selected. This fix removes setting the focus so that the selection is retained and the view is not scrolled to the top.