### PR TITLE
fix: restore layout slot panel column layout and reduce title textarea height

### DIFF
--- a/search-parts/src/components/StyledWebPartTitle.module.scss
+++ b/search-parts/src/components/StyledWebPartTitle.module.scss
@@ -1,0 +1,8 @@
+.titleWrapper {
+    :global {
+        textarea {
+            height: 30px !important;
+            padding: 2px 0 !important;
+        }
+    }
+}

--- a/search-parts/src/components/StyledWebPartTitle.tsx
+++ b/search-parts/src/components/StyledWebPartTitle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { WebPartTitle, IWebPartTitleProps } from '@pnp/spfx-controls-react/lib/WebPartTitle';
+import styles from './StyledWebPartTitle.module.scss';
 
 export interface IStyledWebPartTitleProps {
     instanceId: string;
@@ -30,9 +31,11 @@ export const StyledWebPartTitle: React.FC<IStyledWebPartTitleProps> = (props) =>
     const hasCustomStyling = titleFont || titleFontSize !== undefined || titleFontColor;
 
     if (!hasCustomStyling) {
-        return testId
-            ? <div data-ui-test-id={testId}><WebPartTitle {...webPartTitleProps} /></div>
-            : <WebPartTitle {...webPartTitleProps} />;
+        return (
+            <div className={styles.titleWrapper} {...(testId ? { 'data-ui-test-id': testId } : {})}>
+                <WebPartTitle {...webPartTitleProps} />
+            </div>
+        );
     }
 
     const safeFont = sanitizeFont(titleFont);
@@ -53,7 +56,7 @@ export const StyledWebPartTitle: React.FC<IStyledWebPartTitleProps> = (props) =>
     `;
 
     return (
-        <div className={titleWrapperClass} {...(testId ? { 'data-ui-test-id': testId } : {})}>
+        <div className={`${styles.titleWrapper} ${titleWrapperClass}`} {...(testId ? { 'data-ui-test-id': testId } : {})}>
             <style key={`title-style-${safeFont}-${safeFontSize}-${safeColor}`}>{styleString}</style>
             <WebPartTitle {...webPartTitleProps} />
         </div>

--- a/search-parts/src/styles/Common.module.scss
+++ b/search-parts/src/styles/Common.module.scss
@@ -5,3 +5,32 @@
         font-family: var(--fontFamilyCustomFont1300, var(--fontFamilyBase));
     }
 }
+
+// Fix PropertyFieldCollectionData table layout broken by FluentUI/SPFx CSS upgrades.
+// Applied via tableClassName prop on the PropertyFieldCollectionData control.
+.slotTable {
+    display: table !important;
+    width: 100% !important;
+    border-collapse: separate;
+    border-spacing: 0 8px;
+
+    :global {
+        .PropertyFieldCollectionData__panel__table-head,
+        .PropertyFieldCollectionData__panel__table-row {
+            display: table-row !important;
+            line-height: 30px;
+        }
+
+        .PropertyFieldCollectionData__panel__table-cell {
+            display: table-cell !important;
+            padding: 0 10px;
+            vertical-align: middle;
+        }
+
+        .PropertyFieldCollectionData__panel__table-row > span {
+            display: table-cell !important;
+            padding: 0 10px;
+            vertical-align: middle;
+        }
+    }
+}

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -75,6 +75,7 @@ import defaultPeopleTemplate from '../../layouts/resultTypes/default_people.html
 import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
 import { Link } from '@fluentui/react/lib/Link';
 import { IComboBoxOption } from '@fluentui/react/lib/ComboBox';
+import { PanelType } from '@fluentui/react/lib/Panel';
 import { IToggleProps, Toggle } from '@fluentui/react/lib/Toggle';
 import { PropertyFieldMessage } from '@pnp/spfx-property-controls/lib/PropertyFieldMessage';
 
@@ -1506,6 +1507,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     panelDescription: webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.ConfigureSlotsPanelDescription,
                     label: webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.ConfigureSlotsLabel,
                     value: this.properties.templateSlots,
+                    panelProps: {
+                        type: PanelType.medium
+                    },
+                    tableClassName: commonStyles.slotTable,
                     fields: [
                         {
                             id: 'slotName',

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.module.scss
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.module.scss
@@ -4,11 +4,3 @@
     justify-content: center;
     align-items: center;
 }
-
-.title {
-
-    textarea {
-        font-size: 20px!important;
-        font-weight: 600!important;
-    }
-}


### PR DESCRIPTION
## Summary

Fixes broken Layout Slots panel column layout and excessive WebPartTitle textarea height in edit mode.

### Changes

**Slot panel layout fix:**
- FluentUI CSS upgrades broke the PropertyFieldCollectionData table layout, causing slot name and slot field to stack vertically instead of side-by-side columns
- Applied scoped `.slotTable` CSS class via `tableClassName` prop to restore `display: table-cell` layout
- Added `border-spacing` for row spacing between slot entries
- Narrowed the slot panel flyout from `PanelType.large` to `PanelType.medium`

**WebPartTitle textarea fix:**
- Reduced textarea height from 40px to 30px in edit mode to match font size
- Created `StyledWebPartTitle.module.scss` with scoped `.titleWrapper` class (no global CSS)
- Applied to all web parts via the shared `StyledWebPartTitle` component

**Cleanup:**
- Removed unused `.title` class from `SearchResultsContainer.module.scss`