### PR TITLE
fix: use getMemberGroups for vertical audience targeting (#4675)

### DIFF
--- a/search-parts/src/services/audienceTargetingService/AudienceTargetingService.ts
+++ b/search-parts/src/services/audienceTargetingService/AudienceTargetingService.ts
@@ -116,8 +116,9 @@ export class AudienceTargetingService {
     }
 
     /**
-     * Check if the current user is a member or transitive member of an AAD group
-     * @param groupIds The IDs of the Azure AD groups
+     * Check if the current user is a member of any of the specified Entra groups (transitive).
+     * Uses getMemberGroups which returns up to 11,000 group IDs in a single call.
+     * @param groupIds The IDs of the Entra groups to check
      * @returns true if the user is a member of any of the groups, false otherwise
      */
     private async isCurrentUserMemberOfAADGroup(groupIds: string[]): Promise<boolean> {
@@ -139,23 +140,22 @@ export class AudienceTargetingService {
 
             const graphClient = await this._context.msGraphClientFactory.getClient('3');
 
-            // Get the list of groups (including nested groups) the current user is a member of
-            const transitiveGroups = await graphClient
-                .api('/me/transitiveMemberOf')
+            // Use getMemberGroups (POST) which is transitive and returns up to 11,000 group IDs
+            // in a single call without pagination
+            const response = await graphClient
+                .api('/me/getMemberGroups')
                 .version('v1.0')
-                .select('id') // Only select group IDs to reduce the payload
-                .get();
+                .post({ securityEnabledOnly: false });
 
-            // Cache the groupIds and timestamp in localStorage
-            const transitiveGroupIds = transitiveGroups.value.map((group: { id: string }) => group.id);
+            const memberGroupIds: string[] = response.value;
             const groupData = {
-                ids: transitiveGroupIds,
+                ids: memberGroupIds,
                 timestamp: new Date().getTime().toString()
             };
             localStorage.setItem(AudienceTargetingService.AAD_GROUP_CACHE_KEY, JSON.stringify(groupData));
 
             // Filter locally for the group IDs you're interested in
-            return groupIds.some(groupId => transitiveGroupIds.includes(groupId));
+            return groupIds.some(groupId => memberGroupIds.includes(groupId));
         } catch (error) {
             console.error(`Error checking AAD group membership: ${error}`);
             return false;


### PR DESCRIPTION
## Problem

Fixes #4675 — Some vertical tabs are hidden when audience targeting is configured, even though the user is a member of the configured Entra groups. This regression started in v4.19.1.

## Root cause

The `AudienceTargetingService.isCurrentUserMemberOfAADGroup()` method used `/me/transitiveMemberOf` which returns **paginated results** (default 100 per page). Only the first page was being read and cached. Users who are members of many Entra groups would have some groups missing from the result set, causing those vertical tabs to be incorrectly hidden.

## Fix

Replaced `transitiveMemberOf` (GET, paginated) with `getMemberGroups` (POST, single call). This is the same API that was used in v4.18.2 where the issue didn't exist.

`getMemberGroups` is **transitive** (includes inherited memberships) and returns up to **11,000 group IDs** in a single response — no pagination needed.