### PR TITLE
fix: apply slotTable class to all PropertyFieldCollectionData dialogs

### DIFF
--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -17,6 +17,7 @@ import { DataSourceHelper } from '../helpers/DataSourceHelper';
 import { IAsyncComboProps } from "../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps";
 import { PropertyPaneNonReactiveTextField } from "../controls/PropertyPaneNonReactiveTextField/PropertyPaneNonReactiveTextField";
 import { IMicrosoftSearchDataSourceData } from "../models/search/IMicrosoftSearchDataSourceData";
+import commonStyles from '../styles/Common.module.scss';
 import * as React from "react";
 import { BuiltinDataSourceProviderKeys } from "./AvailableDataSources";
 import { AutoCalculatedDataSourceFields, SortableFields } from "../common/Constants";
@@ -355,6 +356,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                     panelDescription: commonStrings.DataSources.MicrosoftSearch.CollapseProperties.CollapsePropertiesDescription,
                     label: commonStrings.DataSources.MicrosoftSearch.CollapseProperties.CollapsePropertiesPropertyPaneFieldLabel,
                     value: this.properties.collapseProperties,
+                    tableClassName: commonStyles.slotTable,
                     fields: [
                         {
                             id: 'fields',
@@ -414,6 +416,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                     panelDescription: commonStrings.DataSources.SearchCommon.Sort.SortListDescription,
                     label: commonStrings.DataSources.SearchCommon.Sort.SortPropertyPaneFieldLabel,
                     value: this.properties.sortProperties,
+                    tableClassName: commonStyles.slotTable,
                     fields: [
                         {
                             id: 'sortField',

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -40,6 +40,7 @@ import { BuiltinDataSourceProviderKeys } from './AvailableDataSources';
 import { StringHelper } from '../helpers/StringHelper';
 import { AutoCalculatedDataSourceFields, SortableFields } from '../common/Constants';
 import { ObjectHelper } from '../helpers/ObjectHelper';
+import commonStyles from '../styles/Common.module.scss';
 import { PnPClientStorage } from "@pnp/common/storage";
 
 const TAXONOMY_REFINER_REGEX = /((L0|GP0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
@@ -335,6 +336,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                         panelDescription: commonStrings.DataSources.SearchCommon.Sort.SortListDescription,
                         label: commonStrings.DataSources.SearchCommon.Sort.SortPropertyPaneFieldLabel,
                         value: this.properties.sortList,
+                        tableClassName: commonStyles.slotTable,
                         fields: [
                             {
                                 id: 'sortField',

--- a/search-parts/src/layouts/results/cards/CardsLayout.ts
+++ b/search-parts/src/layouts/results/cards/CardsLayout.ts
@@ -5,6 +5,7 @@ import * as strings from 'CommonStrings';
 import { Icon, IIconProps, IComboBoxOption } from '@fluentui/react';
 import * as React from "react";
 import { TemplateValueFieldEditor, ITemplateValueFieldEditorProps } from "../../../controls/TemplateValueFieldEditor/TemplateValueFieldEditor";
+import commonStyles from '../../../styles/Common.module.scss';
 
 export interface ICardsLayoutProperties {
 
@@ -148,6 +149,7 @@ export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
                 disableItemDeletion: true,
                 label: strings.Layouts.Cards.ManageTilesFieldsLabel,
                 value: this.properties.documentCardFields,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'name',

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -9,6 +9,7 @@ import { AsyncCombo } from "../../../controls/PropertyPaneAsyncCombo/components/
 import { IAsyncComboProps } from "../../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps";
 import { PropertyFieldNumber } from "@pnp/spfx-property-controls/lib/PropertyFieldNumber";
 import commonStyles from './DetailsListLayout.module.scss';
+import sharedStyles from '../../../styles/Common.module.scss';
 
 /**
  * Details List Builtin Layout
@@ -191,6 +192,7 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
                 enableSorting: true,
                 label: strings.Layouts.DetailsList.ManageDetailsListColumnLabel,
                 value: this.properties.detailsListColumns,
+                tableClassName: sharedStyles.slotTable,
                 fields: [
                     {
                         id: 'name',
@@ -336,7 +338,7 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
                   panelHeader: strings.Layouts.DetailsList.AdditionalGroupByFieldsLabel,
                   panelDescription: strings.Layouts.DetailsList.AdditionalGroupByFieldsDescription,
                   enableSorting: true,
-                  tableClassName: commonStyles.additionalGroupByFieldsTable,
+                  tableClassName: sharedStyles.slotTable,
                   label: strings.Layouts.DetailsList.AdditionalGroupByFieldsLabel,
                   value: this.properties.additionalGroupByFields,
                   disabled: !this.properties.enableGrouping || !this.properties.groupByField || this.properties.groupByField.length === 0,

--- a/search-parts/src/layouts/results/people/PeopleLayout.ts
+++ b/search-parts/src/layouts/results/people/PeopleLayout.ts
@@ -6,6 +6,7 @@ import { IComboBoxOption, Icon, IIconProps } from '@fluentui/react';
 import { IComponentFieldsConfiguration } from "../../../models/common/IComponentFieldsConfiguration";
 import * as strings from 'CommonStrings';
 import { loadMsGraphToolkit } from "../../../helpers/GraphToolKitHelper";
+import commonStyles from '../../../styles/Common.module.scss';
 
 export interface IPeopleLayoutProperties {
 
@@ -122,6 +123,7 @@ export class PeopleLayout extends BaseLayout<IPeopleLayoutProperties> {
                 disableItemDeletion: true,
                 label: strings.Layouts.People.ManagePeopleFieldsLabel,
                 value: this.properties.peopleFields,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'name',

--- a/search-parts/src/styles/Common.module.scss
+++ b/search-parts/src/styles/Common.module.scss
@@ -16,9 +16,20 @@
 
     :global {
         .PropertyFieldCollectionData__panel__table-head,
-        .PropertyFieldCollectionData__panel__table-row {
+        .PropertyFieldCollectionData__panel__table-row,
+        [class*='tableHead_'],
+        [class*='tableRow_'] {
             display: table-row !important;
             line-height: 30px;
+        }
+
+        .PropertyFieldCollectionData__panel__table-head > span,
+        [class*='tableHead_'] > span {
+            display: table-cell !important;
+            padding: 0 10px;
+            vertical-align: middle;
+            font-size: 12px;
+            font-weight: 300;
         }
 
         .PropertyFieldCollectionData__panel__table-cell {
@@ -27,10 +38,46 @@
             vertical-align: middle;
         }
 
-        .PropertyFieldCollectionData__panel__table-row > span {
+        .PropertyFieldCollectionData__panel__table-row,
+        [class*='tableRow_']:not([class*='tableHead_']) {
+            background-color: #edebe9;
+        }
+
+        .PropertyFieldCollectionData__panel__table-row > span,
+        [class*='tableCell_'] {
             display: table-cell !important;
             padding: 0 10px;
             vertical-align: middle;
+        }
+
+        [class*='tableCell_'] > div,
+        [class*='tableCell_'] > div.ms-TextField {
+            margin-top: 8px;
+            margin-bottom: 8px;
+        }
+    }
+}
+
+// Restore broken native styles for "No data" label and action buttons
+// in all PropertyFieldCollectionData panels after FluentUI/SPFx CSS upgrades.
+:global {
+    .PropertyFieldCollectionData__panel__no-collection-data,
+    [class*='noCollectionData_'] {
+        text-align: center !important;
+        display: block !important;
+    }
+
+    .PropertyFieldCollectionData__panel__actions,
+    [class*='panelActions_'] {
+        margin-top: 15px !important;
+        text-align: right !important;
+
+        button {
+            margin-right: 15px;
+
+            &:last-child {
+                margin-right: 0;
+            }
         }
     }
 }

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -484,6 +484,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                     disabled: !this.properties.enableQuerySuggestions,
                     label: webPartStrings.PropertyPane.QuerySuggestionsGroup.SuggestionProvidersLabel,
                     value: this.properties.suggestionProviderConfiguration,
+                    tableClassName: commonStyles.slotTable,
                     fields: [
                         {
                             id: 'enabled',
@@ -756,6 +757,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 panelDescription: webPartStrings.PropertyPane.InformationPage.Extensibility.PanelDescription,
                 label: commonStrings.PropertyPane.InformationPage.Extensibility.FieldLabel,
                 value: this.properties.extensibilityLibraryConfiguration,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'name',

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -739,6 +739,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 panelDescription: webPartStrings.PropertyPane.DataFilterCollection.CustomizeFiltersDescription,
                 label: webPartStrings.PropertyPane.DataFilterCollection.CustomizeFiltersFieldLabel,
                 value: this.properties.filtersConfiguration,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'displayValue',

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -75,7 +75,6 @@ import defaultPeopleTemplate from '../../layouts/resultTypes/default_people.html
 import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
 import { Link } from '@fluentui/react/lib/Link';
 import { IComboBoxOption } from '@fluentui/react/lib/ComboBox';
-import { PanelType } from '@fluentui/react/lib/Panel';
 import { IToggleProps, Toggle } from '@fluentui/react/lib/Toggle';
 import { PropertyFieldMessage } from '@pnp/spfx-property-controls/lib/PropertyFieldMessage';
 
@@ -1398,6 +1397,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 panelDescription: webPartStrings.PropertyPane.InformationPage.Extensibility.PanelDescription,
                 label: commonStrings.PropertyPane.InformationPage.Extensibility.FieldLabel,
                 value: this.properties.extensibilityLibraryConfiguration,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'name',
@@ -1507,9 +1507,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     panelDescription: webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.ConfigureSlotsPanelDescription,
                     label: webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.ConfigureSlotsLabel,
                     value: this.properties.templateSlots,
-                    panelProps: {
-                        type: PanelType.medium
-                    },
                     tableClassName: commonStyles.slotTable,
                     fields: [
                         {
@@ -2536,6 +2533,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 enableSorting: true,
                 label: webPartStrings.PropertyPane.CustomQueryModifier.QueryModifiersLabel,
                 value: this.properties.queryModifierConfiguration,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'enabled',

--- a/search-parts/src/webparts/searchResults/propertyPane/StylingPageGroupsBuilder.ts
+++ b/search-parts/src/webparts/searchResults/propertyPane/StylingPageGroupsBuilder.ts
@@ -11,6 +11,7 @@ import { ResultTypeOperator } from '../../../models/common/IDataResultType';
 import * as React from 'react';
 import { LayoutHelper } from '../../../helpers/LayoutHelper';
 import { PropertyPaneTabsField } from '../../../controls/PropertyPaneTabsField/PropertyPaneTabsField';
+import commonStyles from '../../../styles/Common.module.scss';
 
 export class StylingPageGroupsBuilder {
 
@@ -197,6 +198,7 @@ export class StylingPageGroupsBuilder {
                 enableSorting: true,
                 label: this.webPartStrings.PropertyPane.LayoutPage.Handlebars.ResultTypes.ResultTypeslabel,
                 value: this.properties.resultTypes,
+                tableClassName: commonStyles.slotTable,
                 disabled: this.properties.selectedLayoutKey === BuiltinLayoutsKeys.DetailsList
                     || this.properties.selectedLayoutKey === BuiltinLayoutsKeys.ResultsDebug
                     || this.properties.selectedLayoutKey === BuiltinLayoutsKeys.Slider,

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -350,6 +350,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                 enableSorting: true,
                 label: webPartStrings.PropertyPane.Verticals.PropertyLabel,
                 value: this.properties.verticals,
+                tableClassName: commonStyles.slotTable,
                 fields: [
                     {
                         id: 'tabName',


### PR DESCRIPTION
Fixed the remaining panels/dialogs using the same approach as in https://github.com/microsoft-search/pnp-modern-search/pull/4715