### PR TITLE
fix: ExternalItem + Result Types causes API error (#4722)

### DIFF
--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -323,7 +323,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             }),
             PropertyPaneToggle('dataSourceProperties.enableResultTypes', {
                 label: "Enable result types",
-                disabled: this.properties.entityTypes.includes(EntityType.ExternalItem)
+                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.ListItem)
             }),
             PropertyPaneToggle('dataSourceProperties.showSPEmbeddedContent', {
                 label: commonStrings.DataSources.MicrosoftSearch.showSPEmbeddedContentLabel,
@@ -1369,7 +1369,8 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private applyResultTemplateOptions(searchRequest: IMicrosoftSearchRequest): void {
-        if (this.properties.enableResultTypes) {
+        const supportedTypes = [EntityType.ExternalItem, EntityType.ListItem];
+        if (this.properties.enableResultTypes && this.properties.entityTypes.every(e => supportedTypes.includes(e))) {
             searchRequest.resultTemplateOptions = {
                 enableResultTemplate: true
             };

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -323,7 +323,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             }),
             PropertyPaneToggle('dataSourceProperties.enableResultTypes', {
                 label: "Enable result types",
-                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.DriveItem || e === EntityType.ListItem || e === EntityType.Site)
+                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.ListItem)
             }),
             PropertyPaneToggle('dataSourceProperties.showSPEmbeddedContent', {
                 label: commonStrings.DataSources.MicrosoftSearch.showSPEmbeddedContentLabel,
@@ -1369,7 +1369,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private applyResultTemplateOptions(searchRequest: IMicrosoftSearchRequest): void {
-        const supportedTypes = [EntityType.ExternalItem, EntityType.DriveItem, EntityType.ListItem, EntityType.Site];
+        const supportedTypes = [EntityType.ExternalItem, EntityType.ListItem];
         if (this.properties.enableResultTypes && this.properties.entityTypes.every(e => supportedTypes.includes(e))) {
             searchRequest.resultTemplateOptions = {
                 enableResultTemplate: true

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -276,6 +276,10 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         let enableTopResultsFields: IPropertyPaneField<any>[] = [];
         let sortPropertiesFields: IPropertyPaneField<any>[] = [];
         let queryAlterationFields: IPropertyPaneField<any>[] = [];
+        const supportsResultTypes = (entityTypes: EntityType[] = []) => {
+            return entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.ListItem);
+        };
+
         let commonFields: IPropertyPaneField<any>[] = [
             PropertyPaneLabel('', {
                 text: commonStrings.DataSources.MicrosoftSearch.QueryTextFieldLabel
@@ -304,7 +308,14 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                 placeholder: "",
                 searchAsYouType: false,
                 defaultSelectedKeys: this.properties.entityTypes,
-                onPropertyChange: this.onCustomPropertyUpdate.bind(this),
+                onPropertyChange: (targetProperty?: string, newValue?: EntityType[]) => {
+                    const previousEnableResultTypes = this.properties.enableResultTypes;
+                    this.onCustomPropertyUpdate(targetProperty, newValue);
+
+                    if (supportsResultTypes(newValue) && previousEnableResultTypes) {
+                        this.properties.enableResultTypes = previousEnableResultTypes;
+                    }
+                },
                 textDisplayValue: entityTypesDisplayValue.filter(Boolean).join(",")
             }),
             new PropertyPaneAsyncCombo('dataSourceProperties.fields', {
@@ -323,7 +334,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             }),
             PropertyPaneToggle('dataSourceProperties.enableResultTypes', {
                 label: "Enable result types",
-                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.ListItem)
+                disabled: !supportsResultTypes(this.properties.entityTypes)
             }),
             PropertyPaneToggle('dataSourceProperties.showSPEmbeddedContent', {
                 label: commonStrings.DataSources.MicrosoftSearch.showSPEmbeddedContentLabel,

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -323,7 +323,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             }),
             PropertyPaneToggle('dataSourceProperties.enableResultTypes', {
                 label: "Enable result types",
-                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.ListItem)
+                disabled: !this.properties.entityTypes.every(e => e === EntityType.ExternalItem || e === EntityType.DriveItem || e === EntityType.ListItem || e === EntityType.Site)
             }),
             PropertyPaneToggle('dataSourceProperties.showSPEmbeddedContent', {
                 label: commonStrings.DataSources.MicrosoftSearch.showSPEmbeddedContentLabel,
@@ -1369,7 +1369,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private applyResultTemplateOptions(searchRequest: IMicrosoftSearchRequest): void {
-        const supportedTypes = [EntityType.ExternalItem, EntityType.ListItem];
+        const supportedTypes = [EntityType.ExternalItem, EntityType.DriveItem, EntityType.ListItem, EntityType.Site];
         if (this.properties.enableResultTypes && this.properties.entityTypes.every(e => supportedTypes.includes(e))) {
             searchRequest.resultTemplateOptions = {
                 enableResultTemplate: true


### PR DESCRIPTION
## Summary
Fixes #4722 — Selecting ExternalItem entity type with "Enable result types" causes an API error.

## Problem
Two issues in the Microsoft Search data source configuration:

1. **Toggle disabled logic was backwards**: The "Enable result types" toggle was disabled when `ExternalItem` was selected, but `externalItem` is actually one of the entity types that *supports* `resultTemplateOptions` per the [Microsoft Graph Search API docs](https://learn.microsoft.com/en-us/graph/search-concept-display-layout).

2. **No entity type validation**: `applyResultTemplateOptions()` sent `enableResultTemplate: true` regardless of which entity types were selected, causing API errors when unsupported types (e.g., `message`, `event`, `driveItem`, etc.) were included.

## Solution
- **Fixed toggle**: Now disabled when entity types include types OTHER than `externalItem`/`listItem` (the only types that support result templates)
- **Added guard**: `applyResultTemplateOptions()` only sends `enableResultTemplate: true` when ALL selected entity types support it

## Changes
- `MicrosoftSearchDataSource.ts`: Fixed disabled condition on the result types toggle and added entity type validation in `applyResultTemplateOptions()`