### PR TITLE
Fix for getUserEmail when a email address contains a single quote

### DIFF
--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -866,18 +866,14 @@ export class TemplateService implements ITemplateService {
 
         // Match and return an email in the specified expression
         this.Handlebars.registerHelper("getUserEmail", (expr: string) => {
-
             if (!isEmpty(expr)) {
-
-                const matches = expr.match(/([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,63})/gi);
+                const matches = expr.match(/[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/gi);
                 if (matches) {
                     return matches[0]; // Return the full match
                 } else {
                     return expr;
                 }
-
             }
-
         });
 
         // Return SPFx page context variable


### PR DESCRIPTION
This should fix https://github.com/microsoft-search/pnp-modern-search/issues/3916

The updated regex is from the [HMTL standard](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address)

I have tested out the following email addresses and it is returned by the template helper:

- `franck.cornu@contoso.onmicrosoft.com|Franck Cornu | 693A30232E667C6D656D626572736869707C6672616E636B2E636F726E7540616571756F736465762E6F6E6D6963726F736F66742E636F6D i:0#.f|membership|franck.cornu@contoso.onmicrosoft.com`
- `franck.cornu@contoso.onmicrosoft.com`
- `test.firstname+lastname@domain.com`
- `franck.c'ornu@contoso.onmicrosoft.com`
- `123456789test@domain.com`
- `test@dom-ain.com`

