### PR TITLE
Fix panel filter events by preserving instanceId

### DIFF
--- a/search-parts/src/components/PanelComponent.tsx
+++ b/search-parts/src/components/PanelComponent.tsx
@@ -266,6 +266,7 @@ export class PanelComponent extends React.Component<IPanelComponentProps, IPanel
             webPartDomElement.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_APPLY_ALL, {
                 detail: {
                     filterName: ev.detail.filterName,
+                    instanceId: webPartInstanceId
                 },
                 bubbles: true,
                 cancelable: true
@@ -291,10 +292,10 @@ export class PanelComponent extends React.Component<IPanelComponentProps, IPanel
         const webPartDomElement = window.document.querySelector(`div[data-instance-id="${webPartInstanceId}"]`);
 
         if (webPartDomElement) {
-
             webPartDomElement.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_CLEAR_ALL, {
                 detail: {
                     filterName: ev.detail.filterName,
+                    instanceId: webPartInstanceId
                 },
                 bubbles: true,
                 cancelable: true
@@ -358,7 +359,8 @@ export class PanelComponent extends React.Component<IPanelComponentProps, IPanel
             webPartDomElement.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_VALUE_OPERATOR_UPDATED, {
                 detail: {
                     filterName: ev.detail.filterName,
-                    operator: ev.detail.operator
+                    operator: ev.detail.operator,
+                    instanceId: webPartInstanceId
                 },
                 bubbles: true,
                 cancelable: true


### PR DESCRIPTION
## Summary
Fixes an issue where Search Filters configured with the Panel layout do not respond when Apply or Clear is clicked.

## Root cause
PanelComponent re-dispatches filter events from the panel back to the Search Filters web part.
For Apply, Clear, and filter operator updates, the re-dispatched event details did not include instanceId.

SearchFiltersContainer scopes these events to the current web part instance and ignores events when instanceId is missing, so the panel buttons appeared to do nothing.

## Changes
Updated `search-parts/src/components/PanelComponent.tsx` so that re-dispatched:
- `EVENT_FILTER_APPLY_ALL`
- `EVENT_FILTER_CLEAR_ALL`
- `EVENT_FILTER_VALUE_OPERATOR_UPDATED`

all include the originating `instanceId`.

## Testing
Tested in a SharePoint dev tenant with:
- PnP Search Results connected to PnP Search Filters
- Search Filters layout set to Panel

Verified that:
- selecting filter values and clicking Apply updates results
- clicking Clear clears the filter and updates results
- panel interaction works as expected after redeployment
