### PR TITLE
Add correct loading of handlebars templates

### DIFF
--- a/search-parts/gulpfile.js
+++ b/search-parts/gulpfile.js
@@ -60,6 +60,11 @@ const envCheck = build.subTask('environmentCheck', (gulp, config, done) => {
               "fs": false
             };
 
+            // Remove the default html rule
+            generatedConfiguration.module.rules = generatedConfiguration.module.rules.filter(rule => {
+                return rule.test.toString() !== '/\\.html$/';
+            });
+
             generatedConfiguration.module.rules.push({
                 test: /\.js$/,
                 include: [
@@ -100,6 +105,13 @@ const envCheck = build.subTask('environmentCheck', (gulp, config, done) => {
                 test: /index\.js$/,
                 include: [/spfx-controls-react[/\\]lib[/\\]controls[/\\]HoverReactionsBar/],
                 loader: 'ignore-loader',
+            }, {
+              // Add html loader without minimize so that we can use it for handlebars templates
+              test: /\.html$/,
+              loader: 'html-loader',
+              options: {
+                minimize: false
+              }
             });
 
             generatedConfiguration.optimization.splitChunks = { cacheGroups: { vendors: false } };

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -76,7 +76,7 @@
                 "eslint-plugin-react-hooks": "4.3.0",
                 "fancy-log": "1.3.3",
                 "gulp": "4.0.2",
-                "html-loader": "1.1.0",
+                "html-loader": "4.2.0",
                 "ignore-loader": "0.1.2",
                 "path-browserify": "1.0.1",
                 "semver": "7.5.4",
@@ -7827,19 +7827,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/clean-css": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "source-map": "~0.6.0"
-            },
-            "engines": {
-                "node": ">= 10.0"
-            }
-        },
         "node_modules/@microsoft/spfx-heft-plugins/node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -7857,16 +7844,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@microsoft/spfx-heft-plugins/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7875,19 +7852,6 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
-            }
-        },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/@microsoft/spfx-heft-plugins/node_modules/escape-string-regexp": {
@@ -7977,49 +7941,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/html-loader": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-4.2.0.tgz",
-            "integrity": "sha512-OxCHD3yt+qwqng2vvcaPApCEvbx+nXWu+v69TYHx1FO8bffHn/JjHtE3TTQZmHjwvnJe4xxzuecetDVBrQR1Zg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "html-minifier-terser": "^7.0.0",
-                "parse5": "^7.0.0"
-            },
-            "engines": {
-                "node": ">= 14.15.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
-            }
-        },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/html-minifier-terser": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-            "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "camel-case": "^4.1.2",
-                "clean-css": "~5.3.2",
-                "commander": "^10.0.0",
-                "entities": "^4.4.0",
-                "param-case": "^3.0.4",
-                "relateurl": "^0.2.7",
-                "terser": "^5.15.1"
-            },
-            "bin": {
-                "html-minifier-terser": "cli.js"
-            },
-            "engines": {
-                "node": "^14.13.1 || >=16.0.0"
-            }
-        },
         "node_modules/@microsoft/spfx-heft-plugins/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -8045,19 +7966,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@microsoft/spfx-heft-plugins/node_modules/parse5": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-            "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "entities": "^4.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/@microsoft/spfx-heft-plugins/node_modules/qs": {
@@ -16614,13 +16522,13 @@
             }
         },
         "node_modules/commander": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 6"
+                "node": ">=14"
             }
         },
         "node_modules/commondir": {
@@ -18407,22 +18315,6 @@
             "license": "MIT",
             "dependencies": {
                 "webidl-conversions": "^4.0.2"
-            }
-        },
-        "node_modules/domhandler": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-            "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
         "node_modules/dompurify": {
@@ -23050,88 +22942,99 @@
             "license": "MIT"
         },
         "node_modules/html-loader": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz",
-            "integrity": "sha512-zwLbEgy+i7sgIYTlxI9M7jwkn29IvdsV6f1y7a2aLv/w8l1RigVk0PFijBZLLFsdi2gvL8sf2VJhTjLlfnK8sA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-4.2.0.tgz",
+            "integrity": "sha512-OxCHD3yt+qwqng2vvcaPApCEvbx+nXWu+v69TYHx1FO8bffHn/JjHtE3TTQZmHjwvnJe4xxzuecetDVBrQR1Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "html-minifier-terser": "^5.0.5",
-                "htmlparser2": "^4.1.0",
-                "loader-utils": "^2.0.0",
-                "parse-srcset": "^1.0.2",
-                "schema-utils": "^2.6.5"
+                "html-minifier-terser": "^7.0.0",
+                "parse5": "^7.0.0"
             },
             "engines": {
-                "node": ">= 10.13.0"
+                "node": ">= 14.15.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             }
         },
-        "node_modules/html-minifier-terser": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-            "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+        "node_modules/html-loader/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/html-loader/node_modules/parse5": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+            "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "camel-case": "^4.1.1",
-                "clean-css": "^4.2.3",
-                "commander": "^4.1.1",
-                "he": "^1.2.0",
-                "param-case": "^3.0.3",
+                "entities": "^4.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/html-minifier-terser": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+            "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camel-case": "^4.1.2",
+                "clean-css": "~5.3.2",
+                "commander": "^10.0.0",
+                "entities": "^4.4.0",
+                "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
-                "terser": "^4.6.3"
+                "terser": "^5.15.1"
             },
             "bin": {
                 "html-minifier-terser": "cli.js"
             },
             "engines": {
-                "node": ">=6"
+                "node": "^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/html-minifier-terser/node_modules/clean-css": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-            "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "source-map": "~0.6.0"
             },
             "engines": {
-                "node": ">= 4.0"
+                "node": ">= 10.0"
             }
         },
-        "node_modules/html-minifier-terser/node_modules/terser": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-            "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+        "node_modules/html-minifier-terser/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "dependencies": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
             "engines": {
-                "node": ">=6.0.0"
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
-        },
-        "node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/html-tag": {
             "version": "2.0.0",
@@ -23153,19 +23056,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/htmlparser2": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-            "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^3.0.0",
-                "domutils": "^2.0.0",
-                "entities": "^2.0.0"
             }
         },
         "node_modules/http-cache-semantics": {
@@ -29100,13 +28990,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/parse-srcset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/parse5": {
             "version": "5.1.0",

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -80,7 +80,7 @@
         "eslint-plugin-react-hooks": "4.3.0",
         "fancy-log": "1.3.3",
         "gulp": "4.0.2",
-        "html-loader": "1.1.0",
+        "html-loader": "4.2.0",
         "ignore-loader": "0.1.2",
         "path-browserify": "1.0.1",
         "semver": "7.5.4",

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -69,6 +69,12 @@ import { PropertyPaneTabsField } from '../../controls/PropertyPaneTabsField/Prop
 import { loadMsGraphToolkit } from '../../helpers/GraphToolKitHelper';
 import { PropertyFieldMessage } from '@pnp/spfx-property-controls';
 
+// Import statements for templates
+import defaultSimpleListTemplate from '../../layouts/resultTypes/default_simple_list.html';
+import defaultCardsTemplate from '../../layouts/resultTypes/default_cards.html';
+import defaultCustomTemplate from '../../layouts/resultTypes/default_custom.html';
+import defaultPeopleTemplate from '../../layouts/resultTypes/default_people.html';
+
 const LogSource = "SearchResultsWebPart";
 
 export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebPartProps> implements IDynamicDataCallables {
@@ -1235,19 +1241,19 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         switch (this.properties.selectedLayoutKey) {
             case BuiltinLayoutsKeys.SimpleList:
-                resultTypeInlineTemplate = require('../../layouts/resultTypes/default_simple_list.html');
+                resultTypeInlineTemplate = defaultSimpleListTemplate;
                 break;
 
             case BuiltinLayoutsKeys.Cards:
-                resultTypeInlineTemplate = require('../../layouts/resultTypes/default_cards.html');
+                resultTypeInlineTemplate = defaultCardsTemplate;
                 break;
 
             case BuiltinLayoutsKeys.ResultsCustomHandlebars:
-                resultTypeInlineTemplate = require('../../layouts/resultTypes/default_custom.html');
+                resultTypeInlineTemplate = defaultCustomTemplate;
                 break;
 
             case BuiltinLayoutsKeys.People:
-                resultTypeInlineTemplate = require('../../layouts/resultTypes/default_people.html');
+                resultTypeInlineTemplate = defaultPeopleTemplate;
                 break;
 
             default:


### PR DESCRIPTION
Removes the default loading of html files and adds non-minimized loading of those to handle the handlebars templates correctly. Also bumps html-loader to be the same version as in SPFx 1.20.

Addresses #4220 