### PR TITLE
Use toISOString in token service to fix date token replacement for better localization

### DIFF
--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -453,13 +453,13 @@ export class TokenService implements ITokenService {
                 const digit = parseInt(operatorSplit[operatorSplit.length - 1].replace("{", "").replace("}", "").trim()) * addOrRemove;
                 let dt = new Date();
                 dt.setDate(dt.getDate() + digit);
-                const formatDate = this.moment(dt).utc().format("YYYY-MM-DDTHH:mm:ss\\Z");
+                const formatDate = this.moment(dt).toISOString();
                 inputString = inputString.replace(result, formatDate);
             }
         }
 
         // Replaces any "{Today}" expression by it's actual value
-        let formattedDate = this.moment(new Date()).utc().format("YYYY-MM-DDTHH:mm:ss\\Z");
+        let formattedDate = this.moment(new Date()).toISOString();
         inputString = inputString.replace(new RegExp("{Today}", 'gi'), formattedDate);
 
         const d = new Date();


### PR DESCRIPTION
We ran into an issue for Arabic users where the momentJS format function would result in non-ISO date strings being used in the {Today} token replacement (known issue with momentJS).

To ensure the date token replacement works for any language, I updated it to use .toISOString() instead, which doesn't results in a malformed date string.

Thanks!