### PR TITLE
update Localized Metadata separator to | rather than a comma as labels might contain a comma. Updated Card and List layout to handle this update

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -1347,7 +1347,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
                         // Create a new property and keep the original value with the original property name
                         // This allow to let the original value accessible in templates 
-                        result[`Auto${res.propertyName}`] = res.termLabels.join(', ');
+                        result[`Auto${res.propertyName}`] = res.termLabels.join('| ');
                     });
                 }
 

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -1347,7 +1347,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
                         // Create a new property and keep the original value with the original property name
                         // This allow to let the original value accessible in templates 
-                        result[`Auto${res.propertyName}`] = res.termLabels.join('| ');
+                        result[`Auto${res.propertyName}`] = res.termLabels.join('ǂǂ ');
                     });
                 }
 

--- a/search-parts/src/layouts/results/cards/CardsLayout.ts
+++ b/search-parts/src/layouts/results/cards/CardsLayout.ts
@@ -61,7 +61,32 @@ export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
                                                 [
                                                     { name: strings.Layouts.Cards.Fields.Title, field: 'title', value: '{{slot item @root.slots.Title}}', useHandlebarsExpr: true, supportHtml: false },
                                                     { name: strings.Layouts.Cards.Fields.Location, field: 'location', value: `<a style="color:{{@root.theme.palette.themePrimary}};font-weight:600;font-family:'{{@root.theme.fonts.small.fontFamily}}'" href="{{SPSiteURL}}">{{SiteTitle}}</a>`, useHandlebarsExpr: true, supportHtml: true },
-                                                    { name: strings.Layouts.Cards.Fields.Tags, field: 'tags', value: `<style>\n\t.tags {\n\t\tdisplay: flex;\n\t\talign-items: center;\n\t\twhite-space: normal;\n\t\tscursor: auto; \n\t}\n\t.tags i { \n\t\tmargin-right: 5px; \n\t}\n\t.tags div {\n\t\tdisplay: flex;\n\t\tflex-wrap: wrap; \n\t\tjustify-content: flex-end; \n\t}\n\t.tags div span {\n\t\ttext-decoration: underline; \n\t\tmargin-right: auto; \n\t}\n\t .simpletags \n\t\{\n\t\tdisplay: inline-block;\n\t\tpadding: 2px 5px;\n\t\tmargin-right: 5px;\n\t\tbackground-color: {{@root.theme.palette.neutralLight}};\n\t\tcolor: {{@root.theme.palette.neutralDark}};\n\t\tborder-radius: 5px;\n\t\tfont-size: 12px;\n\t\}\n</style>\n\n{{#if (slot item @root.slots.Tags)}}\n\t<div class="tags">\n\t\t<pnp-icon data-name="Tag" aria-hidden="true" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon>\n\t\t<div>\n\t\t\t{{#each (split (slot item @root.slots.Tags) ";") as |tag| }}\n\t\t\t\t<span class="simpletags">\n\t\t\t\t\t{{#with (split (tag) '|')}}\n\t\t\t\t\t\t{{trim [2]}}\n\t\t\t\t\t{{/with}}\n\t\t\t</span>\n\t\t\t{{/each}}\n\t\t</div>\n\t</div>\n{{/if}}`, useHandlebarsExpr: true, supportHtml: true },
+                                                    { name: strings.Layouts.Cards.Fields.Tags, field: 'tags', value: `<style>\n\t.tags {\n\t\tdisplay: flex;\n\t\talign-items: center;\n\t\twhite-space: normal;\n\t\tcursor: auto; \n\t}\n\t.tags i { \n\t\tmargin-right: 5px; \n\t}\n\t.tags div {\n\t\tdisplay: flex;\n\t\tflex-wrap: wrap; \n\t\tjustify-content: flex-end; \n\t}\n\t.tags div span {\n\t\ttext-decoration: underline; \n\t\tmargin-right: auto; \n\t}\n\t .simpletags \n\t\{\n\t\tdisplay: inline-block;\n\t\tpadding: 2px 5px;\n\t\tmargin-right: 5px;\n\t\tbackground-color: {{@root.theme.palette.neutralLight}};\n\t\tcolor: {{@root.theme.palette.neutralDark}};\n\t\tborder-radius: 5px;\n\t\tfont-size: 12px;\n\t\}\n</style>\n\n{{#if (slot item @root.slots.Tags)}}
+	<div class="tags">
+		<pnp-icon data-name="Tag" aria-hidden="true" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon>
+		<div>
+		    <!-- If the enableLocalization is on I assume that the Auto[property] is used -->
+            {{#if @root.properties.dataSourceProperties.enableLocalization}}
+             
+                {{#each (split (slot item @root.slots.Tags) "|") as |tag| }}
+             <span class="simpletags">
+                    {{trim tag}}
+                
+            </span>
+                {{/each}}
+                
+            {{else}}    
+			{{#each (split (slot item @root.slots.Tags) ";") as |tag| }}
+				<span class="simpletags">
+					{{#with (split (tag) '|')}}
+						{{trim [2]}}
+					{{/with}}
+			</span>
+			{{/each}}
+			  {{/if}}
+		</div>
+	</div>
+{{/if}}`, useHandlebarsExpr: true, supportHtml: true },
                                                     { name: strings.Layouts.Cards.Fields.PreviewImage, field: 'previewImage',  value: "{{slot item @root.slots.PreviewImageUrl}}", useHandlebarsExpr: true, supportHtml: false },
                                                     { name: strings.Layouts.Cards.Fields.PreviewUrl, field: 'previewUrl' , value: "{{slot item @root.slots.PreviewUrl}}", useHandlebarsExpr: true, supportHtml: false },
                                                     { name: strings.Layouts.Cards.Fields.Date, field: 'date', value: "{{getDate (slot item @root.slots.Date) 'LL'}}", useHandlebarsExpr: true, supportHtml: false },

--- a/search-parts/src/layouts/results/cards/CardsLayout.ts
+++ b/search-parts/src/layouts/results/cards/CardsLayout.ts
@@ -68,7 +68,7 @@ export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
 		    <!-- If the enableLocalization is on I assume that the Auto[property] is used -->
             {{#if @root.properties.dataSourceProperties.enableLocalization}}
              
-                {{#each (split (slot item @root.slots.Tags) "|") as |tag| }}
+                {{#each (split (slot item @root.slots.Tags) "ǂǂ") as |tag| }}
              <span class="simpletags">
                     {{trim tag}}
                 

--- a/search-parts/src/layouts/results/simpleList/simple-list.html
+++ b/search-parts/src/layouts/results/simpleList/simple-list.html
@@ -121,17 +121,31 @@
                                         {{#if (slot item @root.slots.Tags)}}
                                             <pnp-icon data-name="Tag" aria-hidden="true" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon>
                                             <div>
-                                                {{#each (split (slot item @root.slots.Tags) ";") as |tag| }}
-                                                <div class="simpletags">
-                                                    {{#with (split (tag) '|')}}
-                                                        {{trim [2]}}
-                                                    <!-- Use this if you want the tags to be displayed as a search link -->
-                                                    <!-- <i class="ms-Icon ms-Icon--MapPin" aria-hidden="true"></i> -->
-                                                    <!-- <a href="?q=Tags:'    {{[2]}}'" data-interception="off">{{[2]}}</a> -->
-                                                    {{/with}}
+
+                                                <!-- If the enableLocalization is on I assume that the Auto[property] is used -->
+                                                {{#if @root.properties.dataSourceProperties.enableLocalization}}
+                                                 
+                                                    {{#each (split (slot item @root.slots.Tags) "|") as |tag| }}
+                                                    <div class="simpletags"> 
+                                                        {{trim tag}}
+                                                    </div>        
+                                                        
+                                                    {{/each}}
                                                     
-                                                </div>
-                                                {{/each}}
+                                                {{else}}    
+                                                    <!-- If the enableLocalization is OFF I assume that the Auto[property] is NOT used -->
+                                                    {{#each (split (slot item @root.slots.Tags) ";") as |tag| }}
+                                                    <div class="simpletags">
+                                                        {{#with (split (tag) '|')}}
+                                                            {{trim [2]}}
+                                                        <!-- Use this if you want the tags to be displayed as a search link -->
+                                                        <!-- <i class="ms-Icon ms-Icon--MapPin" aria-hidden="true"></i> -->
+                                                        <!-- <a href="?q=Tags:'    {{[2]}}'" data-interception="off">{{[2]}}</a> -->
+                                                        {{/with}}
+                                                        
+                                                    </div>
+                                                    {{/each}}
+                                                {{/if}}
                                             </div>
                                         {{/if}}
                                     </div>

--- a/search-parts/src/layouts/results/simpleList/simple-list.html
+++ b/search-parts/src/layouts/results/simpleList/simple-list.html
@@ -125,7 +125,7 @@
                                                 <!-- If the enableLocalization is on I assume that the Auto[property] is used -->
                                                 {{#if @root.properties.dataSourceProperties.enableLocalization}}
                                                  
-                                                    {{#each (split (slot item @root.slots.Tags) "|") as |tag| }}
+                                                    {{#each (split (slot item @root.slots.Tags) "ǂǂ") as |tag| }}
                                                     <div class="simpletags"> 
                                                         {{trim tag}}
                                                     </div>        


### PR DESCRIPTION
handles Change to tag display in templates "breaks" existing PnP Search Results Web Parts #4039