### PR TITLE
replace refinableyesno token

### DIFF
--- a/search-parts/src/helpers/DataFilterHelper.ts
+++ b/search-parts/src/helpers/DataFilterHelper.ts
@@ -126,6 +126,10 @@ export class DataFilterHelper {
                         value = "string('')";
                     }
 
+                    if (/RefinableYesNo/.test(filter.filterName)) {
+                        value = DataFilterHelper.fixRefinableYesNoFilter(filter, value);
+                    }
+
                     // Enclose the expression with quotes if the value contains spaces, or number only
                     if ((/\s/.test(value) && value.indexOf('range') === -1) || (filter.filterName.indexOf("RefinableString") && /^\d+$/.test(value))) {
                         value = `"${value}"`;
@@ -170,6 +174,10 @@ export class DataFilterHelper {
                         refinementToken = "string('')";
                     }
 
+                    if (/RefinableYesNo/.test(filter.filterName)) {
+                        refinementToken = DataFilterHelper.fixRefinableYesNoFilter(filter, refinementToken);
+                    }
+
                     // Enclose the expression with quotes if the value contains spaces
                     if (/\s/.test(refinementToken) && refinementToken.indexOf('range') === -1) {
                         refinementToken = `"${refinementToken}"`;
@@ -181,5 +189,14 @@ export class DataFilterHelper {
         });
 
         return refinementQueryConditions;
+    }
+
+    private static fixRefinableYesNoFilter(filter: IDataFilter, value: string) {
+        if (value === "\"ǂǂ54727565\"") {
+            value = "true";
+        } else if (value === "\"ǂǂ46616c7365\"") {
+            value = "false";
+        }
+        return value;
     }
 }


### PR DESCRIPTION
See https://github.com/SharePoint/sp-dev-docs/issues/9098
When using a YesNo type refiner, the tokens ǂǂ54727565 and ǂǂ46616c7365 do not work. In this case, I replace the tokens with the values true and false. Feel free to modify my code 👋