### PR TITLE
Update templating.md - fixing html error

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -63,7 +63,7 @@ The following custom helpers are available in addition to the [handlebars-helper
 
 **Description** Return object structure for list item attachments.
 
-**Example** `{{#getAttachments LinkOfficeChild}}<a href="{{url}}">{{index}} - {{fileName}}</href>{{/getAttachments}}`
+**Example** `{{#getAttachments LinkOfficeChild}}<a href="{{url}}">{{index}} - {{fileName}}</a>{{/getAttachments}}`
 
 #### getCountMessage
 


### PR DESCRIPTION
Small typo in the html structure of the getAttachments helper.

The closing html tag containts href while the element is an '< a >'