### PR TITLE
fix: address security advisories — XSS, CSS injection, and DOMPurify hardening

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -23,7 +23,45 @@ In a basic customization scenario, super users and webmasters can customize exis
 
 !["Handlebars"](../assets/extensibility/handlebars_templating.png){: .center}
 
-> The templates and fields HTML markup is sanitized automatically preventing XSS attacks. We used [`DOMPurify`](https://github.com/cure53/DOMPurify) to do so. It means for instance, you cannot add your own `<script>` tags or inline JavaScript.
+> The templates and fields HTML markup is sanitized automatically preventing XSS attacks. We use [`DOMPurify`](https://github.com/cure53/DOMPurify) to do so. It means for instance, you cannot add your own `<script>` tags or inline JavaScript.
+
+### Blocked HTML elements
+
+The following HTML elements are removed during sanitization because they have no legitimate use in search result templates and present security risks:
+
+| Element | Reason |
+|---------|--------|
+| `<script>` | JavaScript execution |
+| `<iframe>` | Arbitrary content embedding |
+| `<form>` | `action` attribute accepts `javascript:` URIs |
+| `<button>` | `formaction` attribute accepts `javascript:` URIs |
+| `<object>` | Plugin execution, external resource loading |
+| `<embed>` | Plugin execution, external resource loading |
+
+### Blocked HTML attributes
+
+The following attributes are stripped from all elements to prevent JavaScript execution and data exfiltration:
+
+| Attribute | Reason |
+|-----------|--------|
+| `on*` (onclick, onerror, etc.) | Inline JavaScript execution |
+| `action`, `formaction` | Accept `javascript:` URIs |
+| `xlink:href` | SVG JavaScript execution via `javascript:` URIs |
+| `srcdoc` | HTML/JavaScript injection |
+| `ping` | Data exfiltration to external servers |
+| `dynsrc`, `lowsrc`, `background` | Legacy attributes that accept `javascript:` URIs |
+
+### Allowed elements and attributes
+
+Standard HTML elements for layout and presentation (`<div>`, `<span>`, `<table>`, `<a>`, `<img>`, `<ul>`, `<li>`, etc.) are allowed, along with:
+
+- **`<style>` tags** for [custom CSS](#custom-css-styles) (CSS content is sanitized to block `@import`, `javascript:`, and similar vectors)
+- **`<link rel="stylesheet">` tags** for same-origin stylesheets only (external domains are blocked)
+- **`<content>` tags** for template structure
+- **Custom web components** (e.g. `<pnp-iconfile>`, `<my-component>`)
+- **`data-*` attributes** for custom component configuration
+- **`style` attributes** (sanitized to remove dangerous CSS patterns)
+- **`href`** on links (validated against an allowlist of safe URI schemes — `javascript:` is blocked)
 
 ### Template structure
 

--- a/docs/usage/search-results/layouts/custom.md
+++ b/docs/usage/search-results/layouts/custom.md
@@ -10,6 +10,8 @@ You can also start from an existing layout by first selecting it, and then click
 
 You have also the ability to use an external _.html_ file to centralize your customizations. This file must be stored in an accessible location for uses (ex: a SharePoint document library with _'Read'_ permissions for concerned users).
 
+> Template HTML is sanitized to prevent XSS attacks. Some elements (e.g. `<script>`, `<form>`, `<iframe>`) and dangerous attributes are blocked. See [Template sanitization](../../../extensibility/templating.md#blocked-html-elements) for the full list of blocked elements and attributes.
+
 !["External file"](../../../assets/webparts/search-results/layouts/custom_external_file.png){: .center} 
 
 > Unless you specify an external file, the template content is stored in the Web Part property bag.

--- a/search-parts/src/components/StyledWebPartTitle.tsx
+++ b/search-parts/src/components/StyledWebPartTitle.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { WebPartTitle, IWebPartTitleProps } from '@pnp/spfx-controls-react/lib/WebPartTitle';
+
+export interface IStyledWebPartTitleProps {
+    instanceId: string;
+    titleFont?: string;
+    titleFontSize?: number;
+    titleFontColor?: string;
+    webPartTitleProps: IWebPartTitleProps;
+    /** Optional test ID attribute for the wrapper div */
+    testId?: string;
+}
+
+// Sanitize font value by stripping characters that can break out of CSS context
+const sanitizeFont = (font: string): string => (font || '').replace(/[{};<>\\"']/g, '');
+
+// Clamp font size to the allowed slider range
+const sanitizeFontSize = (size: number | undefined): number | undefined => {
+    if (size === undefined) return undefined;
+    const n = Number(size);
+    return isNaN(n) ? undefined : Math.floor(Math.min(Math.max(n, 10), 48));
+};
+
+// Only allow hex and rgba color values
+const sanitizeColor = (color: string): string =>
+    /^(#[0-9a-fA-F]{3,8}|rgba?\([\d\s,.]+\))$/.test(color || '') ? color : '';
+
+export const StyledWebPartTitle: React.FC<IStyledWebPartTitleProps> = (props) => {
+    const { instanceId, titleFont, titleFontSize, titleFontColor, webPartTitleProps, testId } = props;
+    const hasCustomStyling = titleFont || titleFontSize !== undefined || titleFontColor;
+
+    if (!hasCustomStyling) {
+        return testId
+            ? <div data-ui-test-id={testId}><WebPartTitle {...webPartTitleProps} /></div>
+            : <WebPartTitle {...webPartTitleProps} />;
+    }
+
+    const safeFont = sanitizeFont(titleFont);
+    const safeFontSize = sanitizeFontSize(titleFontSize);
+    const safeColor = sanitizeColor(titleFontColor);
+    const titleWrapperClass = `custom-title-wrapper-${instanceId || 'default'}`;
+
+    const styleString = `
+        .${titleWrapperClass} *,
+        .${titleWrapperClass} div,
+        .${titleWrapperClass} span,
+        .${titleWrapperClass} h2,
+        .${titleWrapperClass} textarea {
+            ${safeFont ? `font-family: ${safeFont} !important;` : ''}
+            ${safeFontSize !== undefined ? `font-size: ${safeFontSize}px !important;` : ''}
+            ${safeColor ? `color: ${safeColor} !important;` : ''}
+        }
+    `;
+
+    return (
+        <div className={titleWrapperClass} {...(testId ? { 'data-ui-test-id': testId } : {})}>
+            <style key={`title-style-${safeFont}-${safeFontSize}-${safeColor}`}>{styleString}</style>
+            <WebPartTitle {...webPartTitleProps} />
+        </div>
+    );
+};

--- a/search-parts/src/controls/TemplateRenderer/TemplateRenderer.tsx
+++ b/search-parts/src/controls/TemplateRenderer/TemplateRenderer.tsx
@@ -202,11 +202,25 @@ export class TemplateRenderer extends React.Component<
       if (!this._divTemplateRenderer?.current) {
         return;
       }
-      this._divTemplateRenderer.current.innerHTML = `<style>${allStyles.join(
-        " "
-      )}</style><div id="${this.props.templateService.TEMPLATE_ID_PREFIX}${
-        this.props.instanceId
-      }">${templateAsHtml.body.innerHTML}</div>`;
+
+      // Security fix: Use DOM methods instead of innerHTML string concatenation
+      // to prevent XSS via CSS escape sequences (e.g. \3c unescaping to <)
+      // that could break out of <style> tags when using cssText.
+      const container = this._divTemplateRenderer.current;
+      container.innerHTML = "";
+
+      // Create <style> element and set content via textContent (auto-escapes)
+      if (allStyles.length > 0) {
+        const styleEl = document.createElement("style");
+        styleEl.textContent = allStyles.join(" ");
+        container.appendChild(styleEl);
+      }
+
+      // Create content wrapper div
+      const contentDiv = document.createElement("div");
+      contentDiv.id = `${this.props.templateService.TEMPLATE_ID_PREFIX}${this.props.instanceId}`;
+      contentDiv.innerHTML = templateAsHtml.body.innerHTML;
+      container.appendChild(contentDiv);
     } else if (
       props.renderType == LayoutRenderType.AdaptiveCards &&
       template instanceof HTMLElement

--- a/search-parts/src/helpers/DomPurifyHelper.ts
+++ b/search-parts/src/helpers/DomPurifyHelper.ts
@@ -113,11 +113,17 @@ export class DomPurifyHelper {
     // Returning early lets DOMPurify apply its own validation (ALLOWED_URI_REGEXP / FORBID_ATTR).
     private static readonly DANGEROUS_ATTRS: ReadonlySet<string> = new Set([
         'href',        // DOMPurify validates against ALLOWED_URI_REGEXP — don't bypass
+        'src',         // images, scripts, iframes — DOMPurify validates URI scheme
+        'srcset',      // responsive images — contains URIs
         'action',      // form submit target — accepts javascript: URIs
         'formaction',  // per-button override of action — same risk
         'xlink:href',  // SVG link — accepts javascript: URIs
         'srcdoc',      // iframe HTML injection
         'ping',        // <a> data exfiltration to attacker-controlled URLs
+        'poster',      // <video> — external resource loading
+        'cite',        // <blockquote>/<q> — URI attribute
+        'codebase',    // <object>/<applet> — base URI for code loading
+        'usemap',      // client-side image map — URI reference
         'dynsrc',      // legacy IE — javascript: execution
         'lowsrc',      // legacy IE — javascript: execution
         'background',  // legacy body/table — external resource loading
@@ -195,7 +201,9 @@ export class DomPurifyHelper {
                         return;
                     }
                 } catch {
-                    // Relative URL that new URL can't parse — allow it
+                    // With a base URL, only truly malformed URIs throw — treat as unsafe
+                    node.parentNode?.removeChild(node);
+                    return;
                 }
             }
         }

--- a/search-parts/src/helpers/DomPurifyHelper.ts
+++ b/search-parts/src/helpers/DomPurifyHelper.ts
@@ -21,28 +21,35 @@ export class DomPurifyHelper {
     private static getConfig(): any {
         if (!DomPurifyHelper._config) {
             DomPurifyHelper._config = {
+                // Allow <style> for template CSS, <link> for same-origin stylesheets (restricted via hook),
+                // <content> for custom template elements, #comment for HTML comments
                 ADD_TAGS: ["style", "#comment", "link", "content"],
+                // Allow target (link behavior), loading (lazy images), data-* (custom component config),
+                // style (inline CSS — sanitized via sanitizeStyleAttributeHook)
                 ADD_ATTR: ["target", "loading", "data-fields-configuration", "data-*", "style"],
                 ALLOW_DATA_ATTR: true,
+                // Allowlist of safe URI schemes — blocks javascript:, data:, vbscript: etc.
                 ALLOWED_URI_REGEXP: Constants.ALLOWED_URI_REGEXP,
-                // CRITICAL: Must be false for fragments, but we handle <style> via hook
+                // Must be false — templates are rendered as fragments, not full documents
                 WHOLE_DOCUMENT: false,
-                // Explicitly allow very long attribute values for configuration data
                 SANITIZE_NAMED_PROPS: false,
                 RETURN_DOM: false,
                 RETURN_DOM_FRAGMENT: false,
                 RETURN_DOM_IMPORT: false,
-                // More permissive configuration to preserve custom attributes
+                // Preserve text content when removing disallowed elements
                 KEEP_CONTENT: true,
                 SAFE_FOR_TEMPLATES: false,
-                // Force allow style tags and custom elements
-                FORBID_TAGS: [],
-                FORBID_ATTR: [],
-                // CRITICAL: Allow <style> in body context
+                // SECURITY: Block elements with no legitimate use in search result templates
+                // form/button: action/formaction attributes accept javascript: URIs
+                // object/embed: plugin execution, external resource loading
+                FORBID_TAGS: ['form', 'button', 'object', 'embed'],
+                // SECURITY: Block attributes that carry URIs or enable code execution.
+                // forceKeepAttr in allowCustomAttributesHook bypasses DOMPurify's URI validation,
+                // so these must be explicitly forbidden. Also blocked in the hook as defense-in-depth.
+                FORBID_ATTR: ['action', 'formaction', 'xlink:href', 'srcdoc', 'ping', 'dynsrc', 'lowsrc', 'background'],
                 IN_PLACE: false,
-                // Security: Sanitize style attributes to prevent XSS via CSS
-                // This removes dangerous CSS like expression(), javascript: URLs, etc.
-                SANITIZE_DOM: true, // Default is true, but being explicit
+                // Sanitize DOM clobbering attacks (e.g. id/name that shadow document properties)
+                SANITIZE_DOM: true,
             };
         }
         return DomPurifyHelper._config;
@@ -102,15 +109,35 @@ export class DomPurifyHelper {
         return DomPurifyHelper.instance.sanitize(dirty, config);
     }
 
+    // Attributes that carry URIs or enable code execution — must not be force-kept.
+    // Returning early lets DOMPurify apply its own validation (ALLOWED_URI_REGEXP / FORBID_ATTR).
+    private static readonly DANGEROUS_ATTRS: ReadonlySet<string> = new Set([
+        'href',        // DOMPurify validates against ALLOWED_URI_REGEXP — don't bypass
+        'action',      // form submit target — accepts javascript: URIs
+        'formaction',  // per-button override of action — same risk
+        'xlink:href',  // SVG link — accepts javascript: URIs
+        'srcdoc',      // iframe HTML injection
+        'ping',        // <a> data exfiltration to attacker-controlled URLs
+        'dynsrc',      // legacy IE — javascript: execution
+        'lowsrc',      // legacy IE — javascript: execution
+        'background',  // legacy body/table — external resource loading
+    ]);
+
     /**
-     * Allows custom attributes
-     * @param attr the attribute name
-     * @param data the DOMPurify data
+     * Allows custom attributes needed by web components and Handlebars templates.
+     * Blocks event handlers (on*) and dangerous URI-carrying attributes.
+     * All other attributes are force-kept to support custom components like
+     * <my-component data-foo="bar"> and Handlebars data attributes.
      */
     public static allowCustomAttributesHook(attr, data) {
         if (data && data.attrName) {
-            if (data.attrName.indexOf("on") == 0) return;
-            if (data.attrName == "href") return;
+            const attrLower = data.attrName.toLowerCase();
+
+            // Block event handlers (onclick, onerror, onload, etc.)
+            if (attrLower.startsWith('on')) return;
+
+            // Don't force-keep dangerous URI attributes — let DOMPurify validate them
+            if (DomPurifyHelper.DANGEROUS_ATTRS.has(attrLower)) return;
 
             data.allowedAttributes[data.attrName] = true;
             data.forceKeepAttr = true;

--- a/search-parts/src/helpers/DomPurifyHelper.ts
+++ b/search-parts/src/helpers/DomPurifyHelper.ts
@@ -210,9 +210,10 @@ export class DomPurifyHelper {
         // Block @import (external stylesheet loading)
         css = css.replace(/@import\s+[^;]+;?/gi, '/* @import blocked */');
         // Block javascript: URLs inside url()
-        css = css.replace(/url\s*\(\s*['"]?\s*javascript:/gi, 'url(/* blocked */');
+        // [\s'"]* instead of \s*['"]?\s* to avoid ReDoS via quadratic backtracking
+        css = css.replace(/url\s*\([\s'"]*javascript:/gi, 'url(/* blocked */');
         // Block data: URLs inside url() except data:image/* (legitimate use)
-        css = css.replace(/url\s*\(\s*['"]?\s*data:(?!image\/)/gi, 'url(/* blocked */');
+        css = css.replace(/url\s*\([\s'"]*data:(?!image\/)/gi, 'url(/* blocked */');
         // Block expression() (IE legacy XSS)
         css = css.replace(/expression\s*\([^)]*\)/gi, '/* expression() blocked */');
         // Block behavior (IE legacy)
@@ -246,11 +247,12 @@ export class DomPurifyHelper {
                 styleValue = styleValue.replace(/expression\s*\(/gi, '');
 
                 // Remove javascript: URLs in url()
-                styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*javascript:/gi, 'url(');
+                // [\s'"]* instead of \s*['"]?\s* to avoid ReDoS via quadratic backtracking
+                styleValue = styleValue.replace(/url\s*\([\s'"]*javascript:/gi, 'url(');
 
                 // Remove data: URLs in url() that could contain scripts
                 // Allow data:image/* for legitimate image use cases
-                styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*data:(?!image\/)/gi, 'url(');
+                styleValue = styleValue.replace(/url\s*\([\s'"]*data:(?!image\/)/gi, 'url(');
 
                 // Remove @import statements (shouldn't be in inline styles but just in case)
                 styleValue = styleValue.replace(/@import/gi, '');

--- a/search-parts/src/helpers/DomPurifyHelper.ts
+++ b/search-parts/src/helpers/DomPurifyHelper.ts
@@ -1,169 +1,242 @@
 import { Constants } from "../common/Constants";
 
 export class DomPurifyHelper {
-  private static _instance: any = null;
-  private static _config: any = null;
+    private static _instance: any = null;
+    private static _config: any = null;
 
-  /**
-   * Gets the singleton DOMPurify instance with shared configuration
-   */
-  public static get instance(): any {
-    if (!DomPurifyHelper._instance) {
-      DomPurifyHelper._instance = require("dompurify");
-      DomPurifyHelper.configureInstance();
+    /**
+     * Gets the singleton DOMPurify instance with shared configuration
+     */
+    public static get instance(): any {
+        if (!DomPurifyHelper._instance) {
+            DomPurifyHelper._instance = require("dompurify");
+            DomPurifyHelper.configureInstance();
+        }
+        return DomPurifyHelper._instance;
     }
-    return DomPurifyHelper._instance;
-  }
 
-  /**
-   * Gets the shared DOMPurify configuration
-   */
-  private static getConfig(): any {
-    if (!DomPurifyHelper._config) {
-      DomPurifyHelper._config = {
-        ADD_TAGS: ["style", "#comment", "link", "content"],
-        ADD_ATTR: ["target", "loading", "data-fields-configuration", "data-*", "style"],
-        ALLOW_DATA_ATTR: true,
-        ALLOWED_URI_REGEXP: Constants.ALLOWED_URI_REGEXP,
-        // CRITICAL: Must be false for fragments, but we handle <style> via hook
-        WHOLE_DOCUMENT: false,
-        // Explicitly allow very long attribute values for configuration data
-        SANITIZE_NAMED_PROPS: false,
-        RETURN_DOM: false,
-        RETURN_DOM_FRAGMENT: false,
-        RETURN_DOM_IMPORT: false,
-        // More permissive configuration to preserve custom attributes
-        KEEP_CONTENT: true,
-        SAFE_FOR_TEMPLATES: false,
-        // Force allow style tags and custom elements
-        FORBID_TAGS: [],
-        FORBID_ATTR: [],
-        // CRITICAL: Allow <style> in body context
-        IN_PLACE: false,
-        // Security: Sanitize style attributes to prevent XSS via CSS
-        // This removes dangerous CSS like expression(), javascript: URLs, etc.
-        SANITIZE_DOM: true, // Default is true, but being explicit
-      };
+    /**
+     * Gets the shared DOMPurify configuration
+     */
+    private static getConfig(): any {
+        if (!DomPurifyHelper._config) {
+            DomPurifyHelper._config = {
+                ADD_TAGS: ["style", "#comment", "link", "content"],
+                ADD_ATTR: ["target", "loading", "data-fields-configuration", "data-*", "style"],
+                ALLOW_DATA_ATTR: true,
+                ALLOWED_URI_REGEXP: Constants.ALLOWED_URI_REGEXP,
+                // CRITICAL: Must be false for fragments, but we handle <style> via hook
+                WHOLE_DOCUMENT: false,
+                // Explicitly allow very long attribute values for configuration data
+                SANITIZE_NAMED_PROPS: false,
+                RETURN_DOM: false,
+                RETURN_DOM_FRAGMENT: false,
+                RETURN_DOM_IMPORT: false,
+                // More permissive configuration to preserve custom attributes
+                KEEP_CONTENT: true,
+                SAFE_FOR_TEMPLATES: false,
+                // Force allow style tags and custom elements
+                FORBID_TAGS: [],
+                FORBID_ATTR: [],
+                // CRITICAL: Allow <style> in body context
+                IN_PLACE: false,
+                // Security: Sanitize style attributes to prevent XSS via CSS
+                // This removes dangerous CSS like expression(), javascript: URLs, etc.
+                SANITIZE_DOM: true, // Default is true, but being explicit
+            };
+        }
+        return DomPurifyHelper._config;
     }
-    return DomPurifyHelper._config;
-  }
 
-  /**
-   * Configures the DOMPurify instance with shared settings
-   */
-  private static configureInstance(): void {
-    // Add hooks for custom elements and attributes
-    DomPurifyHelper._instance.addHook(
-      "uponSanitizeElement",
-      DomPurifyHelper.allowCustomComponentsHook
-    );
-    DomPurifyHelper._instance.addHook(
-      "uponSanitizeAttribute",
-      DomPurifyHelper.allowCustomAttributesHook
-    );
-    DomPurifyHelper._instance.addHook(
-      "uponSanitizeElement",
-      DomPurifyHelper.allowStyleAndContentTagsHook
-    );
-    DomPurifyHelper._instance.addHook(
-      "afterSanitizeAttributes",
-      DomPurifyHelper.sanitizeStyleAttributeHook
-    );
-  }
-
-  /**
-   * Forces DomPurify to allow <style> and <content> tags
-   * In DomPurify 3.x with WHOLE_DOCUMENT:false, <style> tags are rejected
-   * This hook forces them to be allowed regardless of context
-   */
-  public static allowStyleAndContentTagsHook(node, data) {
-    // Force allow style and content tags in ANY context
-    if (data.tagName === 'style' || data.tagName === 'content' || data.tagName === 'link') {
-      data.allowedTags[data.tagName] = true;
-      // Keep the element even if it would normally be removed
-      data.keepElement = true;
+    /**
+     * Configures the DOMPurify instance with shared settings
+     */
+    private static configureInstance(): void {
+        // Add hooks for custom elements and attributes
+        DomPurifyHelper._instance.addHook(
+            "uponSanitizeElement",
+            DomPurifyHelper.allowCustomComponentsHook
+        );
+        DomPurifyHelper._instance.addHook(
+            "uponSanitizeAttribute",
+            DomPurifyHelper.allowCustomAttributesHook
+        );
+        DomPurifyHelper._instance.addHook(
+            "uponSanitizeElement",
+            DomPurifyHelper.allowStyleAndContentTagsHook
+        );
+        DomPurifyHelper._instance.addHook(
+            "afterSanitizeAttributes",
+            DomPurifyHelper.sanitizeStyleAttributeHook
+        );
+        DomPurifyHelper._instance.addHook(
+            "afterSanitizeElements",
+            DomPurifyHelper.sanitizeStyleTagContentHook
+        );
+        DomPurifyHelper._instance.addHook(
+            "afterSanitizeElements",
+            DomPurifyHelper.restrictLinkTagHook
+        );
     }
-  }
 
-  /**
-   * Sanitizes HTML with the configured settings
-   * In DomPurify 3.x, config must be passed to each sanitize() call
-   */
-  public static sanitize(dirty: string): string {
-    const config = DomPurifyHelper.getConfig();
-    return DomPurifyHelper.instance.sanitize(dirty, config);
-  }
-
-  /**
-   * Allows custom attributes
-   * @param attr the attribute name
-   * @param data the DOMPurify data
-   */
-  public static allowCustomAttributesHook(attr, data) {
-    if (data && data.attrName) {
-      if (data.attrName.indexOf("on") == 0) return;
-      if (data.attrName == "href") return;
-
-      data.allowedAttributes[data.attrName] = true;
-      data.forceKeepAttr = true;
+    /**
+     * Forces DomPurify to allow <style> and <content> tags
+     * In DomPurify 3.x with WHOLE_DOCUMENT:false, <style> tags are rejected
+     * This hook forces them to be allowed regardless of context
+     */
+    public static allowStyleAndContentTagsHook(node, data) {
+        // Force allow style and content tags in ANY context
+        if (data.tagName === 'style' || data.tagName === 'content' || data.tagName === 'link') {
+            data.allowedTags[data.tagName] = true;
+            // Keep the element even if it would normally be removed
+            data.keepElement = true;
+        }
     }
-  }
 
-  /**
-   * Allows custom components (ex: <my-component>)
-   * @param node the HTML node
-   * @param data the DOMPurify data
-   */
-  public static allowCustomComponentsHook(node, data) {
-    if (
-      node.nodeName &&
-      node.nodeName.match(/^\w+(-\w+)+$/) &&
-      !data.allowedTags[data.tagName]
-    ) {
-      data.allowedTags[data.tagName] = true;
+    /**
+     * Sanitizes HTML with the configured settings
+     * In DomPurify 3.x, config must be passed to each sanitize() call
+     */
+    public static sanitize(dirty: string): string {
+        const config = DomPurifyHelper.getConfig();
+        return DomPurifyHelper.instance.sanitize(dirty, config);
     }
-  }
 
-  /**
-   * Sanitizes style attribute values to prevent XSS attacks
-   * Removes dangerous CSS patterns like:
-   * - expression() (IE legacy XSS vector)
-   * - javascript: URLs in url()
-   * - data: URLs in url() (can contain scripts)
-   * - import statements
-   * 
-   * This provides defense-in-depth on top of DOMPurify's built-in CSS sanitization
-   * 
-   * @param node the HTML node
-   * @param data the DOMPurify data
-   */
-  public static sanitizeStyleAttributeHook(node) {
-    if (node.hasAttribute && node.hasAttribute('style')) {
-      let styleValue = node.getAttribute('style');
-      
-      if (styleValue) {
-        // Remove expression() - IE legacy XSS vector
-        styleValue = styleValue.replace(/expression\s*\(/gi, '');
-        
-        // Remove javascript: URLs in url()
-        styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*javascript:/gi, 'url(');
-        
-        // Remove data: URLs in url() that could contain scripts
-        // Allow data:image/* for legitimate image use cases
-        styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*data:(?!image\/)/gi, 'url(');
-        
-        // Remove @import statements (shouldn't be in inline styles but just in case)
-        styleValue = styleValue.replace(/@import/gi, '');
-        
-        // Remove behavior property (IE legacy)
-        styleValue = styleValue.replace(/behavior\s*:/gi, '');
-        
-        // Remove -moz-binding (Firefox legacy XSS)
-        styleValue = styleValue.replace(/-moz-binding\s*:/gi, '');
-        
-        // Update the attribute with sanitized value
-        node.setAttribute('style', styleValue);
-      }
+    /**
+     * Allows custom attributes
+     * @param attr the attribute name
+     * @param data the DOMPurify data
+     */
+    public static allowCustomAttributesHook(attr, data) {
+        if (data && data.attrName) {
+            if (data.attrName.indexOf("on") == 0) return;
+            if (data.attrName == "href") return;
+
+            data.allowedAttributes[data.attrName] = true;
+            data.forceKeepAttr = true;
+        }
     }
-  }
+
+    /**
+     * Allows custom components (ex: <my-component>)
+     * @param node the HTML node
+     * @param data the DOMPurify data
+     */
+    public static allowCustomComponentsHook(node, data) {
+        if (
+            node.nodeName &&
+            node.nodeName.match(/^\w+(-\w+)+$/) &&
+            !data.allowedTags[data.tagName]
+        ) {
+            data.allowedTags[data.tagName] = true;
+        }
+    }
+
+    /**
+     * Sanitizes CSS inside <style> tags to block exfiltration vectors.
+     * Blocks url(), @import, expression(), javascript:, behavior, -moz-binding.
+     * Defense-in-depth: also applied in TemplateService.sanitizeHtmlWithStylePreservation.
+     */
+    public static sanitizeStyleTagContentHook(node) {
+        if (node.nodeName && node.nodeName.toLowerCase() === 'style' && node.textContent) {
+            node.textContent = DomPurifyHelper.sanitizeCssContent(node.textContent);
+        }
+    }
+
+    /**
+     * Restricts <link> tags to rel="stylesheet" with same-origin or relative href.
+     * Removes <link> tags with rel="dns-prefetch", "preconnect", "preload", etc.
+     * and external stylesheet references.
+     */
+    public static restrictLinkTagHook(node) {
+        if (node.nodeName && node.nodeName.toLowerCase() === 'link') {
+            const rel = (node.getAttribute('rel') || '').toLowerCase().trim();
+            const href = node.getAttribute('href') || '';
+
+            // Only allow rel="stylesheet"
+            if (rel !== 'stylesheet') {
+                node.parentNode?.removeChild(node);
+                return;
+            }
+
+            // Block external URLs — allow relative paths and same-origin only
+            if (href) {
+                try {
+                    const url = new URL(href, window.location.href);
+                    if (url.origin !== window.location.origin) {
+                        node.parentNode?.removeChild(node);
+                        return;
+                    }
+                } catch {
+                    // Relative URL that new URL can't parse — allow it
+                }
+            }
+        }
+    }
+
+    /**
+     * Sanitizes CSS content by removing dangerous patterns.
+     * Used by both DOMPurify hooks and TemplateService style preservation.
+     */
+    public static sanitizeCssContent(css: string): string {
+        if (!css) return css;
+        // Block @import (external stylesheet loading)
+        css = css.replace(/@import\s+[^;]+;?/gi, '/* @import blocked */');
+        // Block javascript: URLs inside url()
+        css = css.replace(/url\s*\(\s*['"]?\s*javascript:/gi, 'url(/* blocked */');
+        // Block data: URLs inside url() except data:image/* (legitimate use)
+        css = css.replace(/url\s*\(\s*['"]?\s*data:(?!image\/)/gi, 'url(/* blocked */');
+        // Block expression() (IE legacy XSS)
+        css = css.replace(/expression\s*\([^)]*\)/gi, '/* expression() blocked */');
+        // Block behavior (IE legacy)
+        css = css.replace(/behavior\s*:[^;]+;?/gi, '/* behavior blocked */');
+        // Block -moz-binding (Firefox legacy XSS)
+        css = css.replace(/-moz-binding\s*:[^;]+;?/gi, '/* -moz-binding blocked */');
+        // Block javascript: in any context
+        css = css.replace(/javascript\s*:/gi, '/* javascript: blocked */');
+        return css;
+    }
+
+    /**
+     * Sanitizes style attribute values to prevent XSS attacks
+     * Removes dangerous CSS patterns like:
+     * - expression() (IE legacy XSS vector)
+     * - javascript: URLs in url()
+     * - data: URLs in url() (can contain scripts)
+     * - import statements
+     * 
+     * This provides defense-in-depth on top of DOMPurify's built-in CSS sanitization
+     * 
+     * @param node the HTML node
+     * @param data the DOMPurify data
+     */
+    public static sanitizeStyleAttributeHook(node) {
+        if (node.hasAttribute && node.hasAttribute('style')) {
+            let styleValue = node.getAttribute('style');
+
+            if (styleValue) {
+                // Remove expression() - IE legacy XSS vector
+                styleValue = styleValue.replace(/expression\s*\(/gi, '');
+
+                // Remove javascript: URLs in url()
+                styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*javascript:/gi, 'url(');
+
+                // Remove data: URLs in url() that could contain scripts
+                // Allow data:image/* for legitimate image use cases
+                styleValue = styleValue.replace(/url\s*\(\s*['"]?\s*data:(?!image\/)/gi, 'url(');
+
+                // Remove @import statements (shouldn't be in inline styles but just in case)
+                styleValue = styleValue.replace(/@import/gi, '');
+
+                // Remove behavior property (IE legacy)
+                styleValue = styleValue.replace(/behavior\s*:/gi, '');
+
+                // Remove -moz-binding (Firefox legacy XSS)
+                styleValue = styleValue.replace(/-moz-binding\s*:/gi, '');
+
+                // Update the attribute with sanitized value
+                node.setAttribute('style', styleValue);
+            }
+        }
+    }
 }

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -735,7 +735,7 @@ export class TemplateService implements ITemplateService {
         // Extract all <style> tags before sanitization
         const styleTags: string[] = [];
         let templateWithoutStyles = html;
-        const styleRegex = /<style[\s\S]*?<\/style>/gi;
+        const styleRegex = /<style(?:\s[^>]*)?>[\s\S]*?<\/style[^>]*>/gi;
         let match;
 
         while ((match = styleRegex.exec(html)) !== null) {

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -739,7 +739,8 @@ export class TemplateService implements ITemplateService {
         let match;
 
         while ((match = styleRegex.exec(html)) !== null) {
-            styleTags.push(match[0]);
+            // Sanitize CSS content before storing to block exfiltration vectors
+            styleTags.push(DomPurifyHelper.sanitizeCssContent(match[0]));
             templateWithoutStyles = templateWithoutStyles.replace(
                 match[0],
                 `<div data-style-placeholder="${styleTags.length - 1}"></div>`

--- a/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxContainer.tsx
@@ -9,7 +9,7 @@ import SearchBoxAutoComplete from './SearchBoxAutoComplete/SearchBoxAutoComplete
 import styles from './SearchBoxContainer.module.scss';
 import { BuiltinTokenNames } from '../../../services/tokenService/TokenService';
 import { isEmpty } from '@microsoft/sp-lodash-subset';
-import { WebPartTitle } from '@pnp/spfx-controls-react/lib/WebPartTitle';
+import { StyledWebPartTitle } from '../../../components/StyledWebPartTitle';
 
 export default class SearchBoxContainer extends React.Component<ISearchBoxContainerProps, ISearchBoxContainerState> {
 
@@ -272,39 +272,13 @@ export default class SearchBoxContainer extends React.Component<ISearchBoxContai
 
     public render(): React.ReactElement<ISearchBoxContainerProps> {
 
-        let renderTitle: JSX.Element = null;
-
-        // WebPart title with custom styling
-        const titleWrapperClass = `custom-title-wrapper-${this.props.instanceId || 'default'}`;
-        
-        if (this.props.titleFont || this.props.titleFontSize !== undefined || this.props.titleFontColor) {
-            const styleString = `
-                .${titleWrapperClass} *,
-                .${titleWrapperClass} div,
-                .${titleWrapperClass} span,
-                .${titleWrapperClass} h2,
-                .${titleWrapperClass} textarea {
-                    ${this.props.titleFont ? `font-family: ${this.props.titleFont} !important;` : ''}
-                    ${this.props.titleFontSize !== undefined ? `font-size: ${this.props.titleFontSize}px !important;` : ''}
-                    ${this.props.titleFontColor ? `color: ${this.props.titleFontColor} !important;` : ''}
-                }
-            `;
-            
-            renderTitle = <div className={titleWrapperClass}>
-                <style key={`title-style-${this.props.titleFont}-${this.props.titleFontSize}-${this.props.titleFontColor}`} dangerouslySetInnerHTML={{ __html: styleString }} />
-                <WebPartTitle
-                    displayMode={this.props.webPartTitleProps.displayMode}
-                    title={this.props.webPartTitleProps.title}
-                    updateProperty={this.props.webPartTitleProps.updateProperty}
-                    className={this.props.webPartTitleProps.className} />
-            </div>;
-        } else {
-            renderTitle = <WebPartTitle
-                displayMode={this.props.webPartTitleProps.displayMode}
-                title={this.props.webPartTitleProps.title}
-                updateProperty={this.props.webPartTitleProps.updateProperty}
-                className={this.props.webPartTitleProps.className} />;
-        }
+        const renderTitle = <StyledWebPartTitle
+            instanceId={this.props.instanceId}
+            titleFont={this.props.titleFont}
+            titleFontSize={this.props.titleFontSize}
+            titleFontColor={this.props.titleFontColor}
+            webPartTitleProps={this.props.webPartTitleProps}
+        />;
 
         let renderErrorMessage: JSX.Element = null;
 

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -3,7 +3,7 @@ import { ISearchFiltersContainerProps } from './ISearchFiltersContainerProps';
 import { TemplateRenderer } from '../../../controls/TemplateRenderer/TemplateRenderer';
 import { ISearchFiltersContainerState } from './ISearchFiltersContainerState';
 import { isEqual, cloneDeep, sortBy } from '@microsoft/sp-lodash-subset';
-import { WebPartTitle } from "@pnp/spfx-controls-react/lib/WebPartTitle";
+import { StyledWebPartTitle } from '../../../components/StyledWebPartTitle';
 import * as webPartStrings from 'SearchFiltersWebPartStrings';
 import * as commonStrings from 'CommonStrings';
 import update from 'immutability-helper';
@@ -60,41 +60,13 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
         let renderWpContent: JSX.Element = null;
         let templateContent: string = null;
-        let renderTitle: JSX.Element = null;
-
-        // WP title with custom styling
-        const titleWrapperClass = `custom-title-wrapper-${this.props.instanceId || 'default'}`;
-
-        if (this.props.titleFont || this.props.titleFontSize !== undefined || this.props.titleFontColor) {
-            const styleString = `
-        .${titleWrapperClass} *,
-        .${titleWrapperClass} div,
-        .${titleWrapperClass} span,
-        .${titleWrapperClass} h2,
-        .${titleWrapperClass} textarea {
-          ${this.props.titleFont ? `font-family: ${this.props.titleFont} !important;` : ''}
-          ${this.props.titleFontSize !== undefined ? `font-size: ${this.props.titleFontSize}px !important;` : ''}
-          ${this.props.titleFontColor ? `color: ${this.props.titleFontColor} !important;` : ''}
-        }
-      `;
-
-            renderTitle = <div className={titleWrapperClass}>
-                <style key={`title-style-${this.props.titleFont}-${this.props.titleFontSize}-${this.props.titleFontColor}`} dangerouslySetInnerHTML={{ __html: styleString }} />
-                <WebPartTitle
-                    displayMode={this.props.webPartTitleProps.displayMode}
-                    title={this.props.webPartTitleProps.title}
-                    updateProperty={this.props.webPartTitleProps.updateProperty}
-                    className={this.props.webPartTitleProps.className}
-                />
-            </div>;
-        } else {
-            renderTitle = <WebPartTitle
-                displayMode={this.props.webPartTitleProps.displayMode}
-                title={this.props.webPartTitleProps.title}
-                updateProperty={this.props.webPartTitleProps.updateProperty}
-                className={this.props.webPartTitleProps.className}
-            />;
-        }
+        const renderTitle = <StyledWebPartTitle
+            instanceId={this.props.instanceId}
+            titleFont={this.props.titleFont}
+            titleFontSize={this.props.titleFontSize}
+            titleFontColor={this.props.titleFontColor}
+            webPartTitleProps={this.props.webPartTitleProps}
+        />;
 
         // If no filter 
         if (this.state.currentUiFilters.length === 0) {

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -13,7 +13,7 @@ import { Constants, TestConstants } from '../../../common/Constants';
 import { ITemplateSlot } from '@pnp/modern-search-extensibility';
 import { ObjectHelper } from '../../../helpers/ObjectHelper';
 import { BuiltinLayoutsKeys } from '../../../layouts/AvailableLayouts';
-import { WebPartTitle } from '@pnp/spfx-controls-react/lib/WebPartTitle';
+import { StyledWebPartTitle } from '../../../components/StyledWebPartTitle';
 import * as webPartStrings from 'SearchResultsWebPartStrings';
 import { Selection, SelectionMode, SelectionZone } from "@fluentui/react/lib/Selection";
 import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
@@ -89,48 +89,16 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
         let renderTemplate: JSX.Element = null;
         let renderOverlay: JSX.Element = null;
         let templateContent: string = null;
-        let renderTitle: JSX.Element = null;
         let renderInfoMessage: JSX.Element = null;
 
-        // Web Part title with custom styling
-        const titleWrapperClass = `custom-title-wrapper-${this.props.instanceId || 'default'}`;
-        
-        if (this.props.titleFont || this.props.titleFontSize !== undefined || this.props.titleFontColor) {
-            const styleString = `
-                .${titleWrapperClass} *,
-                .${titleWrapperClass} div,
-                .${titleWrapperClass} span,
-                .${titleWrapperClass} h2,
-                .${titleWrapperClass} textarea {
-                    ${this.props.titleFont ? `font-family: ${this.props.titleFont} !important;` : ''}
-                    ${this.props.titleFontSize !== undefined ? `font-size: ${this.props.titleFontSize}px !important;` : ''}
-                    ${this.props.titleFontColor ? `color: ${this.props.titleFontColor} !important;` : ''}
-                }
-            `;
-            
-            renderTitle = <div data-ui-test-id={TestConstants.SearchResultsWebPartTitle} className={titleWrapperClass}>
-                <style key={`title-style-${this.props.titleFont}-${this.props.titleFontSize}-${this.props.titleFontColor}`} dangerouslySetInnerHTML={{ __html: styleString }} />
-                <WebPartTitle
-                    displayMode={this.props.webPartTitleProps.displayMode}
-                    title={this.props.webPartTitleProps.title}
-                    updateProperty={this.props.webPartTitleProps.updateProperty}
-                    moreLink={this.props.webPartTitleProps.moreLink}
-                    themeVariant={this.props.webPartTitleProps.themeVariant}
-                    className={this.props.webPartTitleProps.className}
-                />
-            </div>;
-        } else {
-            renderTitle = <div data-ui-test-id={TestConstants.SearchResultsWebPartTitle}>
-                <WebPartTitle
-                    displayMode={this.props.webPartTitleProps.displayMode}
-                    title={this.props.webPartTitleProps.title}
-                    updateProperty={this.props.webPartTitleProps.updateProperty}
-                    moreLink={this.props.webPartTitleProps.moreLink}
-                    themeVariant={this.props.webPartTitleProps.themeVariant}
-                    className={this.props.webPartTitleProps.className}
-                />
-            </div>;
-        }
+        let renderTitle: JSX.Element = <StyledWebPartTitle
+            instanceId={this.props.instanceId}
+            titleFont={this.props.titleFont}
+            titleFontSize={this.props.titleFontSize}
+            titleFontColor={this.props.titleFontColor}
+            webPartTitleProps={this.props.webPartTitleProps}
+            testId={TestConstants.SearchResultsWebPartTitle}
+        />;
 
         // Content loading
         templateContent = this.templateService.getTemplateMarkup(this.props.templateContent);

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -138,12 +138,26 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
           resolvedUrl = resolvedUrl.replace(/\{inputQueryText\}|\{searchTerms\}|\{SearchBoxQuery\}/gi, inputQueryText);
           resolvedUrl = resolvedUrl.replace(inputQueryText, encodeURIComponent(inputQueryText));
 
+          // Block dangerous URI schemes (javascript:, data:, vbscript:, etc.)
+          try {
+            const parsed = new URL(resolvedUrl, window.location.href);
+            if (!['http:', 'https:'].includes(parsed.protocol)) {
+              Log.warn(VerticalContainer_LogSource, `Blocked navigation to disallowed URL scheme: ${parsed.protocol}`);
+              return;
+            }
+          } catch {
+            Log.warn(VerticalContainer_LogSource, `Invalid URL for vertical navigation: ${resolvedUrl}`);
+            return;
+          }
+
           if (vertical.openBehavior === PageOpenBehavior.NewTab) {
-            window.open(resolvedUrl, "_blank");
+            window.open(resolvedUrl, "_blank", "noopener");
           } else {
             // Allow SharePoint to intercept the click and do a soft navigation
-            document.body.insertAdjacentHTML('beforeend', `<a href="${resolvedUrl}" style="display:none;"></a>`);
-            const anchor = document.body.lastElementChild as HTMLElement;
+            const anchor = document.createElement('a');
+            anchor.href = resolvedUrl;
+            anchor.style.display = 'none';
+            document.body.appendChild(anchor);
             anchor.click();
             document.body.removeChild(anchor);
           }

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from './SearchVerticalsContainer.module.scss';
 import { ISearchVerticalsContainerProps } from './ISearchVerticalsContainerProps';
-import { WebPartTitle } from '@pnp/spfx-controls-react/lib/WebPartTitle';
+import { StyledWebPartTitle } from '../../../components/StyledWebPartTitle';
 import { PageOpenBehavior } from '../../../helpers/UrlHelper';
 import { ISearchVerticalsContainerState } from './ISearchVerticalsContainerState';
 import { BuiltinTokenNames } from '../../../services/tokenService/TokenService';
@@ -36,43 +36,13 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
 
   public render(): React.ReactElement<ISearchVerticalsContainerProps> {
 
-    let renderTitle: JSX.Element = null;
-
-    // Web Part title with custom styling
-    const titleWrapperClass = `custom-title-wrapper-${this.props.instanceId || 'default'}`;
-    
-    if (this.props.titleFont || this.props.titleFontSize !== undefined || this.props.titleFontColor) {
-      const styleString = `
-        .${titleWrapperClass} *,
-        .${titleWrapperClass} div,
-        .${titleWrapperClass} span,
-        .${titleWrapperClass} h2,
-        .${titleWrapperClass} textarea {
-          ${this.props.titleFont ? `font-family: ${this.props.titleFont} !important;` : ''}
-          ${this.props.titleFontSize !== undefined ? `font-size: ${this.props.titleFontSize}px !important;` : ''}
-          ${this.props.titleFontColor ? `color: ${this.props.titleFontColor} !important;` : ''}
-        }
-      `;
-      
-      renderTitle = <div className={titleWrapperClass}>
-        <style key={`title-style-${this.props.titleFont}-${this.props.titleFontSize}-${this.props.titleFontColor}`} dangerouslySetInnerHTML={{ __html: styleString }} />
-        <WebPartTitle
-          displayMode={this.props.webPartTitleProps.displayMode}
-          title={this.props.webPartTitleProps.title}
-          updateProperty={this.props.webPartTitleProps.updateProperty}
-          themeVariant={this.props.webPartTitleProps.themeVariant}
-          className={this.props.webPartTitleProps.className}
-        />
-      </div>;
-    } else {
-      renderTitle = <WebPartTitle
-        displayMode={this.props.webPartTitleProps.displayMode}
-        title={this.props.webPartTitleProps.title}
-        updateProperty={this.props.webPartTitleProps.updateProperty}
-        themeVariant={this.props.webPartTitleProps.themeVariant}
-        className={this.props.webPartTitleProps.className}
-      />;
-    }
+    const renderTitle = <StyledWebPartTitle
+      instanceId={this.props.instanceId}
+      titleFont={this.props.titleFont}
+      titleFontSize={this.props.titleFontSize}
+      titleFontColor={this.props.titleFontColor}
+      webPartTitleProps={this.props.webPartTitleProps}
+    />;
 
     const renderPivotItems = this.props.verticals.map(vertical => {
 


### PR DESCRIPTION
## Summary

Addresses 6 security advisories reported against the DOMPurify configuration and template rendering pipeline. All fixes are defense-in-depth — the attack surface requires template editing access (Site Owner/Site Collection Admin), but these changes harden the sanitization layer to prevent privilege escalation.

## Security Fixes

### 1. XSS via CSS escape sequences in TemplateRenderer
- CSS `\3c` unescapes to `<` when read via `cssText`, breaking out of `innerHTML` concatenation
- **Fix:** Replace `innerHTML` string concatenation with DOM `createElement`/`textContent`/`appendChild`

### 2. CSS injection via title styling props
- `dangerouslySetInnerHTML` with unsanitized font/size/color web part properties
- **Fix:** Input sanitization (regex allowlists for font, size clamping, hex/rgba validation), React `<style>{children}</style>` instead of `dangerouslySetInnerHTML`
- **Refactor:** Extracted shared `StyledWebPartTitle` component, removing ~150 lines of duplication across 4 container files

### 3. URL injection in vertical navigation
- `javascript:` URIs in `window.open` + `insertAdjacentHTML` for attribute injection
- **Fix:** URL scheme allowlist (http/https only via `new URL()` parsing), `createElement` instead of `insertAdjacentHTML`, `noopener` on `window.open`

### 4. Style tag regex bypass
**Advisory:** GHSA-vhgq-xhm4-6rg5
- `<stylefoobar>` and `</style x>` bypass the style extraction regex in `sanitizeHtmlWithStylePreservation`
- **Fix:** Tightened regex to require whitespace boundary on opening tag and flexible close tag matching

### 5. CSS content exfiltration + link tag abuse
- `<style>` content not sanitized (`url()`, `@import` for data exfiltration via CSS selectors)
- `<link>` tags abusable with `rel="dns-prefetch"`, `"preconnect"`, `"preload"` for network probing
- **Fix:** New `sanitizeCssContent()` method blocks `@import`, `javascript:`/non-image `data:` in `url()`, `expression()`, `behavior`, `-moz-binding`. Applied in both DOMPurify hook pipeline and `TemplateService.sanitizeHtmlWithStylePreservation`. `<link>` restricted to `rel="stylesheet"` + same-origin href only.

### 6. Dangerous URI attributes and form elements
- `forceKeepAttr` in `allowCustomAttributesHook` bypasses DOMPurify's URI validation, allowing `javascript:` in `action`, `formaction`, `xlink:href`
- **Fix:**
  - `FORBID_TAGS`: `form`, `button`, `object`, `embed` (no legitimate template use case)
  - `FORBID_ATTR`: `action`, `formaction`, `xlink:href`, `srcdoc`, `ping`, `dynsrc`, `lowsrc`, `background`
  - Expanded hook blocklist with `Set` for O(1) lookup + case-insensitive matching
  - Added explanatory comments documenting all security decisions in DOMPurify config

## Documentation
- Expanded sanitization section in `docs/extensibility/templating.md` with tables of blocked elements and attributes
- Added cross-reference from custom layout docs

## Testing
- `heft build` passes clean
- `heft test --clean --production` passes
- `heft package-solution --production` produces valid `.sppkg`
