### PR TITLE
fix: reset regex lastIndex in replacePageTokens (#4707)

### DIFF
--- a/search-parts/src/services/tokenService/TokenService.ts
+++ b/search-parts/src/services/tokenService/TokenService.ts
@@ -321,6 +321,7 @@ export class TokenService implements ITokenService {
                 }
 
                 inputString = inputString.replace(matches[0], itemProp);
+                pageTokenRegExp.lastIndex = 0;
                 matches = pageTokenRegExp.exec(inputString);
             }
         }


### PR DESCRIPTION
## Problem

Fixes #4707 — Page taxonomy tokens like `{Page.KM_Taxonomy.Label}` resolve to empty depending on their position in the query template. The same token works or fails based on clause order.

## Root cause

In `replacePageTokens()`, a global regex (`/gi`) is used with `exec()` in a while loop. After each token replacement, the input string is mutated (often becoming shorter), but `RegExp.lastIndex` is not reset. When a replacement value is shorter than the token placeholder, subsequent tokens shift left in the string. If a token's new position falls before `lastIndex`, the regex skips it entirely.

## Fix

Reset `pageTokenRegExp.lastIndex = 0` after each replacement, as proposed by @appieschot in the issue comments.