### PR TITLE
Enhance taxonomy refiner regex and localization for max buckets warning across multiple languages

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -40,7 +40,7 @@ import { StringHelper } from '../helpers/StringHelper';
 import { SortableFields } from '../common/Constants';
 import { PnPClientStorage } from "@pnp/common/storage";
 
-const TAXONOMY_REFINER_REGEX = /((L0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
+const TAXONOMY_REFINER_REGEX = /((L0|GP0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
 
 export enum BuiltinSourceIds {
     Documents = 'e7ec8cee-ded8-43c9-beb5-436b54b31e84',
@@ -1229,8 +1229,9 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                         if (isTerm) {
                             const matches = TAXONOMY_REFINER_REGEX.exec(value.name);
                             const termId = matches[3];
-                            const termPrefix = matches[2]; // 'L0'
-                            if (termPrefix.localeCompare("L0") === 0) {
+                            const termPrefix = matches[2]; // 'L0' or 'GP0'
+                            // Handle both L0 and GP0 formats
+                            if (termPrefix.localeCompare("L0") === 0 || termPrefix.localeCompare("GP0") === 0) {
                                 const termFilterWithoutTranslations = `GP0|#${termId.toString()}`;
                                 const termTextFilter = `L0|#0${termId.toString()}`;
 
@@ -1245,8 +1246,9 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                         value.name = existingFilters[0].localizedTermLabel;
                     }
 
-                    // Keep only terms (L0). The crawl property ows_taxid_xxx return term sets too.
-                    if (!(/(GTSet|GPP|GP0)/i).test(value.name)) {
+                    // Keep only terms (L0 or GP0). The crawl property ows_taxid_xxx return term sets too.
+                    // GP0 values should be kept as they represent actual terms when maxBuckets is used
+                    if (!(/(GTSet|GPP)/i).test(value.name)) {
                         return value;
                     }
 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -45,6 +45,7 @@ import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
 import { IComboBoxOption } from '@fluentui/react/lib/ComboBox';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 import { Dropdown, IDropdownOption, IDropdownProps } from '@fluentui/react/lib/Dropdown';
+import { TextField } from '@fluentui/react/lib/TextField';
 
 const LogSource = "SearchFiltersWebPart";
 
@@ -621,7 +622,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 required: true,
                 onCustomRender: (field, value, onUpdate, item) => {
                     return (
-                        React.createElement("div", null,
+                        React.createElement("div", { title: item[field.id] ? item[field.id] : '' },
                             React.createElement(AsyncCombo, {
                                 allowFreeform: true,
                                 availableOptions: availableFieldOptionsFromResults, // We remove already selected fields
@@ -661,9 +662,25 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     {
                         id: 'maxBuckets',
                         title: webPartStrings.PropertyPane.DataFilterCollection.FilterMaxBuckets,
-                        type: this._customCollectionFieldType.number,
+                        type: this._customCollectionFieldType.custom,
                         required: false,
-                        defaultValue: ""
+                        onCustomRender: (field, value, onUpdate, item, itemId, onCustomFieldValidation) => {
+                            const numValue = value ? parseInt(value.toString(), 10) : undefined;
+                            const errorMessage = numValue && numValue > 1000 
+                                ? webPartStrings.PropertyPane.DataFilterCollection.FilterMaxBucketsWarning 
+                                : '';
+                            
+                            return React.createElement(TextField, {
+                                key: `${field.id}-${itemId}`,
+                                type: 'number',
+                                value: value ? value.toString() : '',
+                                errorMessage: errorMessage,
+                                onChange: (ev, newValue) => {
+                                    const parsedValue = newValue && newValue.trim() !== '' ? parseInt(newValue, 10) : undefined;
+                                    onUpdate(field.id, parsedValue);
+                                }
+                            });
+                        }
                     },
                     {
                         id: 'selectedTemplate',

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Vybrat pole",
                 FilterNameLabel: "Filtrační pole",
                 FilterMaxBuckets: "Počet hodnot",
+                FilterMaxBucketsWarning: "Maximální počet hodnot je 1000",
                 FilterDisplayName: "Zobrazovaný název",
                 FilterTemplate: "Šablona",
                 FilterExpandByDefault: "Rozbalit ve výchozím nastavení",

--- a/search-parts/src/webparts/searchFilters/loc/da-dk.js
+++ b/search-parts/src/webparts/searchFilters/loc/da-dk.js
@@ -27,6 +27,7 @@ define([], function() {
                 FilterNameLabel: "Felt til filter",
                 FilterDisplayName: "Visningsnavn",
                 FilterMaxBuckets: "Antal værdier",
+                FilterMaxBucketsWarning: "Det maksimale antal værdier er 1000",
                 FilterTemplate: "Skabelon",
                 FilterExpandByDefault: "Udvid som standard",
                 // FilterType: "Filtertype",

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Wähle ein Feld",
                 FilterNameLabel: "Filter Feld",
                 FilterMaxBuckets: "# der Werte",
+                FilterMaxBucketsWarning: "Die maximale Anzahl von Werten ist 1000",
                 FilterDisplayName: "Anzeige name",
                 FilterTemplate: "Vorlage",
                 FilterExpandByDefault: "Standardmäßig erweitert",

--- a/search-parts/src/webparts/searchFilters/loc/en-us.js
+++ b/search-parts/src/webparts/searchFilters/loc/en-us.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Select field",
                 FilterNameLabel: "Filter field",
                 FilterMaxBuckets: "# of values",
+                FilterMaxBucketsWarning: "The maximum number of values is 1000",
                 FilterDisplayName: "Display name",
                 FilterTemplate: "Template",
                 FilterExpandByDefault: "Expand by default",

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Seleccionar campo",
                 FilterNameLabel: "Campo de filtrado",
                 FilterMaxBuckets: "# de valores",
+                FilterMaxBucketsWarning: "El número máximo de valores es 1000",
                 FilterDisplayName: "Nombre para mostrar",
                 FilterTemplate: "Plantilla",
                 FilterExpandByDefault: "Expandir por defecto",

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Valitse kenttä",
                 FilterNameLabel: "Suodatinkenttä",
                 FilterMaxBuckets: "# arvojen määrä",
+                FilterMaxBucketsWarning: "Arvojen enimmäismäärä on 1000",
                 FilterDisplayName: "Näyttönimi",
                 FilterTemplate: "Templaatti",
                 FilterExpandByDefault: "Näytä oletuksena laajennettuna",

--- a/search-parts/src/webparts/searchFilters/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchFilters/loc/fr-fr.js
@@ -26,8 +26,9 @@ define([], function() {
             },
             DataFilterCollection: {
                 SelectFilterComboBoxLabel: "Sélectionner un champ",
-                FilterNameLabel: "Champ Filtre",
+                FilterNameLabel: "Champ de filtre",
                 FilterMaxBuckets: "Nombre de valeurs",
+                FilterMaxBucketsWarning: "Le nombre maximum de valeurs est 1000",
                 FilterDisplayName: "Nom d'affichage",
                 FilterTemplate: "Modèle",
                 FilterExpandByDefault: "Agrandir par défaut",

--- a/search-parts/src/webparts/searchFilters/loc/it-it.js
+++ b/search-parts/src/webparts/searchFilters/loc/it-it.js
@@ -26,6 +26,7 @@ define([], function () {
                 SelectFilterComboBoxLabel: "Seleziona campo",
                 FilterNameLabel: "Campo filtro",
                 FilterMaxBuckets: "# di valori",
+                FilterMaxBucketsWarning: "Il numero massimo di valori è 1000",
                 FilterDisplayName: "Nome visualizzato",
                 FilterTemplate: "Modello",
                 FilterExpandByDefault: "Espandi per impostazione predefinita",

--- a/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
@@ -25,6 +25,7 @@ declare interface ISearchFiltersWebPartStrings {
             SelectFilterComboBoxLabel: string;
             FilterNameLabel: string;
             FilterMaxBuckets: string;
+            FilterMaxBucketsWarning: string;
             FilterDisplayName: string;
             FilterTemplate: string;
             FilterExpandByDefault: string;

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Velg felt",
                 FilterNameLabel: "Felt for filter",
                 FilterMaxBuckets: "Antall verdier",
+                FilterMaxBucketsWarning: "Maksimalt antall verdier er 1000",
                 FilterDisplayName: "Visningsnavn",
                 FilterTemplate: "Mal",
                 FilterExpandByDefault: "Utvid som standard",

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -24,9 +24,10 @@ define([], function() {
             },
             DataFilterCollection: {
                 SelectFilterComboBoxLabel: "Selecteer veld",
-                FilterNameLabel: "Filter veld",
+                FilterNameLabel: "Filterveld",
                 FilterMaxBuckets: "# waarden",
-                FilterDisplayName: "Weergave naam",
+                FilterMaxBucketsWarning: "Het maximale aantal waarden is 1000",
+                FilterDisplayName: "Weergavenaam",
                 FilterTemplate: "Sjabloon",
                 FilterExpandByDefault: "Standaard uitklappen",
                 FilterType: "Soort filter",

--- a/search-parts/src/webparts/searchFilters/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchFilters/loc/pl-pl.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Wybierz pole",
                 FilterNameLabel: "Filter field",
                 FilterMaxBuckets: "# wartości",
+                FilterMaxBucketsWarning: "Maksymalna liczba wartości to 1000",
                 FilterDisplayName: "Tytuł",
                 FilterTemplate: "Szablon",
                 FilterExpandByDefault: "Domyślnie rozwinięte",

--- a/search-parts/src/webparts/searchFilters/loc/pt-br.js
+++ b/search-parts/src/webparts/searchFilters/loc/pt-br.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Selecionar campo",
                 FilterNameLabel: "Campo de filtro",
                 FilterMaxBuckets: "# de valores",
+                FilterMaxBucketsWarning: "O número máximo de valores é 1000",
                 FilterDisplayName: "Nome de exibição",
                 FilterTemplate: "Modelo",
                 FilterExpandByDefault: "Expandido por padrão",

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -26,6 +26,7 @@ define([], function() {
                 SelectFilterComboBoxLabel: "Välj fält",
                 FilterNameLabel: "Fält för filter",
                 FilterMaxBuckets: "# av värden",
+                FilterMaxBucketsWarning: "Det maximala antalet värden är 1000",
                 FilterDisplayName: "Visningsnamn",
                 FilterTemplate: "Filtermall",
                 FilterExpandByDefault: "Expandera som standard",


### PR DESCRIPTION
Fixed https://github.com/microsoft-search/pnp-modern-search/issues/4240 and added warning if # of values exceed 1000 and added a tooltip for the Filter field, as the text can be hard to read due to lenght 