### PR TITLE
Fix #4431: Default Sort Setting Ignored in Microsoft Search Data Source

### DIFF
--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -939,7 +939,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             } else {
 
                 // Default sort
-                this.properties.sortProperties.filter(s => s.sortField).forEach(sortProperty => {
+                this.properties.sortProperties.filter(s => s.isDefaultSort).forEach(sortProperty => {
                     sortProperties.push({
                         name: sortProperty.sortField,
                         isDescending: sortProperty.sortDirection === SortFieldDirection.Descending ? true : false


### PR DESCRIPTION
## Summary

Fixes #4431 - Default Sort checkbox in the Microsoft Search data source sorting configuration was ignored.

## Problem

In the Microsoft Search data source, the `sortProperties` were being filtered by `s.sortField` (checking if a sort field exists) instead of `s.isDefaultSort` (checking if the "Default Sort" checkbox is enabled). This caused sorting to always be applied regardless of the Default Sort setting.

## Solution

Changed the filter condition from:
```typescript
this.properties.sortProperties.filter(s => s.sortField)
```
to:
```typescript
this.properties.sortProperties.filter(s => s.isDefaultSort)
```

This aligns the behavior with the SharePoint Search Data Source which correctly uses `sort.isDefaultSort` for filtering default sort properties.

## Testing

- Verified build completes successfully
- Logic matches existing SharePoint Search Data Source implementation