### PR TITLE
fix(#4530): Pagination not rendering during SPA navigation from same site

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1127,7 +1127,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.domElement.removeEventListener('pageNumberUpdated', this._pagingEventHandler);
         }
 
-        this._pagingEventHandler = ((ev: CustomEvent) => {
+        this._pagingEventHandler = (ev: CustomEvent) => {
 
             // We ensure the event if not propagated outside the component (i.e. other Web Part instances)
             ev.stopImmediatePropagation();
@@ -1139,7 +1139,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             this.render();
 
-        }).bind(this);
+        };
 
         this.domElement.addEventListener('pageNumberUpdated', this._pagingEventHandler);
     }
@@ -1154,7 +1154,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.domElement.removeEventListener(ExtensibilityConstants.EVENT_SORT_BY, this._sortingEventHandler);
         }
 
-        this._sortingEventHandler = ((ev: CustomEvent) => {
+        this._sortingEventHandler = (ev: CustomEvent) => {
 
             // We ensure the event if not propagated outside the component (i.e. other Web Part instances)
             ev.stopImmediatePropagation();
@@ -1167,7 +1167,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             this.render();
 
-        }).bind(this);
+        };
 
         this.domElement.addEventListener(ExtensibilityConstants.EVENT_SORT_BY, this._sortingEventHandler);
     }


### PR DESCRIPTION
## Summary

Fixes #4530 - Pagination not rendering when navigating from the same site using SharePoint's smart navigation (SPA).

## Problem

When using SharePoint's smart navigation from the same site (e.g., using the default search box on the home page to navigate to a search results page on the same site), the pagination component doesn't render on first load. It only appears after a page refresh.

This happens because SharePoint's SPA navigation replaces the DOM element without triggering `onInit()`, so the event listeners bound in `onInit()` are lost.

## Solution

- Store event handler references as class properties (`_pagingEventHandler`, `_sortingEventHandler`)
- Remove existing listeners before adding new ones in `bindPagingEvents()` and `bindSortingEvents()` to prevent duplicates
- Re-bind pagination and sorting events after each `ReactDom.render()` call in `renderCompleted()`

This ensures events are properly bound even when the DOM is replaced during SPA navigation.