### PR TITLE
Fix for displaying Details List sort arrows on multiple columns

### DIFF
--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -334,7 +334,8 @@ export class DetailsListComponent extends React.Component<IDetailsListComponentP
                         isRowHeader: false,
                         isResizable: column.isResizable === true,
                         isMultiline: column.isMultiline === true,
-                        isSorted: allowSorting,
+                        // show sort arrow only if the column is sortable and sorting has been applied by a previous click ('user sort' happened)
+                        isSorted: allowSorting && column.valueSorting === this.props.defaultSelectedField,
                         isSortedDescending: this.props.defaultDirection === SortFieldDirection.Descending,
                         sortAscendingAriaLabel: 'Sorted A to Z',
                         sortDescendingAriaLabel: 'Sorted Z to A',


### PR DESCRIPTION
This should fix #3839.

As sorting by the user is only possible for one column at a time, a sort arrow is only displayed in the column according to which the search result is currently sorted.