### PR TITLE
Fix #4528: Resolve tokens for inputQueryText in SharePoint Search Data Source

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -922,7 +922,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
             });
         }
 
-        searchQuery.Querytext = dataContext.inputQueryText;
+        searchQuery.Querytext = await this._tokenService.resolveTokens(dataContext.inputQueryText);
 
         searchQuery.EnableQueryRules = this.properties.enableQueryRules;
         if (searchQuery.EnableQueryRules == true || searchQuery.EnableQueryRules == null) {


### PR DESCRIPTION
## Summary
Fixes #4528

Tokens in `inputQueryText` were not being resolved for the SharePoint Search Data Source, while they were correctly resolved for the Microsoft Search Data Source.

## Changes
- Added `await this._tokenService.resolveTokens()` call for `inputQueryText` in `SharePointSearchDataSource.ts` to match the behavior of `MicrosoftSearchDataSource.ts`

## Before
```typescript
searchQuery.Querytext = dataContext.inputQueryText;
```

## After
```typescript
searchQuery.Querytext = await this._tokenService.resolveTokens(dataContext.inputQueryText);
```