### PR TITLE
fix: Search Box disappears intermittently on page load (#4719)

### DIFF
--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -95,6 +95,8 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
      */
     private tokenService: ITokenService;
 
+    private readonly _boundRender = this.render.bind(this);
+
     constructor() {
         super();
 
@@ -171,6 +173,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
         }
 
         if (!this.domElement) {
+            super.renderCompleted();
             return;
         }
         let renderRootElement: JSX.Element = null;
@@ -262,6 +265,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
     }
 
     protected onDispose(): void {
+        window.removeEventListener('hashchange', this._boundRender);
         if (this._pushStateCallback) {
             window.history.pushState = this._pushStateCallback;
         }
@@ -893,9 +897,9 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
         const queryTextSource = DynamicPropertyHelper.tryGetSourceSafe(this.properties.queryText);
         if (queryTextSource && this.properties.queryText?.reference?.localeCompare('PageContext:UrlData:fragment') === 0) {
             // Manually subscribe to hash change since the default property doesn't
-            window.addEventListener('hashchange', this.render);
+            window.addEventListener('hashchange', this._boundRender);
         } else {
-            window.removeEventListener('hashchange', this.render);
+            window.removeEventListener('hashchange', this._boundRender);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #4719 — Search Box web part disappears intermittently on initial page load but appears on browser refresh.

## Root Cause
Two bugs in `SearchBoxWebPart.ts` created a race condition during SPA-style page navigation:

1. **`renderCompleted()` early return without `super.renderCompleted()`**: When `domElement` was not yet available (common during SPA navigation), the method returned without notifying the SPFx framework that rendering completed. This left `renderedOnce` as `false`, blocking subsequent render cycles entirely.

2. **Unbound `this.render` in hashchange listener**: `this.render` was passed directly to `addEventListener` without binding, so when the hashchange event fired, `this` was `window` instead of the web part instance — causing silent failures. The unbound reference also meant `removeEventListener` in the else branch could never match the added listener.

## Why refresh works but initial load doesn't
- **Full page refresh**: Browser reloads everything — `domElement` is guaranteed to exist before `render()` fires, and all initialization is clean.
- **SPA navigation** (clicking a link): SharePoint navigates without a full reload. The async `render()` method has two `await` calls (audience targeting + suggestion providers), creating a timing window where `domElement` may not yet be ready when `renderCompleted()` executes.

## Changes
- Always call `super.renderCompleted()` even when `domElement` is missing, so the framework knows rendering finished
- Store a bound render reference (`_boundRender`) and use it for hashchange `addEventListener`/`removeEventListener`
- Clean up hashchange listener in `onDispose()`