### PR TITLE
fix: Ace editor cursor position offset in template dialog (#4706)

### DIFF
--- a/search-parts/src/controls/TextDialog/TextDialog.tsx
+++ b/search-parts/src/controls/TextDialog/TextDialog.tsx
@@ -114,6 +114,11 @@ export default class TextDialog extends React.Component<ITextDialogProps, ITextD
                                     $blockScrolling: Infinity
                                 }
                             }
+                            onLoad={(editor) => {
+                                // Force resize after the dialog's CSS transform is applied,
+                                // otherwise Ace miscalculates cursor/click positions
+                                requestAnimationFrame(() => editor.resize());
+                            }}
                             name="CodeEditor"
                             enableBasicAutocompletion={true}
                         />


### PR DESCRIPTION
## Problem

Fixes #4706 — When editing templates using the built-in code editor, the cursor and text selection appear at an offset from where the user clicks.

## Root cause

The Fluent UI `Dialog` component uses CSS `transform: translate(...)` for centering. Ace editor calculates mouse-to-text coordinate mapping based on DOM positions, but CSS transforms shift the visual rendering without changing the layout coordinates that Ace reads. This causes clicks to register at the wrong text position.

## Fix

Added an `onLoad` callback on the AceEditor component that calls `editor.resize()` via `requestAnimationFrame`. This forces Ace to recalculate its coordinate mapping after the dialog has fully rendered and its CSS transform has been applied.

Note: The issue reporter mentioned this only occurs on one tenant, suggesting it may be triggered by specific SharePoint CSS or layout variations. This fix handles it generically.