### PR TITLE
Fix ZIP download: inject aadTokenProviderFactory into WebComponent context

### DIFF
--- a/search-parts/src/components/DownloadSelectedItemsButtonComponent.tsx
+++ b/search-parts/src/components/DownloadSelectedItemsButtonComponent.tsx
@@ -384,7 +384,8 @@ export class DownloadSelectedItemsButtonWebComponent extends BaseWebComponent {
 
       props.webPartContext = {}
       props.webPartContext.spHttpClient = this._serviceScope.consume(SPHttpClient.serviceKey);
-      props.webPartContext.httpClient = this._serviceScope.consume(HttpClient.serviceKey);  
+      props.webPartContext.httpClient = this._serviceScope.consume(HttpClient.serviceKey);
+      props.webPartContext.aadTokenProviderFactory = this._serviceScope.consume(AadTokenProviderFactory.serviceKey);
 
       const exportButtonComponent = <DownloadSelectedItemsButtonComponent {...props} />;
       ReactDOM.render(exportButtonComponent, this);


### PR DESCRIPTION
Follow-up to #4629.

Root cause:
DownloadSelectedItemsButtonWebComponent was constructing a partial webPartContext
(spHttpClient, httpClient only). As a result, aadTokenProviderFactory was undefined at runtime,
preventing token acquisition and blocking the /transform/zip call.

Fix:
Inject aadTokenProviderFactory from the SPFx ServiceScope into the WebComponent context so the
existing AAD-based mediap token logic (introduced in #4629) works reliably.

Impact:
- ZIP multi-download works end-to-end