### PR TITLE
fix: prevent duplicate search query notifications on page load (#4673)

### DIFF
--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -190,13 +190,17 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
 
         if (inputValue && typeof (inputValue) === 'string') {
 
-            // Notify subscriber a new value if available
-            this._searchQueryText = decodeURIComponent(inputValue);
+            const decodedInputValue = decodeURIComponent(inputValue);
 
-            // Set the input query text globally for the page. There can be only one input query text submitted at a time even if multiple search box components are on the page
-            GlobalSettings.setValue(BuiltinTokenNames.inputQueryText, this._searchQueryText);
+            // Only notify subscribers if the value actually changed
+            if (decodedInputValue !== this._searchQueryText) {
+                this._searchQueryText = decodedInputValue;
 
-            this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchBox);
+                // Set the input query text globally for the page. There can be only one input query text submitted at a time even if multiple search box components are on the page
+                GlobalSettings.setValue(BuiltinTokenNames.inputQueryText, this._searchQueryText);
+
+                this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchBox);
+            }
         }
 
         renderRootElement = React.createElement(SearchBoxContainer, {
@@ -1066,7 +1070,11 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
         const source = DynamicPropertyHelper.tryGetSourceSafe(this.properties.queryText);
 
         if (source && source.id === ComponentType.PageEnvironment) {
-            this.render();
+            // Only re-render if the dynamic property value actually changed
+            const currentValue = DynamicPropertyHelper.tryGetValueSafe(this.properties.queryText);
+            if (currentValue !== this._searchQueryText) {
+                this.render();
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Fixes #4673 — When redirected from SharePoint's native search bar to a PnP search results page (via URL parameter `q`), results flash correctly then reload showing wrong/all results.

## Root cause

Two issues in the SearchBox web part cause redundant query notifications:

1. **`renderCompleted()`** calls `notifyPropertyChanged()` on **every render cycle**, even when the query value hasn't changed. Multiple render cycles during page load cause the Search Results web part to re-query repeatedly.

2. **`pushStateHandler()`** intercepts all `history.pushState` calls on the page and triggers a full re-render. SharePoint's modern page framework may call pushState during navigation/hydration, causing unnecessary re-renders that can read stale URL param values.

## Fix

- **`renderCompleted()`**: Only call `notifyPropertyChanged()` when the decoded query value actually differs from the previous value
- **`pushStateHandler()`**: Only trigger `this.render()` when the URL parameter value has changed

Note: The recommended setup is to use Page environment → Search (`PageContext:SearchData:searchQuery`) rather than Query string → Query parameters → `q`. However, both configurations should work correctly.