### PR TITLE
Add compatibility matrix for extensibility projects

### DIFF
--- a/docs/extensibility/extensibility_compatibility_matrix.md
+++ b/docs/extensibility/extensibility_compatibility_matrix.md
@@ -1,0 +1,49 @@
+# PnP Modern Search extensibility library - Compatibility matrix
+
+When developing a new extensibility library for the PnP Modern Search solution, your SPFx library project must use the same SPFx version as the main solution.
+The following table lists the SPFx version used by each PnP Modern Search release, helping you determine the appropriate version for your extensibility project.
+
+| PnP Modern Search Release | Release Date       | SPFx Version used |
+|----------------------------|--------------------|--------------------|
+| 4.16.0                     | February 2025     | 1.20.0             |
+| 4.15.0                     | January 2025      | 1.20.0             |
+| 4.14.0                     | November 2024     | 1.18.2             |
+| 4.13.1                     | September 2024    | 1.18.2             |
+| 4.12.2                     | June 2024         | 1.18.2             |
+| 4.12.1                     | June 2024         | 1.18.2             |
+| 4.11.1                     | April 2024        | 1.18.2             |
+| 4.11.0                     | March 2024        | 1.18.2             |
+| 4.10.2                     | February 2024     | 1.18.2             |
+| 4.10.1                     | December 2023     | 1.18.2             |
+| 4.9.3                      | August 2023       | 1.15.2             |
+| 4.9.2                      | August 2023       | 1.15.2             |
+| 4.9.1                      | July 2023         | 1.15.2             |
+| 4.9.0                      | June 2023         | 1.15.2             |
+| 4.8.0                      | November 2022     | 1.15.2             |
+| 4.7.0                      | June 2022         | 1.14.0             |
+| 4.6.1                      | April 2022        | 1.12.1             |
+| 4.5.4                      | February 2022     | 1.12.1             |
+| 4.5.3                      | December 2021     | 1.12.1             |
+| 3.23.0                     | December 2021     | 1.12.1             |
+| 4.4.1                      | October 2021      | 1.12.1             |
+| 3.22.0                     | October 2021      | 1.12.1             |
+| 4.3.0                      | July 2021         | 1.12.1             |
+| 3.21.0                     | July 2021         | 1.12.1             |
+| 4.2.3                      | June 2021         | 1.12.1             |
+| 3.20.0                     | June 2021         | 1.12.1             |
+| 3.19.2                     | April 2021        | 1.10.0             |
+| 4.1.0                      | March 2021        | 1.11.0             |
+| 3.18.2                     | March 2021        | 1.10.0             |
+| 4.0.0                      | January 2021      | 1.11.0             |
+| 3.17.0                     | January 2021      | 1.10.0             |
+| 3.16.0                     | November 2020     | 1.10.0             |
+| 3.15.3                     | September 2020    | 1.10.0             |
+| 3.14.2                     | June 2020         | 1.10.0             |
+| 3.13.0                     | May 2020          | 1.10.0             |
+| 3.12.1                     | April 2020        | 1.10.0             |
+| 3.11.1                     | March 2020        | 1.10.0             |
+| 3.10.0                     | February 2020     | 1.10.0             |
+| 3.9.0                      | January 2020      | 1.10.0             |
+| 3.8.0                      | December 2019     | 1.9.1              |
+| 3.7.0                      | October 2019      | 1.9.1              |
+

--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -29,7 +29,7 @@ For your project to be a valid extensibility library, you must have the followin
 - You library **manifest ID** must be registered in the Web Part where you want to use the extension.
 
 !!! important "SPFx version"
-    The SPFx library project must use the same SPFx version as the main solution (check source code for current version). Owherwise you may face issues at build time. See [GitHub issue #1893](https://github.com/microsoft-search/pnp-modern-search/issues/1893)
+    The SPFx library project must use the same SPFx version as the main solution (check [compatibility matrix](./extensibility_compatibility_matrix.md)). Owherwise you may face issues at build time. See [GitHub issue #1893](https://github.com/microsoft-search/pnp-modern-search/issues/1893)
 
 ### Supported extensions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Custom event handlers for adaptive cards actions: extensibility/adaptivecards_customizations.md
     - Custom data sources: extensibility/custom_data_sources.md
     - Custom query modifier: extensibility/custom_query_modifications.md
+    - Compatibility matrix: extensibility/extensibility_compatibility_matrix.md
   
 theme:
   name: 'material'


### PR DESCRIPTION
The idea behind this pull request is to list for all PnP Modern Search release, the SPFx version it uses so it is easier to know which version to use when developing extensibility projects (easier than looking directly at the source code). 