### PR TITLE
feat: add bidirectional connection warning for filter and results web parts

### DIFF
--- a/search-parts/src/models/dynamicData/IDataFilterSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataFilterSourceData.ts
@@ -10,7 +10,7 @@ export interface IDataFilterSourceData {
     /**
      * The filters configuration for the Data Filter Web Part
      */
-    filterConfiguration: IDataFilterConfiguration[];    
+    filterConfiguration: IDataFilterConfiguration[];
 
     /**
      * The configured logical operator to use between filters
@@ -21,4 +21,9 @@ export interface IDataFilterSourceData {
      * The Web Part instance ID
      */
     instanceId: string;
+
+    /**
+     * The data source references this filter web part is connected to (used for bidirectional connection validation)
+     */
+    connectedResultsSourceReferences?: string[];
 }

--- a/search-parts/src/models/dynamicData/IDataResultSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataResultSourceData.ts
@@ -20,10 +20,15 @@ export interface IDataResultSourceData {
     /**
      * The current selected items in the Search Results Web Part
      */
-    selectedItems?: {[key: string]: string}[];
+    selectedItems?: { [key: string]: string }[];
 
     /**
      * The count of items returned by the getItemCount method of a datasource
      */
-    totalCount?:number;
+    totalCount?: number;
+
+    /**
+     * The filter data source reference this results web part is connected to (used for bidirectional connection validation)
+     */
+    connectedFilterSourceReference?: string;
 }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -637,20 +637,22 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         // Check bidirectional connection: do the connected results web parts also connect back to this filter web part?
         if (this.properties.dataResultsDataSourceReferences.length > 0 && this._dataSourceDynamicProperties.length > 0) {
-            const missingBackConnections: string[] = [];
+            let hasMissingBackConnection = false;
 
             this._dataSourceDynamicProperties.forEach((dynProp) => {
                 const resultData: IDataResultSourceData = DynamicPropertyHelper.tryGetValueSafe(dynProp);
                 if (resultData) {
-                    const isConnectedBack = resultData.connectedFilterSourceReference &&
-                        resultData.connectedFilterSourceReference.indexOf(this.instanceId) !== -1;
+                    // Extract sourceId from the reference (format: "sourceId:propertyId") and check if it ends with this web part's instanceId
+                    const connectedRef = resultData.connectedFilterSourceReference;
+                    const isConnectedBack = connectedRef &&
+                        connectedRef.split(':')[0].endsWith(this.instanceId);
                     if (!isConnectedBack) {
-                        missingBackConnections.push('results');
+                        hasMissingBackConnection = true;
                     }
                 }
             });
 
-            if (missingBackConnections.length > 0 && this._propertyPaneWebPartInformation) {
+            if (hasMissingBackConnection && this._propertyPaneWebPartInformation) {
                 fields.push(
                     this._propertyPaneWebPartInformation({
                         description: `<span style="color: #d83b01;">⚠ ${webPartStrings.PropertyPane.ConnectionsPage.BidirectionalConnectionWarning}</span>`,

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -89,6 +89,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     private _propertyFieldCodeEditorLanguages: any = null;
     private _customCollectionFieldType: any = null;
     private _propertyPanePropertyEditor = null;
+    private _propertyPaneWebPartInformation: any = null;
 
     /**
      * Properties to avoid to recreate instances every render
@@ -429,7 +430,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     filterConfiguration: this.properties.filtersConfiguration,
                     selectedFilters: this._selectedFilters,
                     filterOperator: this.properties.filterOperator,
-                    instanceId: this.instanceId
+                    instanceId: this.instanceId,
+                    connectedResultsSourceReferences: this.properties.dataResultsDataSourceReferences
                 } as IDataFilterSourceData;
 
             default:
@@ -611,7 +613,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             }
         });
 
-        return [
+        const fields: IPropertyPaneField<any>[] = [
             new PropertyPaneAsyncCombo('dataResultsDataSourceReferences', {
                 availableOptions: sourceOptions,
                 allowFreeform: false,
@@ -632,6 +634,33 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 allowMultiSelect: true
             }),
         ];
+
+        // Check bidirectional connection: do the connected results web parts also connect back to this filter web part?
+        if (this.properties.dataResultsDataSourceReferences.length > 0 && this._dataSourceDynamicProperties.length > 0) {
+            const missingBackConnections: string[] = [];
+
+            this._dataSourceDynamicProperties.forEach((dynProp) => {
+                const resultData: IDataResultSourceData = DynamicPropertyHelper.tryGetValueSafe(dynProp);
+                if (resultData) {
+                    const isConnectedBack = resultData.connectedFilterSourceReference &&
+                        resultData.connectedFilterSourceReference.indexOf(this.instanceId) !== -1;
+                    if (!isConnectedBack) {
+                        missingBackConnections.push('results');
+                    }
+                }
+            });
+
+            if (missingBackConnections.length > 0 && this._propertyPaneWebPartInformation) {
+                fields.push(
+                    this._propertyPaneWebPartInformation({
+                        description: `<span style="color: #d83b01;">⚠ ${webPartStrings.PropertyPane.ConnectionsPage.BidirectionalConnectionWarning}</span>`,
+                        key: 'bidirectionalResultsWarning'
+                    })
+                );
+            }
+        }
+
+        return fields;
     }
 
     private async getConnectionOptionsFields(): Promise<IPropertyPaneField<any>[]> {
@@ -1634,6 +1663,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             '@pnp/spfx-property-controls/lib/PropertyPanePropertyEditor'
         );
         this._propertyPanePropertyEditor = PropertyPanePropertyEditor;
+
+        const { PropertyPaneWebPartInformation } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'
+        );
+        this._propertyPaneWebPartInformation = PropertyPaneWebPartInformation;
 
         this.propertyPaneConnectionsFields = await this.getConnectionOptionsFields();
     }

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Použít data z těchto webových dílů",
                 UseDataResultsFromComponentsDescription: "Pokud připojíte více než jeden webový díl, hodnoty a počty filtrů se sloučí pro podobné názvy filtrů.",
                 LinkToVerticalLabel: "Zobrazit filtry pouze při výběru těchto vertikál",
-                LinkToVerticalLabelHoverMessage: "Filtry se zobrazí pouze tehdy, pokud vybraná vertikála odpovídá těm, které jsou nakonfigurovány pro tento webový díl. V opačném případě bude webový díl v režimu zobrazení prázdný (bez okrajů a výplní)."
+                LinkToVerticalLabelHoverMessage: "Filtry se zobrazí pouze tehdy, pokud vybraná vertikála odpovídá těm, které jsou nakonfigurovány pro tento webový díl. V opačném případě bude webový díl v režimu zobrazení prázdný (bez okrajů a výplní).",
+                BidirectionalConnectionWarning: "Jeden nebo více připojených webových dílů výsledků vyhledávání nebylo nakonfigurováno pro zpětné připojení k tomuto webovému dílu filtrů. Oba webové díly musí být vzájemně propojeny, aby filtry fungovaly správně."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Nastavení filtrů",

--- a/search-parts/src/webparts/searchFilters/loc/da-dk.js
+++ b/search-parts/src/webparts/searchFilters/loc/da-dk.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Anvend data fra disse webparts",
                 UseDataResultsFromComponentsDescription: "Hvis du forbinder mere end en webpart, flettes filterværdier til lignende filternavne.",
                 LinkToVerticalLabel: "Vis kun filtre, når følgende vertikaler er valgt",
-                LinkToVerticalLabelHoverMessage: "Filtrene vil kun blive vist, hvis den valgte vertikal matcher med dem, der er konfigureret til denne webdel. Ellers vil webdelen være tom (ingen margen og ingen polstring) i visningstilstand."
+                LinkToVerticalLabelHoverMessage: "Filtrene vil kun blive vist, hvis den valgte vertikal matcher med dem, der er konfigureret til denne webdel. Ellers vil webdelen være tom (ingen margen og ingen polstring) i visningstilstand.",
+                BidirectionalConnectionWarning: "En eller flere tilsluttede søgeresultatwebdele er ikke konfigureret til at forbinde tilbage til denne filterwebdel. Begge webdele skal være forbundet til hinanden, for at filtre kan fungere korrekt."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Indstillinger til filtre",

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Benutze Daten von diesen Webparts",
                 UseDataResultsFromComponentsDescription: "Wenn mehr als ein Webpart verbunden ist, dann werden die Filter Werte und die Anzahl für ähnliche Filter Namen zusammengeführt.",
                 LinkToVerticalLabel: "Zeige Filter nur an, wenn folgende Vertikale ausgewählt sind",
-                LinkToVerticalLabelHoverMessage: "Diese Filter werden nur angezeigt, wenn das ausgewählte Vertikal mit einem der für dieses Webpart konfigurierten übereinstimmt. Ansonsten bleibt das Webpart im Anzeigemodus leer (kein Rand)."
+                LinkToVerticalLabelHoverMessage: "Diese Filter werden nur angezeigt, wenn das ausgewählte Vertikal mit einem der für dieses Webpart konfigurierten übereinstimmt. Ansonsten bleibt das Webpart im Anzeigemodus leer (kein Rand).",
+                BidirectionalConnectionWarning: "Ein oder mehrere verbundene Suchergebnis-Webparts wurden nicht so konfiguriert, dass sie eine Rückverbindung zu diesem Filter-Webpart herstellen. Beide Webparts müssen miteinander verbunden sein, damit die Filter korrekt funktionieren."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Filter Einstellungen",
@@ -67,13 +68,15 @@ define([], function() {
                 ErrorTemplateResolve: "Kann die angegebene Vorlage nicht auflösen. Fehler Details: '{0}'",
                 FiltersTemplateFieldLabel: "Filter Vorlage bearbeiten",
                 FiltersTemplatePanelHeader: "Filter Vorlage bearbeiten"
-            }        },
+            }
+        },
         Styling: {
             StylingOptionsGroupName: "Stiloptionen",
             FilterBackgroundColorLabel: "Filter-Hintergrundfarbe",
             FilterBorderColorLabel: "Filter-Rahmenfarbe",
             FilterBorderThicknessLabel: "Filter-Rahmenstärke",
             ResetToDefaultLabel: "Styling auf Standard zurücksetzen",
-            ResetToDefaultDescription: "Alle Styling-Optionen auf ihre Standardwerte zurücksetzen"        }
+            ResetToDefaultDescription: "Alle Styling-Optionen auf ihre Standardwerte zurücksetzen"
+        }
     }
 });

--- a/search-parts/src/webparts/searchFilters/loc/en-us.js
+++ b/search-parts/src/webparts/searchFilters/loc/en-us.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Use data from these Web Parts",
                 UseDataResultsFromComponentsDescription: "If you connect more than one Web Part, the filter values and counts will be merged for similar filter names.",
                 LinkToVerticalLabel: "Display filters only when the following verticals are selected",
-                LinkToVerticalLabelHoverMessage: "The filters will be displayed only if the selected vertical matches with the ones configured for this Web Part. Otherwise, the Web part will be blank (no margin and no padding) in display mode."
+                LinkToVerticalLabelHoverMessage: "The filters will be displayed only if the selected vertical matches with the ones configured for this Web Part. Otherwise, the Web part will be blank (no margin and no padding) in display mode.",
+                BidirectionalConnectionWarning: "One or more connected search results Web Parts have not been configured to connect back to this filters Web Part. Both web parts must be connected to each other for filters to work correctly."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Filters settings",

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Utilizar los datos de estos Web Parts",
                 UseDataResultsFromComponentsDescription: "Si conecta más de un Web Part, los valores de los filtros y los recuentos se fusionarán para nombres de filtros similares.",
                 LinkToVerticalLabel: "Muestra los filtros sólo cuando se seleccionan las siguientes verticales",
-                LinkToVerticalLabelHoverMessage: "Los filtros se mostrarán sólo si la vertical seleccionada coincide con las configuradas para este Web Part. De lo contrario, el Web Part estará en blanco (sin margen y sin relleno) en el modo de visualización."
+                LinkToVerticalLabelHoverMessage: "Los filtros se mostrarán sólo si la vertical seleccionada coincide con las configuradas para este Web Part. De lo contrario, el Web Part estará en blanco (sin margen y sin relleno) en el modo de visualización.",
+                BidirectionalConnectionWarning: "Uno o más Web Parts de resultados de búsqueda conectados no han sido configurados para conectarse de vuelta a este Web Part de filtros. Ambos Web Parts deben estar conectados entre sí para que los filtros funcionen correctamente."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Configuración de los filtros",

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Käytä tuloksia näistä hakutulosten webosista",
                 UseDataResultsFromComponentsDescription: "Jos yhdistät useamman kuin yhden hakutulosten webosan, suodatinarvot ja tulosmäärät yhdistetään samannimisille suodattimille.",
                 LinkToVerticalLabel: "Näytä suodattimet vain, kun nämä vertikaalit ovat valittuna",
-                LinkToVerticalLabelHoverMessage: "Suodattimet näytetään vain, jos valittu vertikaali on sama kuin tälle webosalle konfiguroitu. Muussa tapauksessa suodatinwebosa on tyhjä (ei vie tilaa eikä näytä kehystä) sivun lukutilassa."
+                LinkToVerticalLabelHoverMessage: "Suodattimet näytetään vain, jos valittu vertikaali on sama kuin tälle webosalle konfiguroitu. Muussa tapauksessa suodatinwebosa on tyhjä (ei vie tilaa eikä näytä kehystä) sivun lukutilassa.",
+                BidirectionalConnectionWarning: "Yhtä tai useampaa yhdistettyä hakutulokset-webosaa ei ole määritetty yhdistämään takaisin tähän suodatin-webosaan. Molemmat webosat on yhdistettävä toisiinsa, jotta suodattimet toimivat oikein."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Suodattimien asetukset",
@@ -67,13 +68,15 @@ define([], function() {
                 ErrorTemplateResolve: "Templaatin tunnistaminen ei onnistunut. Virhetiedot: '{0}'",
                 FiltersTemplateFieldLabel: "Muokkaa suodatintemplaattia",
                 FiltersTemplatePanelHeader: "Muokkaa suodatintemplaattia"
-            }        },
+            }
+        },
         Styling: {
             StylingOptionsGroupName: "Tyyliasetukset",
             FilterBackgroundColorLabel: "Suodattimen taustav\u00e4ri",
             FilterBorderColorLabel: "Suodattimen reunav\u00e4ri",
             FilterBorderThicknessLabel: "Suodattimen reunan paksuus",
             ResetToDefaultLabel: "Palauta oletustyyli",
-            ResetToDefaultDescription: "Palauta kaikki tyyliasetukset oletusarvoihinsa"        }
+            ResetToDefaultDescription: "Palauta kaikki tyyliasetukset oletusarvoihinsa"
+        }
     }
 });

--- a/search-parts/src/webparts/searchFilters/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchFilters/loc/fr-fr.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -18,7 +18,8 @@ define([], function() {
                 UseDataVerticalsWebPartLabel: "Se connecter à un composant WebPart de verticales",
                 UseDataVerticalsFromComponentLabel: "Utiliser les verticales de ce composant",
                 LinkToVerticalLabel: "Afficher les données uniquement lorsque les verticales suivantes sont sélectionnées",
-                LinkToVerticalLabelHoverMessage: "Les filtres ne seront affichés que si la verticale sélectionnée correspond à celles configurées pour ce composant WebPart. Sinon, le composant WebPart restera vide (pas de marge ni de remplissage) en mode affichage."
+                LinkToVerticalLabelHoverMessage: "Les filtres ne seront affichés que si la verticale sélectionnée correspond à celles configurées pour ce composant WebPart. Sinon, le composant WebPart restera vide (pas de marge ni de remplissage) en mode affichage.",
+                BidirectionalConnectionWarning: "Un ou plusieurs composants WebPart de résultats de recherche connectés n'ont pas été configurés pour se reconnecter à ce composant WebPart de filtres. Les deux composants WebPart doivent être connectés l'un à l'autre pour que les filtres fonctionnent correctement."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Paramètres des filtres",

--- a/search-parts/src/webparts/searchFilters/loc/it-it.js
+++ b/search-parts/src/webparts/searchFilters/loc/it-it.js
@@ -16,7 +16,8 @@ define([], function () {
                 UseDataResultsFromComponentsLabel: "Usa dati da questa Web Part",
                 UseDataResultsFromComponentsDescription: "Se colleghi più di una Web Part, i valori e i conteggi dei filtri saranno uniti per nomi di filtro simili.",
                 LinkToVerticalLabel: "Visualizza i filtri solo quando sono selezionati i seguenti verticali",
-                LinkToVerticalLabelHoverMessage: "I filtri saranno visualizzati solo se il verticale selezionato corrisponde a quelli configurati per questa Web Part. Altrimenti, la Web Part sarà vuota (nessun margine e nessun padding) in modalità di visualizzazione."
+                LinkToVerticalLabelHoverMessage: "I filtri saranno visualizzati solo se il verticale selezionato corrisponde a quelli configurati per questa Web Part. Altrimenti, la Web Part sarà vuota (nessun margine e nessun padding) in modalità di visualizzazione.",
+                BidirectionalConnectionWarning: "Una o più Web Part dei risultati di ricerca connesse non sono state configurate per ricollegarsi a questa Web Part dei filtri. Entrambe le Web Part devono essere collegate tra loro affinché i filtri funzionino correttamente."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Impostazioni dei filtri",
@@ -35,7 +36,7 @@ define([], function () {
                 FilterTypeStaticFilter: "Questo modello di filtro agisce come un filtro statico e invia solo valori selezionati arbitrariamente alla fonte dati collegata. I valori dei filtri in entrata non sono presi in considerazione.",
                 CustomizeFiltersBtnLabel: "Modifica",
                 CustomizeFiltersHeader: "Modifica filtri",
-                CustomizeFiltersDescription: "Configura i filtri di ricerca aggiungendo o rimuovendo righe. Puoi selezionare campi dai risultati della fonte dati (se già selezionati) o usare valori statici per i filtri. For more details see https://microsoft-search.github.io/pnp-modern-search/usage/search-filters/#filter-settings" ,
+                CustomizeFiltersDescription: "Configura i filtri di ricerca aggiungendo o rimuovendo righe. Puoi selezionare campi dai risultati della fonte dati (se già selezionati) o usare valori statici per i filtri. For more details see https://microsoft-search.github.io/pnp-modern-search/usage/search-filters/#filter-settings",
                 CustomizeFiltersFieldLabel: "Personalizza filtri",
                 ShowCount: "Mostra conteggio",
                 Operator: "Operatore tra i valori",

--- a/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
@@ -16,6 +16,7 @@ declare interface ISearchFiltersWebPartStrings {
             UseDataResultsFromComponentsDescription: string;
             LinkToVerticalLabel: string;
             LinkToVerticalLabelHoverMessage: string;
+            BidirectionalConnectionWarning: string;
         },
         FiltersSettingsPage: {
             SettingsGroupName: string;

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Bruk data fra disse nettdelene",
                 UseDataResultsFromComponentsDescription: "Om du kobler til mer enn 1 nettdel slås filterverdiene sammen til liknende filternavn.",
                 LinkToVerticalLabel: "Vis filtre bare når følgende vertikaler er valgt",
-                LinkToVerticalLabelHoverMessage: "Filtrene vil bare vises hvis den valgte vertikalen samsvarer med de som er konfigurert for denne webdelen. Ellers vil webdelen være tom (ingen marg og ingen utfylling) i visningsmodus."
+                LinkToVerticalLabelHoverMessage: "Filtrene vil bare vises hvis den valgte vertikalen samsvarer med de som er konfigurert for denne webdelen. Ellers vil webdelen være tom (ingen marg og ingen utfylling) i visningsmodus.",
+                BidirectionalConnectionWarning: "En eller flere tilkoblede søkeresultat-webdeler er ikke konfigurert til å koble tilbake til denne filter-webdelen. Begge webdelene må være koblet til hverandre for at filtre skal fungere korrekt."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Filterinnstillinger",

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,9 +16,10 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Gebruik data van deze webonderdelen",
                 UseDataResultsFromComponentsDescription: "Wanneer je verbindt met meer dan één webonderdeel worden aantallen en waarden voor gelijknamige filters samengevoegd.",
                 LinkToVerticalLabel: "Filters alleen weergeven als de volgende verticalen zijn geselecteerd",
-                LinkToVerticalLabelHoverMessage: "De filters worden alleen weergegeven als de geselecteerde verticale lijn overeenkomt met de filters die voor dit webonderdeel zijn geconfigureerd. Anders is het webonderdeel leeg (geen marge en geen opvulling) in de weergavemodus."
+                LinkToVerticalLabelHoverMessage: "De filters worden alleen weergegeven als de geselecteerde verticale lijn overeenkomt met de filters die voor dit webonderdeel zijn geconfigureerd. Anders is het webonderdeel leeg (geen marge en geen opvulling) in de weergavemodus.",
+                BidirectionalConnectionWarning: "Een of meer verbonden zoekresultaten webonderdelen zijn niet geconfigureerd om terug te verbinden met dit filters webonderdeel. Beide webonderdelen moeten met elkaar verbonden zijn om filters correct te laten werken."
             },
-            FiltersSettingsPage: { 
+            FiltersSettingsPage: {
                 SettingsGroupName: "Filter instellingen",
                 FilterOperator: "Bewerking om tussen filters te gebruiken"
             },

--- a/search-parts/src/webparts/searchFilters/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchFilters/loc/pl-pl.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Użyj danych z następujących Web Partów",
                 UseDataResultsFromComponentsDescription: "Jeśli połączysz więcej niż jeden Web Part, wartości filtrów i liczność będzie połączona po nazwach filtrów.",
                 LinkToVerticalLabel: "Wyświetlaj filtry tylko wtedy, gdy wybrane są następujące branże",
-                LinkToVerticalLabelHoverMessage: "Filtry będą wyświetlane tylko wtedy, gdy wybrana branża pasuje do tych skonfigurowanych dla tego składnika Web Part. W przeciwnym razie składnik Web Part będzie pusty (bez marginesów i dopełnienia) w trybie wyświetlania."
+                LinkToVerticalLabelHoverMessage: "Filtry będą wyświetlane tylko wtedy, gdy wybrana branża pasuje do tych skonfigurowanych dla tego składnika Web Part. W przeciwnym razie składnik Web Part będzie pusty (bez marginesów i dopełnienia) w trybie wyświetlania.",
+                BidirectionalConnectionWarning: "Jeden lub więcej połączonych składników Web Part wyników wyszukiwania nie zostało skonfigurowanych do połączenia zwrotnego z tym składnikiem Web Part filtrów. Oba składniki Web Part muszą być ze sobą połączone, aby filtry działały poprawnie."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Ustawienia filtrów",

--- a/search-parts/src/webparts/searchFilters/loc/pt-br.js
+++ b/search-parts/src/webparts/searchFilters/loc/pt-br.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Usar dados destas Web Parts",
                 UseDataResultsFromComponentsDescription: "Se você conectar mais de uma Web Part, os valores e contadores do filtro vão ser mesclados em nomes de filtro similares.",
                 LinkToVerticalLabel: "Exibir filtros somente quando as seguintes verticais forem selecionadas",
-                LinkToVerticalLabelHoverMessage: "Os filtros serão exibidos somente se a vertical selecionada combinar com uma das configuradas para esta Web Part. Caso contrário, a Web Part ficará em branco (sem margens nem preenchimento) no mode de exibição."
+                LinkToVerticalLabelHoverMessage: "Os filtros serão exibidos somente se a vertical selecionada combinar com uma das configuradas para esta Web Part. Caso contrário, a Web Part ficará em branco (sem margens nem preenchimento) no mode de exibição.",
+                BidirectionalConnectionWarning: "Uma ou mais Web Parts de resultados de pesquisa conectadas não foram configuradas para se conectar de volta a esta Web Part de filtros. Ambas as Web Parts devem estar conectadas entre si para que os filtros funcionem corretamente."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Configurações dos filtros",

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -16,7 +16,8 @@ define([], function() {
                 UseDataResultsFromComponentsLabel: "Använd data från dessa webbdelar",
                 UseDataResultsFromComponentsDescription: "Om du ansluter mer än en webbdel slås filtervärden samman till liknande filternamn.",
                 LinkToVerticalLabel: "Visa filter endast när följande vertikaler är valda",
-                LinkToVerticalLabelHoverMessage: "Filtren kommer endast att visas om den valda vertikalen matchar de som konfigurerats för den här webbdelen. Annars kommer webbdelen att vara tom (ingen marginal och ingen utfyllnad) i visningsläge."
+                LinkToVerticalLabelHoverMessage: "Filtren kommer endast att visas om den valda vertikalen matchar de som konfigurerats för den här webbdelen. Annars kommer webbdelen att vara tom (ingen marginal och ingen utfyllnad) i visningsläge.",
+                BidirectionalConnectionWarning: "En eller flera anslutna sökresultatwebbdelar har inte konfigurerats för att ansluta tillbaka till denna filterwebbdel. Båda webbdelarna måste vara anslutna till varandra för att filtren ska fungera korrekt."
             },
             FiltersSettingsPage: {
                 SettingsGroupName: "Filterinställningar",

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1796,8 +1796,12 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             if (this.properties.filtersDataSourceReference && this._filtersConnectionSourceData) {
                 const filterData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
                 if (filterData && filterData.connectedResultsSourceReferences) {
+                    // Extract sourceId from each reference (format: "sourceId:propertyId") and check if it ends with this web part's instanceId
                     const isConnectedBack = filterData.connectedResultsSourceReferences.some(
-                        ref => ref.indexOf(this.instanceId) !== -1
+                        ref => {
+                            const sourceId = ref.split(':')[0];
+                            return sourceId.endsWith(this.instanceId);
+                        }
                     );
                     if (!isConnectedBack) {
                         filtersConnectionFields.push(

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -379,6 +379,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 // Pass the Handlebars context to consumers, so they can register custom helpers for their own services 
                 this._currentDataResultsSourceData.handlebarsContext = this.templateService.Handlebars;
                 this._currentDataResultsSourceData.totalCount = this.dataSource?.getItemCount();
+                this._currentDataResultsSourceData.connectedFilterSourceReference = this.properties.filtersDataSourceReference;
 
                 return this._currentDataResultsSourceData;
 
@@ -1790,6 +1791,24 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     label: webPartStrings.PropertyPane.ConnectionsPage.UseFiltersFromComponentLabel
                 })
             );
+
+            // Check bidirectional connection: does the filter web part also connect back to this results web part?
+            if (this.properties.filtersDataSourceReference && this._filtersConnectionSourceData) {
+                const filterData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
+                if (filterData && filterData.connectedResultsSourceReferences) {
+                    const isConnectedBack = filterData.connectedResultsSourceReferences.some(
+                        ref => ref.indexOf(this.instanceId) !== -1
+                    );
+                    if (!isConnectedBack) {
+                        filtersConnectionFields.push(
+                            this._propertyPaneWebPartInformation({
+                                description: `<span style="color: #d83b01;">⚠ ${webPartStrings.PropertyPane.ConnectionsPage.BidirectionalConnectionWarning}</span>`,
+                                key: 'bidirectionalFilterWarning'
+                            })
+                        );
+                    }
+                }
+            }
         }
 
         return filtersConnectionFields;

--- a/search-parts/src/webparts/searchResults/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchResults/loc/cs-cz.js
@@ -115,7 +115,8 @@ define([], function () {
                 SearchQueryTextDefaultValue: "Výchozí hodnota",
                 SourceDestinationFieldLabel: "Název cílového pole",
                 SourceDestinationFieldDescription: "Cílové pole, které se použije v tomto webovém dílu pro shodu s vybranými hodnotami",
-                AvailableFieldValuesFromResults: "Pole obsahující hodnotu filtru"
+                AvailableFieldValuesFromResults: "Pole obsahující hodnotu filtru",
+                BidirectionalConnectionWarning: "Připojený webový díl filtrů není nakonfigurován pro zpětné připojení k tomuto webovému dílu výsledků vyhledávání. Oba webové díly musí být vzájemně propojeny, aby filtry fungovaly správně."
             },
             InformationPage: {
                 Extensibility: {
@@ -136,13 +137,15 @@ define([], function () {
                 },
                 EnableQueryModificationLabel: "Povolit úpravy dotazu",
                 DisableQueryModificationLabel: "Zakázat úpravy dotazu"
-            }        },
+            }
+        },
         Styling: {
             StylingOptionsGroupName: "Možnosti stylu",
             ResultsBackgroundColorLabel: "Barva pozadí výsledků",
             ResultsBorderColorLabel: "Barva okraje výsledků",
             ResultsBorderThicknessLabel: "Tloušťka okraje výsledků",
             ResetToDefaultLabel: "Obnovit výchozí styl",
-            ResetToDefaultDescription: "Obnovit všechny možnosti stylu na výchozí hodnoty"        }
+            ResetToDefaultDescription: "Obnovit všechny možnosti stylu na výchozí hodnoty"
+        }
     };
 });

--- a/search-parts/src/webparts/searchResults/loc/da-dk.js
+++ b/search-parts/src/webparts/searchResults/loc/da-dk.js
@@ -1,146 +1,149 @@
-define([], function() {
-  return {
-    General: {
-      PlaceHolder: {
-        EditLabel: "Redigér",
-        IconText: "Søgeresultats-webpart af @PnP",
-        Description: "Viser søgeresultater fra SharePoint eller Microsoft Search.",
-        ConfigureBtnLabel: "Konfigurér"
-      },
-      WebPartDefaultTitle: "Søgeresultats-webpart",
-      ShowBlankEditInfoMessage: "Intet resultat returneret på denne forespørgsel. Denne webpart vil forblive blank i visningstilstand ifølge parametrene.",
-      CurrentVerticalNotSelectedMessage: "Den valgte vertikal matcher ikke med den, der er associeret denne webpart. Den vil forblive blank i visningstilstand."
-    },
-    PropertyPane: {
-      DataSourcePage: {
-        DataSourceConnectionGroupName: "Tilgængelige datakilder",
-        PagingOptionsGroupName: "Sidevisninger",
-        ItemsCountPerPageFieldName: "Antal elementer per side",
-        PagingRangeFieldName: "Antal sider der skal vises i rækkefølge",
-        ShowPagingFieldName: "Vis sideantal",
-        HidePageNumbersFieldName: "Skjul sidenumre",
-        HideNavigationFieldName: "Skjul navigationsknapper (foregående side, næste side)",
-        HideFirstLastPagesFieldName: "Skjul første/sidste navigationsknapper",
-        HideDisabledFieldName: "Skjul navigationsknapper (foregående, næste, første, sidste), hvis de er deaktiveret.",
-        TemplateSlots: {
-          GroupName: "Layout-slots",
-          ConfigureSlotsLabel: "Redigér layout-slots for denne datakilde",
-          ConfigureSlotsBtnLabel: "Tilpas",
-          MissingSlotsMessage: "Manglende slots fundet i layoutskabelon: {0}",
-          ConfigureSlotsPanelHeader: "Layout-slots",
-          ConfigureSlotsPanelDescription: "Her kan du tilføje de slots, der skal bruges til de forskellige layouts. Et slot er en pladsholder-variabel, som du indsætter i din skabelon, hvor værdien vil blive erstattet med et feltets værdi fra en datakilde. På denne måde vil dine skabeloner blive mere generiske og nemmere at genbruge. For at bruge dem, skal du bruge `{{slot item @root.slots.<SlotName>}}` Handlebars-udtrykket.",
-          SlotNameFieldName: "Slot-navn",
-          SlotFieldFieldName: "Slot-felt",
-          SlotFieldPlaceholderName: "Vælg et felt"
-        }
-      },
-      LayoutPage: {
-        LayoutSelectionGroupName: "Tilgængelige layouts",
-        LayoutTemplateOptionsGroupName: "Layout-muligheder",
-        CommonOptionsGroupName: "Almindelig",
-        TemplateUrlFieldLabel: "Anvend en URL fra en ekstern skabelon",
-        TemplateUrlPlaceholder: "https://myfile.html",
-        ErrorTemplateExtension: "Skabelonen skal være en valid .htm or .html fil",
-        ErrorTemplateResolve: "Kan ikke læse the specificerede skabelon. Fejlbeskrivelse: '{0}'",
-        DialogButtonLabel: "Redigér resultatsskabelonen",
-        DialogTitle: "Redigér resultatsskabelonen",
-        MissingSlotsMessage: "Følgende slots er ikke blevet konfigureret: {0}",
-        ShowSelectedFilters: "Vis valgte filtre",
-        ShowBlankIfNoResult: "Skjul denne webpart, hvis der ikke er noget at vise.",
-        ShowResultsCount: "Vis antallet af resultater",
-        HandlebarsRenderTypeLabel: "Handlebars/HTML",
-        HandlebarsRenderTypeDesc: "Vælg layout baseret på HTML, CSS og Handlebars",
-        AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
-        AdaptiveCardsRenderTypeDesc: "Vælg layout baseret på JSON adaptive kort",        
-        Handlebars: {
-          UseMicrosoftGraphToolkit: "brug Microsoft Graph Toolkit",
-          ResultTypes: {
-            ResultTypeslabel: "Resultattyper",
-            ResultTypesDescription: "Her kan du tilføje de templates, du vil bruge til resultaterne, i overensstemmelse med en eller flere tilstande. Tilstande er evalueret i den konfigurerede rækkefølge og eksterne skabeloner har forrang over integrerede skabeloner. Vær sikker på at felterne på datakilden, du bruger, findes i datasvaret.",
-            InlineTemplateContentLabel: "Integreret skabelon",
-            EditResultTypesLabel: "Redigér resultattyper",
-            ConditionPropertyLabel: "Felt på datakilde",
-            ConditionValueLabel: "Tilstandsværdi",
-            CondtionOperatorValue: "Operatør",
-            ExternalUrlLabel: "Ekstern skabelon-URL",
-            EqualOperator: "Er lig med",
-            NotEqualOperator: "Er ikke lig med",
-            ContainsOperator: "Indeholder",
-            StartsWithOperator: "Starter med",
-            NotNullOperator: "Er ikke nul",
-            GreaterOrEqualOperator: "Større eller lig med",
-            GreaterThanOperator: "Større end",
-            LessOrEqualOperator: "Mindre eller lig med",
-            LessThanOperator: "Mindre end",
-            CancelButtonText: "Annuller",
-            DialogButtonText: "Redigér skabelon",
-            DialogTitle: "Redigér resultatsskabelon",
-            SaveButtonText: "Gem"
-          },
-          AllowItemSelection: "Tillad valg af elementer",
-          AllowMultipleItemSelection: "Tillad flere valg",
-          SelectionPreservedOnEmptyClick: "Bevar valg ved tomt klik",
-          SelectionModeLabel: "Valgtilstand",
-          AsTokensSelectionMode: "Behandl valgte værdier som tokens (manuel tilstand)",
-          AsDataFiltersSelectionMode: "Behandle valgte værdier som filtre (standardtilstand)",
-          AsDataFiltersDescription: "I denne tilstand sendes valgte værdier til datakilden som almindelige filtre",
-          AsTokensDescription: "I denne tilstand bruges de valgte værdier manuelt gennem tokens og tilgængelige metoder. Eksempel med SharePoint søgeforespørgselsskabelon: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
-          FilterValuesOperator: "Den logiske operator, der skal bruges mellem valgte værdier",
-          FieldToConsumeLabel: "Kildefelt til at anvende",
-          FieldToConsumeDescription: "Brug denne feltværdi til udvalgte varer",
+define([], function () {
+    return {
+        General: {
+            PlaceHolder: {
+                EditLabel: "Redigér",
+                IconText: "Søgeresultats-webpart af @PnP",
+                Description: "Viser søgeresultater fra SharePoint eller Microsoft Search.",
+                ConfigureBtnLabel: "Konfigurér"
+            },
+            WebPartDefaultTitle: "Søgeresultats-webpart",
+            ShowBlankEditInfoMessage: "Intet resultat returneret på denne forespørgsel. Denne webpart vil forblive blank i visningstilstand ifølge parametrene.",
+            CurrentVerticalNotSelectedMessage: "Den valgte vertikal matcher ikke med den, der er associeret denne webpart. Den vil forblive blank i visningstilstand."
         },
-        AdaptiveCards: {
-          HostConfigFieldLabel: "Værtskonfiguration"
-        }
-      },
-      ConnectionsPage: {
-        ConnectionsPageGroupName: "Tilgængelige forbindelser",
-        UseFiltersWebPartLabel: "Forbind til en filter-webpart",
-        UseFiltersFromComponentLabel: "Brug filtre fra dette komponent",
-        UseDynamicFilteringsWebPartLabel: "Opret forbindelse til en dataresultatwebdel",
-        UseDataResultsFromComponentsLabel: "Brug data fra denne webdel",
-        UseDataResultsFromComponentsDescription: "Brug data fra udvalgte elementer i disse webdele",        
-        UseSearchVerticalsWebPartLabel: "Forbind til en vertikal-webpart",
-        UseSearchVerticalsFromComponentLabel: "Brug vertikaler fra dette komponent",
-        LinkToVerticalLabel: "Vis kun data, når følgende vertikaler er valgt",
-        LinkToVerticalLabelHoverMessage: "Resultaterne vil kun blive vist, hvis de valgte vertikaler matcher med den, der er konfigureret til denne webpart. Ellers vil denne webpart være blank.",
-        UseInputQueryText: "Anvend input til forespørgselstekst",
-        UseInputQueryTextHoverMessage: "Anvend {inputQueryText} token i din datakilde for at hente denne værdi",
-        SearchQueryTextFieldLabel: "Forespørgselstekst",
-        SearchQueryTextFieldDescription: "",
-        SearchQueryPlaceHolderText: "Indsæt forespørgselstekst...",
-        InputQueryTextStaticValue: "Statisk værdi",
-        InputQueryTextDynamicValue: "Dynamisk værdi",
-        SearchQueryTextUseDefaultQuery: "Brug en standard værdi",
-        SearchQueryTextDefaultValue: "Standardværdi",
-        SourceDestinationFieldLabel: "Navn på destinationsfelt",
-        SourceDestinationFieldDescription: "Destinationsfelt til brug i denne webdel for at matche de valgte værdier",
-        AvailableFieldValuesFromResults: "Felt, der indeholder filterværdien"        
-      },
-      InformationPage: {
-        Extensibility: {
-          PanelHeader: "Konfigurér extensibility-biblioteker så de indlæser ved opstart.",
-          PanelDescription: "Tilføj/Fjern ID på dit extensibility-bibliotek her. Du kan specificere et visningsnavn og beslutte, om biblioteket skal indlæses eller ej ved opstart. Kun brugerdefinerede datakilder, layouts, web-komponenter og Handlebars-hjælpere vil blive loadet her.",
+        PropertyPane: {
+            DataSourcePage: {
+                DataSourceConnectionGroupName: "Tilgængelige datakilder",
+                PagingOptionsGroupName: "Sidevisninger",
+                ItemsCountPerPageFieldName: "Antal elementer per side",
+                PagingRangeFieldName: "Antal sider der skal vises i rækkefølge",
+                ShowPagingFieldName: "Vis sideantal",
+                HidePageNumbersFieldName: "Skjul sidenumre",
+                HideNavigationFieldName: "Skjul navigationsknapper (foregående side, næste side)",
+                HideFirstLastPagesFieldName: "Skjul første/sidste navigationsknapper",
+                HideDisabledFieldName: "Skjul navigationsknapper (foregående, næste, første, sidste), hvis de er deaktiveret.",
+                TemplateSlots: {
+                    GroupName: "Layout-slots",
+                    ConfigureSlotsLabel: "Redigér layout-slots for denne datakilde",
+                    ConfigureSlotsBtnLabel: "Tilpas",
+                    MissingSlotsMessage: "Manglende slots fundet i layoutskabelon: {0}",
+                    ConfigureSlotsPanelHeader: "Layout-slots",
+                    ConfigureSlotsPanelDescription: "Her kan du tilføje de slots, der skal bruges til de forskellige layouts. Et slot er en pladsholder-variabel, som du indsætter i din skabelon, hvor værdien vil blive erstattet med et feltets værdi fra en datakilde. På denne måde vil dine skabeloner blive mere generiske og nemmere at genbruge. For at bruge dem, skal du bruge `{{slot item @root.slots.<SlotName>}}` Handlebars-udtrykket.",
+                    SlotNameFieldName: "Slot-navn",
+                    SlotFieldFieldName: "Slot-felt",
+                    SlotFieldPlaceholderName: "Vælg et felt"
+                }
+            },
+            LayoutPage: {
+                LayoutSelectionGroupName: "Tilgængelige layouts",
+                LayoutTemplateOptionsGroupName: "Layout-muligheder",
+                CommonOptionsGroupName: "Almindelig",
+                TemplateUrlFieldLabel: "Anvend en URL fra en ekstern skabelon",
+                TemplateUrlPlaceholder: "https://myfile.html",
+                ErrorTemplateExtension: "Skabelonen skal være en valid .htm or .html fil",
+                ErrorTemplateResolve: "Kan ikke læse the specificerede skabelon. Fejlbeskrivelse: '{0}'",
+                DialogButtonLabel: "Redigér resultatsskabelonen",
+                DialogTitle: "Redigér resultatsskabelonen",
+                MissingSlotsMessage: "Følgende slots er ikke blevet konfigureret: {0}",
+                ShowSelectedFilters: "Vis valgte filtre",
+                ShowBlankIfNoResult: "Skjul denne webpart, hvis der ikke er noget at vise.",
+                ShowResultsCount: "Vis antallet af resultater",
+                HandlebarsRenderTypeLabel: "Handlebars/HTML",
+                HandlebarsRenderTypeDesc: "Vælg layout baseret på HTML, CSS og Handlebars",
+                AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
+                AdaptiveCardsRenderTypeDesc: "Vælg layout baseret på JSON adaptive kort",
+                Handlebars: {
+                    UseMicrosoftGraphToolkit: "brug Microsoft Graph Toolkit",
+                    ResultTypes: {
+                        ResultTypeslabel: "Resultattyper",
+                        ResultTypesDescription: "Her kan du tilføje de templates, du vil bruge til resultaterne, i overensstemmelse med en eller flere tilstande. Tilstande er evalueret i den konfigurerede rækkefølge og eksterne skabeloner har forrang over integrerede skabeloner. Vær sikker på at felterne på datakilden, du bruger, findes i datasvaret.",
+                        InlineTemplateContentLabel: "Integreret skabelon",
+                        EditResultTypesLabel: "Redigér resultattyper",
+                        ConditionPropertyLabel: "Felt på datakilde",
+                        ConditionValueLabel: "Tilstandsværdi",
+                        CondtionOperatorValue: "Operatør",
+                        ExternalUrlLabel: "Ekstern skabelon-URL",
+                        EqualOperator: "Er lig med",
+                        NotEqualOperator: "Er ikke lig med",
+                        ContainsOperator: "Indeholder",
+                        StartsWithOperator: "Starter med",
+                        NotNullOperator: "Er ikke nul",
+                        GreaterOrEqualOperator: "Større eller lig med",
+                        GreaterThanOperator: "Større end",
+                        LessOrEqualOperator: "Mindre eller lig med",
+                        LessThanOperator: "Mindre end",
+                        CancelButtonText: "Annuller",
+                        DialogButtonText: "Redigér skabelon",
+                        DialogTitle: "Redigér resultatsskabelon",
+                        SaveButtonText: "Gem"
+                    },
+                    AllowItemSelection: "Tillad valg af elementer",
+                    AllowMultipleItemSelection: "Tillad flere valg",
+                    SelectionPreservedOnEmptyClick: "Bevar valg ved tomt klik",
+                    SelectionModeLabel: "Valgtilstand",
+                    AsTokensSelectionMode: "Behandl valgte værdier som tokens (manuel tilstand)",
+                    AsDataFiltersSelectionMode: "Behandle valgte værdier som filtre (standardtilstand)",
+                    AsDataFiltersDescription: "I denne tilstand sendes valgte værdier til datakilden som almindelige filtre",
+                    AsTokensDescription: "I denne tilstand bruges de valgte værdier manuelt gennem tokens og tilgængelige metoder. Eksempel med SharePoint søgeforespørgselsskabelon: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
+                    FilterValuesOperator: "Den logiske operator, der skal bruges mellem valgte værdier",
+                    FieldToConsumeLabel: "Kildefelt til at anvende",
+                    FieldToConsumeDescription: "Brug denne feltværdi til udvalgte varer",
+                },
+                AdaptiveCards: {
+                    HostConfigFieldLabel: "Værtskonfiguration"
+                }
+            },
+            ConnectionsPage: {
+                ConnectionsPageGroupName: "Tilgængelige forbindelser",
+                UseFiltersWebPartLabel: "Forbind til en filter-webpart",
+                UseFiltersFromComponentLabel: "Brug filtre fra dette komponent",
+                UseDynamicFilteringsWebPartLabel: "Opret forbindelse til en dataresultatwebdel",
+                UseDataResultsFromComponentsLabel: "Brug data fra denne webdel",
+                UseDataResultsFromComponentsDescription: "Brug data fra udvalgte elementer i disse webdele",
+                UseSearchVerticalsWebPartLabel: "Forbind til en vertikal-webpart",
+                UseSearchVerticalsFromComponentLabel: "Brug vertikaler fra dette komponent",
+                LinkToVerticalLabel: "Vis kun data, når følgende vertikaler er valgt",
+                LinkToVerticalLabelHoverMessage: "Resultaterne vil kun blive vist, hvis de valgte vertikaler matcher med den, der er konfigureret til denne webpart. Ellers vil denne webpart være blank.",
+                UseInputQueryText: "Anvend input til forespørgselstekst",
+                UseInputQueryTextHoverMessage: "Anvend {inputQueryText} token i din datakilde for at hente denne værdi",
+                SearchQueryTextFieldLabel: "Forespørgselstekst",
+                SearchQueryTextFieldDescription: "",
+                SearchQueryPlaceHolderText: "Indsæt forespørgselstekst...",
+                InputQueryTextStaticValue: "Statisk værdi",
+                InputQueryTextDynamicValue: "Dynamisk værdi",
+                SearchQueryTextUseDefaultQuery: "Brug en standard værdi",
+                SearchQueryTextDefaultValue: "Standardværdi",
+                SourceDestinationFieldLabel: "Navn på destinationsfelt",
+                SourceDestinationFieldDescription: "Destinationsfelt til brug i denne webdel for at matche de valgte værdier",
+                AvailableFieldValuesFromResults: "Felt, der indeholder filterværdien",
+                BidirectionalConnectionWarning: "Den tilsluttede filterwebdel er ikke konfigureret til at forbinde tilbage til denne søgeresultatwebdel. Begge webdele skal være forbundet til hinanden, for at filtre kan fungere korrekt."
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurér extensibility-biblioteker så de indlæser ved opstart.",
+                    PanelDescription: "Tilføj/Fjern ID på dit extensibility-bibliotek her. Du kan specificere et visningsnavn og beslutte, om biblioteket skal indlæses eller ej ved opstart. Kun brugerdefinerede datakilder, layouts, web-komponenter og Handlebars-hjælpere vil blive loadet her.",
+                },
+                EnableTelemetryLabel: "PnP telemetri",
+                EnableTelemetryOn: "Slå telemetri til",
+                EnableTelemetryOff: "Slå telemetri fra"
+            },
+            CustomQueryModifier: {
+                EditQueryModifiersLabel: "Konfigurere tilgængelige brugerdefinerede forespørgselsmodifikatorer",
+                QueryModifiersLabel: "Tilpassede forespørgselsmodifikatorer",
+                QueryModifiersDescription: "Aktivere eller deaktivere individuelle brugerdefinerede forespørgselsmodifikatorer",
+                EnabledPropertyLabel: "Aktiveret",
+                ModifierNamePropertyLabel: "Navn",
+                ModifierDescriptionPropertyLabel: "Beskrivelse",
+                EndWhenSuccessfullPropertyLabel: "Afslutter, når det lykkes"
+            }
         },
-        EnableTelemetryLabel: "PnP telemetri",
-        EnableTelemetryOn: "Slå telemetri til",
-        EnableTelemetryOff: "Slå telemetri fra"
-      },
-      CustomQueryModifier: {          
-          EditQueryModifiersLabel: "Konfigurere tilgængelige brugerdefinerede forespørgselsmodifikatorer",
-          QueryModifiersLabel: "Tilpassede forespørgselsmodifikatorer",
-          QueryModifiersDescription: "Aktivere eller deaktivere individuelle brugerdefinerede forespørgselsmodifikatorer",
-          EnabledPropertyLabel: "Aktiveret",
-          ModifierNamePropertyLabel: "Navn",
-          ModifierDescriptionPropertyLabel: "Beskrivelse",
-          EndWhenSuccessfullPropertyLabel:"Afslutter, når det lykkes"        
-      }    },
-    Styling: {
-      StylingOptionsGroupName: "Stilindstillinger",
-      ResultsBackgroundColorLabel: "Resultater baggrundsfarve",
-      ResultsBorderColorLabel: "Resultater kantfarve",
-      ResultsBorderThicknessLabel: "Resultater kanttykkelse",
-      ResetToDefaultLabel: "Gendan til standardstil",
-      ResetToDefaultDescription: "Gendan alle stilmuligheder til deres standardværdier"    }
-  }
+        Styling: {
+            StylingOptionsGroupName: "Stilindstillinger",
+            ResultsBackgroundColorLabel: "Resultater baggrundsfarve",
+            ResultsBorderColorLabel: "Resultater kantfarve",
+            ResultsBorderThicknessLabel: "Resultater kanttykkelse",
+            ResetToDefaultLabel: "Gendan til standardstil",
+            ResetToDefaultDescription: "Gendan alle stilmuligheder til deres standardværdier"
+        }
+    }
 });

--- a/search-parts/src/webparts/searchResults/loc/de-de.js
+++ b/search-parts/src/webparts/searchResults/loc/de-de.js
@@ -115,7 +115,8 @@ define([], function () {
                 SearchQueryTextDefaultValue: "Standardwert",
                 SourceDestinationFieldLabel: "Ergebnis Feldname",
                 SourceDestinationFieldDescription: "Zielfeld, das in diesem Webpart verwendet werden soll, um die ausgewählten Werte abzugleichen",
-                AvailableFieldValuesFromResults: "Feld, das den Filterwert enthält"
+                AvailableFieldValuesFromResults: "Feld, das den Filterwert enthält",
+                BidirectionalConnectionWarning: "Das verbundene Filter-Webpart wurde nicht so konfiguriert, dass es eine Rückverbindung zu diesem Suchergebnis-Webpart herstellt. Beide Webparts müssen miteinander verbunden sein, damit die Filter korrekt funktionieren."
             },
             InformationPage: {
                 Extensibility: {

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -115,7 +115,8 @@ define([], function () {
                 SearchQueryTextDefaultValue: "Default value",
                 SourceDestinationFieldLabel: "Destination field name",
                 SourceDestinationFieldDescription: "Destination field to use in this Web Part to match the selected values",
-                AvailableFieldValuesFromResults: "Field containing the filter value"
+                AvailableFieldValuesFromResults: "Field containing the filter value",
+                BidirectionalConnectionWarning: "The connected filters Web Part has not been configured to connect back to this search results Web Part. Both web parts must be connected to each other for filters to work correctly."
             },
             InformationPage: {
                 Extensibility: {

--- a/search-parts/src/webparts/searchResults/loc/es-es.js
+++ b/search-parts/src/webparts/searchResults/loc/es-es.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -51,7 +51,7 @@ define([], function() {
                 HandlebarsRenderTypeLabel: "Handlebars/HTML",
                 HandlebarsRenderTypeDesc: "Selecciona diseños basados en HTML, CSS y Handlebars",
                 AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
-                AdaptiveCardsRenderTypeDesc: "Seleccione diseños basados en tarjetas adaptables JSON",                
+                AdaptiveCardsRenderTypeDesc: "Seleccione diseños basados en tarjetas adaptables JSON",
                 Handlebars: {
                     UseMicrosoftGraphToolkit: "Utilizar Microsoft Graph Toolkit",
                     ResultTypes: {
@@ -91,7 +91,7 @@ define([], function() {
                 },
                 AdaptiveCards: {
                     HostConfigFieldLabel: "Configuración de host"
-                }                
+                }
             },
             ConnectionsPage: {
                 ConnectionsPageGroupName: "Conexiones disponibles",
@@ -99,7 +99,7 @@ define([], function() {
                 UseFiltersFromComponentLabel: "Utilizar los filtros de este componente",
                 UseDynamicFilteringsWebPartLabel: "Conectar con un Web Part de resultados de búsqueda",
                 UseDataResultsFromComponentsLabel: "Utilizar los datos de este Web Part",
-                UseDataResultsFromComponentsDescription: "Utilice los datos de los elementos seleccionados en estos Web Parts",                
+                UseDataResultsFromComponentsDescription: "Utilice los datos de los elementos seleccionados en estos Web Parts",
                 UseSearchVerticalsWebPartLabel: "Conectar con un Web Part vertical",
                 UseSearchVerticalsFromComponentLabel: "Utilizar las verticales de este componente",
                 LinkToVerticalLabel: "Mostrar datos sólo cuando se selecciona la siguiente vertical",
@@ -115,7 +115,8 @@ define([], function() {
                 SearchQueryTextDefaultValue: "Valor por defecto",
                 SourceDestinationFieldLabel: "Nombre del campo de destino",
                 SourceDestinationFieldDescription: "Campo de destino a utilizar en este Web Part para que coincida con los valores seleccionados",
-                AvailableFieldValuesFromResults: "Campo que contiene el valor del filtro"
+                AvailableFieldValuesFromResults: "Campo que contiene el valor del filtro",
+                BidirectionalConnectionWarning: "El Web Part de filtros conectado no ha sido configurado para conectarse de vuelta a este Web Part de resultados de búsqueda. Ambos Web Parts deben estar conectados entre sí para que los filtros funcionen correctamente."
             },
             InformationPage: {
                 Extensibility: {
@@ -124,13 +125,13 @@ define([], function() {
                 }
             },
             CustomQueryModifier: {
-                  EditQueryModifiersLabel: "Configurar los modificadores de consulta personalizados disponibles",
-                  QueryModifiersLabel: "Modificadores de consulta personalizados",
-                  QueryModifiersDescription: "Habilitar o deshabilitar modificadores de consulta personalizados individuales",
-                  EnabledPropertyLabel: "Habilitado",
-                  ModifierNamePropertyLabel: "Nombre",
-                  ModifierDescriptionPropertyLabel: "Descripción",
-                  EndWhenSuccessfullPropertyLabel:"Finalizar cuando se ha realizado con éxito"              
+                EditQueryModifiersLabel: "Configurar los modificadores de consulta personalizados disponibles",
+                QueryModifiersLabel: "Modificadores de consulta personalizados",
+                QueryModifiersDescription: "Habilitar o deshabilitar modificadores de consulta personalizados individuales",
+                EnabledPropertyLabel: "Habilitado",
+                ModifierNamePropertyLabel: "Nombre",
+                ModifierDescriptionPropertyLabel: "Descripción",
+                EndWhenSuccessfullPropertyLabel: "Finalizar cuando se ha realizado con éxito"
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchResults/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchResults/loc/fi-fi.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -99,7 +99,7 @@ define([], function() {
                 UseFiltersFromComponentLabel: "Käytä suodattimia tästä webosasta",
                 UseDynamicFilteringsWebPartLabel: "Yhdistä hakutulosten webosaan",
                 UseDataResultsFromComponentsLabel: "Käytä tuloksia tästä webosasta",
-                UseDataResultsFromComponentsDescription: "Käytä tuloksia valituista kohteista näissä webosissa",                
+                UseDataResultsFromComponentsDescription: "Käytä tuloksia valituista kohteista näissä webosissa",
                 UseSearchVerticalsWebPartLabel: "Yhdistä vertikaalien webosaan",
                 UseSearchVerticalsFromComponentLabel: "Käytä vertikaaleja näistä webosista",
                 LinkToVerticalLabel: "Näytä tulokset vain, kun seuraava vertikaali on valittu",
@@ -115,7 +115,8 @@ define([], function() {
                 SearchQueryTextDefaultValue: "Oletusarvo",
                 SourceDestinationFieldLabel: "Kohdekentän nimi",
                 SourceDestinationFieldDescription: "Tässä webosassa käytettävä kohdekenttä, joka vastaa valittuihin arvoihin",
-                AvailableFieldValuesFromResults: "Kenttä joka sisältää suodatinarvon"
+                AvailableFieldValuesFromResults: "Kenttä joka sisältää suodatinarvon",
+                BidirectionalConnectionWarning: "Yhdistettyä suodatin-webosaa ei ole määritetty yhdistämään takaisin tähän hakutulokset-webosaan. Molemmat webosat on yhdistettävä toisiinsa, jotta suodattimet toimivat oikein."
             },
             InformationPage: {
                 Extensibility: {
@@ -124,13 +125,13 @@ define([], function() {
                 }
             },
             CustomQueryModifier: {
-                  EditQueryModifiersLabel: "Käytettävissä olevien mukautettujen kyselyn muokkaimien määrittäminen",
-                  QueryModifiersLabel: "Mukautetut kyselyn muokkaajat",
-                  QueryModifiersDescription: "Ota käyttöön tai poista käytöstä yksittäisiä mukautettuja kyselyn muokkaajia.",
-                  EnabledPropertyLabel: "Enabled",
-                  ModifierNamePropertyLabel: "Nimi",
-                  ModifierDescriptionPropertyLabel: "Kuvaus",
-                  EndWhenSuccessfullPropertyLabel:"Loppuu, kun onnistuu"              
+                EditQueryModifiersLabel: "Käytettävissä olevien mukautettujen kyselyn muokkaimien määrittäminen",
+                QueryModifiersLabel: "Mukautetut kyselyn muokkaajat",
+                QueryModifiersDescription: "Ota käyttöön tai poista käytöstä yksittäisiä mukautettuja kyselyn muokkaajia.",
+                EnabledPropertyLabel: "Enabled",
+                ModifierNamePropertyLabel: "Nimi",
+                ModifierDescriptionPropertyLabel: "Kuvaus",
+                EndWhenSuccessfullPropertyLabel: "Loppuu, kun onnistuu"
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -1,147 +1,148 @@
-define([], function() {
-  return {
-    General: {
-      PlaceHolder: {
-            EditLabel: "Modifier",
-            IconText: "Composant Web des résultats de recherche par @PnP",
-            Description: "Affiche les résultats de la recherche dans SharePoint ou Microsoft.",
-            ConfigureBtnLabel: "Configurer"
-      },
-      WebPartDefaultTitle: "Composant Web des résultats de recherche",
-      ShowBlankEditInfoMessage: "Cette requête n’a donné aucun résultat. Ce composant Web doit demeurer vide en mode d’affichage en fonction des critères.",
-      CurrentVerticalNotSelectedMessage: "Le secteur vertical sélectionné ne correspond pas à ce composant Web. Il doit demeurer vide en mode d’affichage."
-    },
-    PropertyPane: {
-      DataSourcePage: {
-            DataSourceConnectionGroupName: "Sources de données disponibles",
-            PagingOptionsGroupName: "Options de pagination",
-            ItemsCountPerPageFieldName: "Nombre d’éléments par page",
-            PagingRangeFieldName: "Nombre de pages à afficher dans la série",
-            ShowPagingFieldName: "Afficher la pagination",
-            HidePageNumbersFieldName: "Masquer les numéros de page",
-            HideNavigationFieldName: "Masquer les boutons de navigation (page précédente, page suivante)",
-            HideFirstLastPagesFieldName: "Masquer les boutons de navigation (première, dernière)",
-            HideDisabledFieldName: "Masquer les boutons de navigation (précédente, suivante, première, dernière) s’ils sont désactivés.",
-        TemplateSlots: {
-          GroupName: "Emplacements de la mise en page",
-          ConfigureSlotsLabel: "Modifier les emplacements de la mise en page pour cette source de données",
-          ConfigureSlotsBtnLabel: "Personnaliser",
-          MissingSlotsMessage: "Slots manquants trouvés dans le modèle de mise en page: {0}",
-          ConfigureSlotsPanelHeader: "Emplacements de la mise en page",
-          ConfigureSlotsPanelDescription: "Ajoutez ici les emplacements à utiliser pour les différentes mises en page. Un emplacement est une variable d’espace réservé que vous ajoutez à vos modèles et dont la valeur sera remplacée de façon dynamique par une valeur de champ source de données. Ainsi, vos modèles deviendront plus génériques et réutilisables, peu importe les champs de la source des données. Pour les utiliser, utilisez l’expression entre accolades `{{slot item @root.slots.<SlotName>}}`.",
-          SlotNameFieldName: "Nom de l’emplacement",
-          SlotFieldFieldName: "Champ de l’emplacement",
-          SlotFieldPlaceholderName: "Choisissez un champ"
-        }
-      },
-      LayoutPage: {
-        LayoutSelectionGroupName: "Mises en page disponibles",
-        LayoutTemplateOptionsGroupName: "Options de mise en page",
-        CommonOptionsGroupName: "Courantes",
-        TemplateUrlFieldLabel: "Utiliser une adresse URL de modèle externe",
-        TemplateUrlPlaceholder: "https://myfile.html",
-        ErrorTemplateExtension: "Le modèle doit être un fichier .txt, .htm ou .html valide",
-        ErrorTemplateResolve: "Impossible de résoudre le modèle indiqué. Renseignements sur l’erreur '{0}'",
-        DialogButtonLabel: "Modifier le modèle de résultats",
-        DialogTitle: "Modifier le modèle de résultats",
-        MissingSlotsMessage: "Les slots suivants n'ont pas été configurés: {0}",
-        ShowSelectedFilters: "Afficher les filtres sélectionnés",
-        ShowBlankIfNoResult: "Masquer ce composant Web s’il n’y a rien à afficher",
-        ShowResultsCount: "Afficher le nombre de résultats",
-        UseMicrosoftGraphToolkit: "Utiliser la boîte à outils Microsoft Graph",
-        HandlebarsRenderTypeLabel: "Handlebars/HTML",
-        HandlebarsRenderTypeDesc: "Sélectionnez un affichage basé sur HTML, CSS and Handlebars",
-        AdaptiveCardsRenderTypeLabel: "Cartes adaptatives",
-        AdaptiveCardsRenderTypeDesc: "Sélectionnez un affichage basé sur des cartes adaptatives JSON",
-        Handlebars: {
-          UseMicrosoftGraphToolkit: "Utiliser Microsoft Graph Toolkit",
-          ResultTypes: {
-            ResultTypeslabel: "Type de résultat",
-            ResultTypesDescription: "Ajoutez ici les modèles à utiliser pour les éléments de résultat selon une ou plusieurs conditions supplémentaires. Les conditions sont évaluées dans l’ordre configuré et les modèles externes ont préséance sur les modèles intégrés. Assurez-vous également que les champs de la source des données que vous utilisez sont présents dans la réponse aux données.",
-            InlineTemplateContentLabel: "Modèle intégré",
-            EditResultTypesLabel: "Modifier les types de résultats",
-            ConditionPropertyLabel: "Champ de source des données",
-            ConditionValueLabel: "Valeur de la condition",
-            CondtionOperatorValue: "Opérateur",
-            ExternalUrlLabel: "URL du modèle externe",
-            EqualOperator: "Égal à",
-            NotEqualOperator: "N’est pas égal à",
-            ContainsOperator: "Contient",
-            StartsWithOperator: "Commence par",
-            NotNullOperator: "N’est pas nul",
-            GreaterOrEqualOperator: "Supérieur ou égal à",
-            GreaterThanOperator: "Supérieur à",
-            LessOrEqualOperator: "Inférieur ou égal à",
-            LessThanOperator: "Inférieur à",
-            CancelButtonText: "Annuler",
-            DialogButtonLabel: "Modifier le modèle",
-            DialogButtonText: "Modifier le modèle",
-            DialogTitle: "Modifier le modèle de résultats",
-            SaveButtonText: "Enregistrer",
-          },
-          AllowItemSelection: "Autoriser la sélection d'éléments",
-          AllowMultipleItemSelection: "Autoriser la sélection multiple",
-          SelectionPreservedOnEmptyClick: "Conserver la sélection sur clic vide",
-          SelectionModeLabel: "Mode de sélection",
-          AsTokensSelectionMode: "Traiter les valeurs en tant que tokens (manuel)",
-          AsDataFiltersSelectionMode: "Traiter les valeurs en tant que filtres (default)",
-          AsDataFiltersDescription: "Dans ce mode, les éléments sélectionnés sont traités en tant que qu'affinements de recherche. Cela signifie que la propriété de destination doit être affinables dans le schéma de recherche.",
-          AsTokensDescription: "Dans ce mode, les éléments sélectionnés sont traités manuellement en tant que tokens. Exemple avec la recherche SharePoint et le modèle de requête: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
-          FilterValuesOperator: "L'opérateur logique entre les valeurs sélectionnées",
-          FieldToConsumeLabel: "Champ source à utiliser",
-          FieldToConsumeDescription: "Utiliser la valeur de ce champ pour les éléments sélectionnés",
+define([], function () {
+    return {
+        General: {
+            PlaceHolder: {
+                EditLabel: "Modifier",
+                IconText: "Composant Web des résultats de recherche par @PnP",
+                Description: "Affiche les résultats de la recherche dans SharePoint ou Microsoft.",
+                ConfigureBtnLabel: "Configurer"
+            },
+            WebPartDefaultTitle: "Composant Web des résultats de recherche",
+            ShowBlankEditInfoMessage: "Cette requête n’a donné aucun résultat. Ce composant Web doit demeurer vide en mode d’affichage en fonction des critères.",
+            CurrentVerticalNotSelectedMessage: "Le secteur vertical sélectionné ne correspond pas à ce composant Web. Il doit demeurer vide en mode d’affichage."
         },
-        AdaptiveCards: {
-            HostConfigFieldLabel: "Configuration de l'hôte"
-        }  
-      },
-      ConnectionsPage: {
-        ConnectionsPageGroupName: "Connexions disponibles",
-        UseFiltersWebPartLabel: "Connexion à un composant Web des filtres",
-        UseDynamicFilteringsWebPartLabel: "Se connecter à un WebPart de résultats",
-        UseDataResultsFromComponentsLabel: "Utiliser les données de ce composant WebPart",
-        UseDataResultsFromComponentsDescription: "Récupère les informations des éléments sélectionnés à partir de ce composant",
-        UseFiltersFromComponentLabel: "Utiliser les filtres de cette composante",
-        UseSearchVerticalsWebPartLabel: "Se connecter à composant Web des secteurs verticaux",
-        UseSearchVerticalsFromComponentLabel: "Utiliser les secteurs verticaux de ce composant",
-        LinkToVerticalLabel: "Afficher les données seulement lorsque le composant vertical suivant est sélectionné",
-        LinkToVerticalLabelHoverMessage: "Les résultats s’afficheront seulement si le secteur vertical sélectionné correspond à celui configuré pour ce composant Web Sinon, le composant Web sera vide (aucune marge et aucun remplissage) en mode d’affichage.",
-        UseInputQueryText: "Utiliser le texte de la requête",
-        UseInputQueryTextHoverMessage: "Utilisez le jeton {inputQueryText} de votre source de données pour récupérer cette valeur",
-        SearchQueryTextFieldLabel: "Texte de la requête",
-        SearchQueryTextFieldDescription: "",
-        SearchQueryPlaceHolderText: "Entrez le texte qui suit...",
-        InputQueryTextStaticValue: "Valeur statique",
-        InputQueryTextDynamicValue: "Valeur dynamique",
-        SearchQueryTextUseDefaultQuery: "Utilisez une valeur par défaut",
-        SearchQueryTextDefaultValue: "Valeur par défaut",
-        SourceDestinationFieldLabel: "Champ de destination",
-        SourceDestinationFieldDescription: "Champ de destination dans cette source à utiliser pour la correspondance des valeurs sélectionnées",
-        AvailableFieldValuesFromResults: "Champ contenant la valeur de filtre"
-      },
-      InformationPage: {
-        Extensibility: {
-          PanelHeader: "Configurez les bibliothèques d’extensibilité pour qu’elles soient chargées au démarrage.",
-          PanelDescription: "Ajoutez ou supprimez vos identifiants personnalisés de la bibliothèque d’extensibilités ici. Vous pouvez préciser un nom d’affichage et décider si la bibliothèque doit être téléchargée ou non au démarrage. Seuls les sources de données, les mises en page, les composants Web et les assistants d’expressions entre accolades personnalisés sont chargés ici.",
+        PropertyPane: {
+            DataSourcePage: {
+                DataSourceConnectionGroupName: "Sources de données disponibles",
+                PagingOptionsGroupName: "Options de pagination",
+                ItemsCountPerPageFieldName: "Nombre d’éléments par page",
+                PagingRangeFieldName: "Nombre de pages à afficher dans la série",
+                ShowPagingFieldName: "Afficher la pagination",
+                HidePageNumbersFieldName: "Masquer les numéros de page",
+                HideNavigationFieldName: "Masquer les boutons de navigation (page précédente, page suivante)",
+                HideFirstLastPagesFieldName: "Masquer les boutons de navigation (première, dernière)",
+                HideDisabledFieldName: "Masquer les boutons de navigation (précédente, suivante, première, dernière) s’ils sont désactivés.",
+                TemplateSlots: {
+                    GroupName: "Emplacements de la mise en page",
+                    ConfigureSlotsLabel: "Modifier les emplacements de la mise en page pour cette source de données",
+                    ConfigureSlotsBtnLabel: "Personnaliser",
+                    MissingSlotsMessage: "Slots manquants trouvés dans le modèle de mise en page: {0}",
+                    ConfigureSlotsPanelHeader: "Emplacements de la mise en page",
+                    ConfigureSlotsPanelDescription: "Ajoutez ici les emplacements à utiliser pour les différentes mises en page. Un emplacement est une variable d’espace réservé que vous ajoutez à vos modèles et dont la valeur sera remplacée de façon dynamique par une valeur de champ source de données. Ainsi, vos modèles deviendront plus génériques et réutilisables, peu importe les champs de la source des données. Pour les utiliser, utilisez l’expression entre accolades `{{slot item @root.slots.<SlotName>}}`.",
+                    SlotNameFieldName: "Nom de l’emplacement",
+                    SlotFieldFieldName: "Champ de l’emplacement",
+                    SlotFieldPlaceholderName: "Choisissez un champ"
+                }
+            },
+            LayoutPage: {
+                LayoutSelectionGroupName: "Mises en page disponibles",
+                LayoutTemplateOptionsGroupName: "Options de mise en page",
+                CommonOptionsGroupName: "Courantes",
+                TemplateUrlFieldLabel: "Utiliser une adresse URL de modèle externe",
+                TemplateUrlPlaceholder: "https://myfile.html",
+                ErrorTemplateExtension: "Le modèle doit être un fichier .txt, .htm ou .html valide",
+                ErrorTemplateResolve: "Impossible de résoudre le modèle indiqué. Renseignements sur l’erreur '{0}'",
+                DialogButtonLabel: "Modifier le modèle de résultats",
+                DialogTitle: "Modifier le modèle de résultats",
+                MissingSlotsMessage: "Les slots suivants n'ont pas été configurés: {0}",
+                ShowSelectedFilters: "Afficher les filtres sélectionnés",
+                ShowBlankIfNoResult: "Masquer ce composant Web s’il n’y a rien à afficher",
+                ShowResultsCount: "Afficher le nombre de résultats",
+                UseMicrosoftGraphToolkit: "Utiliser la boîte à outils Microsoft Graph",
+                HandlebarsRenderTypeLabel: "Handlebars/HTML",
+                HandlebarsRenderTypeDesc: "Sélectionnez un affichage basé sur HTML, CSS and Handlebars",
+                AdaptiveCardsRenderTypeLabel: "Cartes adaptatives",
+                AdaptiveCardsRenderTypeDesc: "Sélectionnez un affichage basé sur des cartes adaptatives JSON",
+                Handlebars: {
+                    UseMicrosoftGraphToolkit: "Utiliser Microsoft Graph Toolkit",
+                    ResultTypes: {
+                        ResultTypeslabel: "Type de résultat",
+                        ResultTypesDescription: "Ajoutez ici les modèles à utiliser pour les éléments de résultat selon une ou plusieurs conditions supplémentaires. Les conditions sont évaluées dans l’ordre configuré et les modèles externes ont préséance sur les modèles intégrés. Assurez-vous également que les champs de la source des données que vous utilisez sont présents dans la réponse aux données.",
+                        InlineTemplateContentLabel: "Modèle intégré",
+                        EditResultTypesLabel: "Modifier les types de résultats",
+                        ConditionPropertyLabel: "Champ de source des données",
+                        ConditionValueLabel: "Valeur de la condition",
+                        CondtionOperatorValue: "Opérateur",
+                        ExternalUrlLabel: "URL du modèle externe",
+                        EqualOperator: "Égal à",
+                        NotEqualOperator: "N’est pas égal à",
+                        ContainsOperator: "Contient",
+                        StartsWithOperator: "Commence par",
+                        NotNullOperator: "N’est pas nul",
+                        GreaterOrEqualOperator: "Supérieur ou égal à",
+                        GreaterThanOperator: "Supérieur à",
+                        LessOrEqualOperator: "Inférieur ou égal à",
+                        LessThanOperator: "Inférieur à",
+                        CancelButtonText: "Annuler",
+                        DialogButtonLabel: "Modifier le modèle",
+                        DialogButtonText: "Modifier le modèle",
+                        DialogTitle: "Modifier le modèle de résultats",
+                        SaveButtonText: "Enregistrer",
+                    },
+                    AllowItemSelection: "Autoriser la sélection d'éléments",
+                    AllowMultipleItemSelection: "Autoriser la sélection multiple",
+                    SelectionPreservedOnEmptyClick: "Conserver la sélection sur clic vide",
+                    SelectionModeLabel: "Mode de sélection",
+                    AsTokensSelectionMode: "Traiter les valeurs en tant que tokens (manuel)",
+                    AsDataFiltersSelectionMode: "Traiter les valeurs en tant que filtres (default)",
+                    AsDataFiltersDescription: "Dans ce mode, les éléments sélectionnés sont traités en tant que qu'affinements de recherche. Cela signifie que la propriété de destination doit être affinables dans le schéma de recherche.",
+                    AsTokensDescription: "Dans ce mode, les éléments sélectionnés sont traités manuellement en tant que tokens. Exemple avec la recherche SharePoint et le modèle de requête: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
+                    FilterValuesOperator: "L'opérateur logique entre les valeurs sélectionnées",
+                    FieldToConsumeLabel: "Champ source à utiliser",
+                    FieldToConsumeDescription: "Utiliser la valeur de ce champ pour les éléments sélectionnés",
+                },
+                AdaptiveCards: {
+                    HostConfigFieldLabel: "Configuration de l'hôte"
+                }
+            },
+            ConnectionsPage: {
+                ConnectionsPageGroupName: "Connexions disponibles",
+                UseFiltersWebPartLabel: "Connexion à un composant Web des filtres",
+                UseDynamicFilteringsWebPartLabel: "Se connecter à un WebPart de résultats",
+                UseDataResultsFromComponentsLabel: "Utiliser les données de ce composant WebPart",
+                UseDataResultsFromComponentsDescription: "Récupère les informations des éléments sélectionnés à partir de ce composant",
+                UseFiltersFromComponentLabel: "Utiliser les filtres de cette composante",
+                UseSearchVerticalsWebPartLabel: "Se connecter à composant Web des secteurs verticaux",
+                UseSearchVerticalsFromComponentLabel: "Utiliser les secteurs verticaux de ce composant",
+                LinkToVerticalLabel: "Afficher les données seulement lorsque le composant vertical suivant est sélectionné",
+                LinkToVerticalLabelHoverMessage: "Les résultats s’afficheront seulement si le secteur vertical sélectionné correspond à celui configuré pour ce composant Web Sinon, le composant Web sera vide (aucune marge et aucun remplissage) en mode d’affichage.",
+                UseInputQueryText: "Utiliser le texte de la requête",
+                UseInputQueryTextHoverMessage: "Utilisez le jeton {inputQueryText} de votre source de données pour récupérer cette valeur",
+                SearchQueryTextFieldLabel: "Texte de la requête",
+                SearchQueryTextFieldDescription: "",
+                SearchQueryPlaceHolderText: "Entrez le texte qui suit...",
+                InputQueryTextStaticValue: "Valeur statique",
+                InputQueryTextDynamicValue: "Valeur dynamique",
+                SearchQueryTextUseDefaultQuery: "Utilisez une valeur par défaut",
+                SearchQueryTextDefaultValue: "Valeur par défaut",
+                SourceDestinationFieldLabel: "Champ de destination",
+                SourceDestinationFieldDescription: "Champ de destination dans cette source à utiliser pour la correspondance des valeurs sélectionnées",
+                AvailableFieldValuesFromResults: "Champ contenant la valeur de filtre",
+                BidirectionalConnectionWarning: "Le composant WebPart de filtres connecté n'a pas été configuré pour se reconnecter à ce composant WebPart de résultats de recherche. Les deux composants WebPart doivent être connectés l'un à l'autre pour que les filtres fonctionnent correctement."
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configurez les bibliothèques d’extensibilité pour qu’elles soient chargées au démarrage.",
+                    PanelDescription: "Ajoutez ou supprimez vos identifiants personnalisés de la bibliothèque d’extensibilités ici. Vous pouvez préciser un nom d’affichage et décider si la bibliothèque doit être téléchargée ou non au démarrage. Seuls les sources de données, les mises en page, les composants Web et les assistants d’expressions entre accolades personnalisés sont chargés ici.",
+                }
+            },
+            CustomQueryModifier: {
+                EditQueryModifiersLabel: "Configurer les modificateurs de requête personnalisés disponibles",
+                QueryModifiersLabel: "Modificateurs de requête personnalisés",
+                QueryModifiersDescription: "Activez ou désactivez les modificateurs de requête personnalisés individuels.",
+                EnabledPropertyLabel: "Activé",
+                ModifierNamePropertyLabel: "Nom",
+                ModifierDescriptionPropertyLabel: "Description",
+                EndWhenSuccessfullPropertyLabel: "Fin en cas de succès"
+            }
+        },
+        Styling: {
+            StylingOptionsGroupName: "Options de style",
+            ResultsBackgroundColorLabel: "Couleur d'arrière-plan des résultats",
+            ResultsBorderColorLabel: "Couleur de bordure des résultats",
+            ResultsBorderThicknessLabel: "Épaisseur de bordure des résultats",
+            ResetToDefaultLabel: "Réinitialiser le style par défaut",
+            ResetToDefaultDescription: "Réinitialiser toutes les options de style à leurs valeurs par défaut"
         }
-      },
-      CustomQueryModifier: {
-            EditQueryModifiersLabel: "Configurer les modificateurs de requête personnalisés disponibles",
-            QueryModifiersLabel: "Modificateurs de requête personnalisés",
-            QueryModifiersDescription: "Activez ou désactivez les modificateurs de requête personnalisés individuels.",
-            EnabledPropertyLabel: "Activé",
-            ModifierNamePropertyLabel: "Nom",
-            ModifierDescriptionPropertyLabel: "Description",
-            EndWhenSuccessfullPropertyLabel:"Fin en cas de succès"        
-      }
-    },
-    Styling: {
-      StylingOptionsGroupName: "Options de style",
-      ResultsBackgroundColorLabel: "Couleur d'arrière-plan des résultats",
-      ResultsBorderColorLabel: "Couleur de bordure des résultats",
-      ResultsBorderThicknessLabel: "Épaisseur de bordure des résultats",
-      ResetToDefaultLabel: "Réinitialiser le style par défaut",
-      ResetToDefaultDescription: "Réinitialiser toutes les options de style à leurs valeurs par défaut"
     }
-  }
 });

--- a/search-parts/src/webparts/searchResults/loc/it-it.js
+++ b/search-parts/src/webparts/searchResults/loc/it-it.js
@@ -115,7 +115,8 @@ define([], function () {
                 SearchQueryTextDefaultValue: "Valore predefinito",
                 SourceDestinationFieldLabel: "Nome campo di destinazione",
                 SourceDestinationFieldDescription: "Campo di destinazione da usare in questa Web Part per corrispondere ai valori selezionati",
-                AvailableFieldValuesFromResults: "Campo contenente il valore del filtro"
+                AvailableFieldValuesFromResults: "Campo contenente il valore del filtro",
+                BidirectionalConnectionWarning: "La Web Part dei filtri connessa non è stata configurata per ricollegarsi a questa Web Part dei risultati di ricerca. Entrambe le Web Part devono essere collegate tra loro affinché i filtri funzionino correttamente."
             },
             InformationPage: {
                 Extensibility: {

--- a/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
@@ -115,6 +115,7 @@ declare interface ISearchResultsWebPartStrings {
             SourceDestinationFieldLabel: string;
             SourceDestinationFieldDescription: string;
             AvailableFieldValuesFromResults: string;
+            BidirectionalConnectionWarning: string;
         },
         InformationPage: {
             Extensibility: {

--- a/search-parts/src/webparts/searchResults/loc/nb-no.js
+++ b/search-parts/src/webparts/searchResults/loc/nb-no.js
@@ -1,145 +1,146 @@
-define([], function() {
+define([], function () {
     return {
-      General: {
-        PlaceHolder: {
-          EditLabel: "Rediger",
-          IconText: "Søkeresultat-nettdel, av @PnP",
-          Description: "Viser søkeresultater fra SharePoint- eller Microsoft-søk.",
-          ConfigureBtnLabel: "Konfigurer"
-        },
-        WebPartDefaultTitle: "Søkeresultat",
-        ShowBlankEditInfoMessage: "Fant ikke noe med denne spørringen. Nettdelen vil være tom i visningsmodus, i tråd med innstillingene.",
-        CurrentVerticalNotSelectedMessage: "Den valgte vertikalen matcher ikke den som er assosiert med denne nettdelen. Den vil være tom i visningsmodus."
-      },
-      PropertyPane: {
-        DataSourcePage: {
-          DataSourceConnectionGroupName: "Tilgjengelige datakilder",
-          PagingOptionsGroupName: "Innstillinger for sideinndeling",
-          ItemsCountPerPageFieldName: "Antall objekter per side",
-          PagingRangeFieldName: "Antall sider som skal vises i sidenavigasjonen",
-          ShowPagingFieldName: "Vis sidenavigasjon",
-          HidePageNumbersFieldName: "Skjul sidenummer",
-          HideNavigationFieldName: "Skjul navigeringslenker forrige side / neste side",
-          HideFirstLastPagesFieldName: "Skjul navigeringslenkene første/siste",
-          HideDisabledFieldName: "Skjul navigeringslenker (forrige, neste, første, siste) hvis de er deaktivert.",
-          TemplateSlots: {
-            GroupName: "Mal",
-            ConfigureSlotsLabel: "Rediger mal-slots for denne datakilden",
-            ConfigureSlotsBtnLabel: "Tilpass",
-            MissingSlotsMessage: "Mangler mal-slots i layoutmalen: {0}",
-            ConfigureSlotsPanelHeader: "Mal-slots",
-            ConfigureSlotsPanelDescription: "Her kan du legge til slots som skal brukes i ulike maler. En slot er en plassholdervariabel som du setter inn i din mal, der verdien kommer til å bli erstattet med en feltverdi fra en datakilde. På denne måten blir dine maler mer generiske og lettere å gjenbruke. Hvis du vil bruke dem, bruker du Handlebars-uttrykket `{{slot item @root.slots.<SlotName>}}`.",
-            SlotNameFieldName: "Navn",
-            SlotFieldFieldName: "Felt",
-            SlotFieldPlaceholderName: "Velg et felt"
-          }
-        },
-        LayoutPage: {
-          LayoutSelectionGroupName: "Tilgjengelige maler",
-          LayoutTemplateOptionsGroupName: "Malvalg",
-          CommonOptionsGroupName: "Vanlig",
-          TemplateUrlFieldLabel: "Bruk en URL for mal",
-          TemplateUrlPlaceholder: "https://myfile.html",
-          ErrorTemplateExtension: "Malen må være en gyldig .txt, .htm eller .html-fil",
-          ErrorTemplateResolve: "Det går ikke å lese denne malen. Feil: '{0}'",
-          DialogButtonLabel: "Rediger resultatmalen",
-          DialogTitle: "Rediger resultatmalen",
-          MissingSlotsMessage: "Følgende slots er ikke konfigurert: {0}",
-          ShowSelectedFilters: "Vis valgte gilter",
-          ShowBlankIfNoResult: "Skjul denne nettdelen om det ikke er noe å vise.",
-          ShowResultsCount: "Vis antall resultat",
-          HandlebarsRenderTypeLabel: "Handlebars/HTML",
-          HandlebarsRenderTypeDesc: "Velg oppsett basert på HTML, CSS og håndtak",
-          AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
-          AdaptiveCardsRenderTypeDesc: "Velg oppsett basert på adaptive JSON-kort",          
-          Handlebars: {
-            UseMicrosoftGraphToolkit: "Bruk Microsoft Graph Toolkit",
-            ResultTypes: {
-              ResultTypeslabel: "Resultattyper",
-              ResultTypesDescription: "Her kan du legge til de maler som du vil bruke for de ulike resultatobjektene basert på én eller flere betingelser. Betingelsene vurderes i den gitte rekkefølgen, og eksterne maler har forrang over integrerte maler. Pass på at feltene i den datakilden du bruker finnes i dataresponsen.",
-              InlineTemplateContentLabel: "Integrert mal",
-              EditResultTypesLabel: "Rediger resultattyper",
-              ConditionPropertyLabel: "Felt i datakilde",
-              ConditionValueLabel: "Betingelse",
-              CondtionOperatorValue: "Operator",
-              ExternalUrlLabel: "Ekstern mal-URL",
-              EqualOperator: "Er lik",
-              NotEqualOperator: "Er ikke lik",
-              ContainsOperator: "Inneholder",
-              StartsWithOperator: "Starter med",
-              NotNullOperator: "Er ikke null",
-              GreaterOrEqualOperator: "Større enn eller lik",
-              GreaterThanOperator: "Større enn",
-              LessOrEqualOperator: "Mindre enn eller lik",
-              LessThanOperator: "Mindre enn",
-              CancelButtonText: "Avbryt",
-              DialogButtonText: "Rediger mal",
-              DialogTitle: "Rediger resultatmal",
-              SaveButtonText: "Lagre"
+        General: {
+            PlaceHolder: {
+                EditLabel: "Rediger",
+                IconText: "Søkeresultat-nettdel, av @PnP",
+                Description: "Viser søkeresultater fra SharePoint- eller Microsoft-søk.",
+                ConfigureBtnLabel: "Konfigurer"
             },
-            AllowItemSelection: "Tillat valg av elementer",
-            AllowMultipleItemSelection: "Tillat flere valg",
-            SelectionPreservedOnEmptyClick: "Behold valg ved tomt klikk",
-            SelectionModeLabel: "Valgmodus",
-            AsTokensSelectionMode: "Behandle valgte verdier som tokens (manuell modus)",
-            AsDataFiltersSelectionMode: "Behandle valgte verdier som filtre (standardmodus)",
-            AsDataFiltersDescription: "I denne modusen sendes valgte verdier til datakilden som vanlige filtre",
-            AsTokensDescription: "I denne modusen brukes valgte verdier manuelt gjennom tokens og tilgjengelige metoder. Eksempel med SharePoint-søkemal: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
-            FilterValuesOperator: "Den logiske operatoren som skal brukes mellom valgte verdier",
-            FieldToConsumeLabel: "Kildefelt å konsumere",
-            FieldToConsumeDescription: "Bruk denne feltverdien for valgte elementer"
-          },
-          AdaptiveCards: {
-            HostConfigFieldLabel: "Vertskonfigurasjon"
-          } 
+            WebPartDefaultTitle: "Søkeresultat",
+            ShowBlankEditInfoMessage: "Fant ikke noe med denne spørringen. Nettdelen vil være tom i visningsmodus, i tråd med innstillingene.",
+            CurrentVerticalNotSelectedMessage: "Den valgte vertikalen matcher ikke den som er assosiert med denne nettdelen. Den vil være tom i visningsmodus."
         },
-        ConnectionsPage: {
-          ConnectionsPageGroupName: "Tilgjengelige tilkoblinger",
-          UseFiltersWebPartLabel: "Koble til en filter-nettdel",
-          UseFiltersFromComponentLabel: "Bruk filter fra denne komponenten",
-          UseDynamicFilteringsWebPartLabel: "Koble til en dataresultatwebdel",
-          UseDataResultsFromComponentsLabel: "Bruk data fra denne webdelen",
-          UseDataResultsFromComponentsDescription: "Bruk data fra utvalgte elementer i disse webdelene",
-          UseSearchVerticalsWebPartLabel: "Koble til en vertikal-nettdel",
-          UseSearchVerticalsFromComponentLabel: "Bruk vertikaler fra denne komponenten",
-          LinkToVerticalLabel: "Vis kun data når følgende vertikaler er valgt",
-          LinkToVerticalLabelHoverMessage: "Resultatee vises kun om de valgte vertikalene passer med den som har blitt konfigurert for denne nettdelen. Ellers er denne nettdelen tom.",
-          UseInputQueryText: "Bruk søkespørringstekst",
-          UseInputQueryTextHoverMessage: "Bruk {inputQueryText} i din datakilde for å hente denne verdien",
-          SearchQueryTextFieldLabel: "Spørretekst",
-          SearchQueryTextFieldDescription: "",
-          SearchQueryPlaceHolderText: "Skriv inn spørring...",
-          InputQueryTextStaticValue: "Statisk verdi",
-          InputQueryTextDynamicValue: "Dynamisk verdi",
-          SearchQueryTextUseDefaultQuery: "Bruk standardverdi",
-          SearchQueryTextDefaultValue: "Standardverdi",
-          SourceDestinationFieldLabel: "Navn på destinasjonsfelt",
-          SourceDestinationFieldDescription: "Destinasjonsfelt som skal brukes i denne webdelen for å matche de valgte verdiene",
-          AvailableFieldValuesFromResults: "Felt som inneholder filterverdien"
+        PropertyPane: {
+            DataSourcePage: {
+                DataSourceConnectionGroupName: "Tilgjengelige datakilder",
+                PagingOptionsGroupName: "Innstillinger for sideinndeling",
+                ItemsCountPerPageFieldName: "Antall objekter per side",
+                PagingRangeFieldName: "Antall sider som skal vises i sidenavigasjonen",
+                ShowPagingFieldName: "Vis sidenavigasjon",
+                HidePageNumbersFieldName: "Skjul sidenummer",
+                HideNavigationFieldName: "Skjul navigeringslenker forrige side / neste side",
+                HideFirstLastPagesFieldName: "Skjul navigeringslenkene første/siste",
+                HideDisabledFieldName: "Skjul navigeringslenker (forrige, neste, første, siste) hvis de er deaktivert.",
+                TemplateSlots: {
+                    GroupName: "Mal",
+                    ConfigureSlotsLabel: "Rediger mal-slots for denne datakilden",
+                    ConfigureSlotsBtnLabel: "Tilpass",
+                    MissingSlotsMessage: "Mangler mal-slots i layoutmalen: {0}",
+                    ConfigureSlotsPanelHeader: "Mal-slots",
+                    ConfigureSlotsPanelDescription: "Her kan du legge til slots som skal brukes i ulike maler. En slot er en plassholdervariabel som du setter inn i din mal, der verdien kommer til å bli erstattet med en feltverdi fra en datakilde. På denne måten blir dine maler mer generiske og lettere å gjenbruke. Hvis du vil bruke dem, bruker du Handlebars-uttrykket `{{slot item @root.slots.<SlotName>}}`.",
+                    SlotNameFieldName: "Navn",
+                    SlotFieldFieldName: "Felt",
+                    SlotFieldPlaceholderName: "Velg et felt"
+                }
+            },
+            LayoutPage: {
+                LayoutSelectionGroupName: "Tilgjengelige maler",
+                LayoutTemplateOptionsGroupName: "Malvalg",
+                CommonOptionsGroupName: "Vanlig",
+                TemplateUrlFieldLabel: "Bruk en URL for mal",
+                TemplateUrlPlaceholder: "https://myfile.html",
+                ErrorTemplateExtension: "Malen må være en gyldig .txt, .htm eller .html-fil",
+                ErrorTemplateResolve: "Det går ikke å lese denne malen. Feil: '{0}'",
+                DialogButtonLabel: "Rediger resultatmalen",
+                DialogTitle: "Rediger resultatmalen",
+                MissingSlotsMessage: "Følgende slots er ikke konfigurert: {0}",
+                ShowSelectedFilters: "Vis valgte gilter",
+                ShowBlankIfNoResult: "Skjul denne nettdelen om det ikke er noe å vise.",
+                ShowResultsCount: "Vis antall resultat",
+                HandlebarsRenderTypeLabel: "Handlebars/HTML",
+                HandlebarsRenderTypeDesc: "Velg oppsett basert på HTML, CSS og håndtak",
+                AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
+                AdaptiveCardsRenderTypeDesc: "Velg oppsett basert på adaptive JSON-kort",
+                Handlebars: {
+                    UseMicrosoftGraphToolkit: "Bruk Microsoft Graph Toolkit",
+                    ResultTypes: {
+                        ResultTypeslabel: "Resultattyper",
+                        ResultTypesDescription: "Her kan du legge til de maler som du vil bruke for de ulike resultatobjektene basert på én eller flere betingelser. Betingelsene vurderes i den gitte rekkefølgen, og eksterne maler har forrang over integrerte maler. Pass på at feltene i den datakilden du bruker finnes i dataresponsen.",
+                        InlineTemplateContentLabel: "Integrert mal",
+                        EditResultTypesLabel: "Rediger resultattyper",
+                        ConditionPropertyLabel: "Felt i datakilde",
+                        ConditionValueLabel: "Betingelse",
+                        CondtionOperatorValue: "Operator",
+                        ExternalUrlLabel: "Ekstern mal-URL",
+                        EqualOperator: "Er lik",
+                        NotEqualOperator: "Er ikke lik",
+                        ContainsOperator: "Inneholder",
+                        StartsWithOperator: "Starter med",
+                        NotNullOperator: "Er ikke null",
+                        GreaterOrEqualOperator: "Større enn eller lik",
+                        GreaterThanOperator: "Større enn",
+                        LessOrEqualOperator: "Mindre enn eller lik",
+                        LessThanOperator: "Mindre enn",
+                        CancelButtonText: "Avbryt",
+                        DialogButtonText: "Rediger mal",
+                        DialogTitle: "Rediger resultatmal",
+                        SaveButtonText: "Lagre"
+                    },
+                    AllowItemSelection: "Tillat valg av elementer",
+                    AllowMultipleItemSelection: "Tillat flere valg",
+                    SelectionPreservedOnEmptyClick: "Behold valg ved tomt klikk",
+                    SelectionModeLabel: "Valgmodus",
+                    AsTokensSelectionMode: "Behandle valgte verdier som tokens (manuell modus)",
+                    AsDataFiltersSelectionMode: "Behandle valgte verdier som filtre (standardmodus)",
+                    AsDataFiltersDescription: "I denne modusen sendes valgte verdier til datakilden som vanlige filtre",
+                    AsTokensDescription: "I denne modusen brukes valgte verdier manuelt gjennom tokens og tilgjengelige metoder. Eksempel med SharePoint-søkemal: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
+                    FilterValuesOperator: "Den logiske operatoren som skal brukes mellom valgte verdier",
+                    FieldToConsumeLabel: "Kildefelt å konsumere",
+                    FieldToConsumeDescription: "Bruk denne feltverdien for valgte elementer"
+                },
+                AdaptiveCards: {
+                    HostConfigFieldLabel: "Vertskonfigurasjon"
+                }
+            },
+            ConnectionsPage: {
+                ConnectionsPageGroupName: "Tilgjengelige tilkoblinger",
+                UseFiltersWebPartLabel: "Koble til en filter-nettdel",
+                UseFiltersFromComponentLabel: "Bruk filter fra denne komponenten",
+                UseDynamicFilteringsWebPartLabel: "Koble til en dataresultatwebdel",
+                UseDataResultsFromComponentsLabel: "Bruk data fra denne webdelen",
+                UseDataResultsFromComponentsDescription: "Bruk data fra utvalgte elementer i disse webdelene",
+                UseSearchVerticalsWebPartLabel: "Koble til en vertikal-nettdel",
+                UseSearchVerticalsFromComponentLabel: "Bruk vertikaler fra denne komponenten",
+                LinkToVerticalLabel: "Vis kun data når følgende vertikaler er valgt",
+                LinkToVerticalLabelHoverMessage: "Resultatee vises kun om de valgte vertikalene passer med den som har blitt konfigurert for denne nettdelen. Ellers er denne nettdelen tom.",
+                UseInputQueryText: "Bruk søkespørringstekst",
+                UseInputQueryTextHoverMessage: "Bruk {inputQueryText} i din datakilde for å hente denne verdien",
+                SearchQueryTextFieldLabel: "Spørretekst",
+                SearchQueryTextFieldDescription: "",
+                SearchQueryPlaceHolderText: "Skriv inn spørring...",
+                InputQueryTextStaticValue: "Statisk verdi",
+                InputQueryTextDynamicValue: "Dynamisk verdi",
+                SearchQueryTextUseDefaultQuery: "Bruk standardverdi",
+                SearchQueryTextDefaultValue: "Standardverdi",
+                SourceDestinationFieldLabel: "Navn på destinasjonsfelt",
+                SourceDestinationFieldDescription: "Destinasjonsfelt som skal brukes i denne webdelen for å matche de valgte verdiene",
+                AvailableFieldValuesFromResults: "Felt som inneholder filterverdien",
+                BidirectionalConnectionWarning: "Den tilkoblede filter-webdelen er ikke konfigurert til å koble tilbake til denne søkeresultat-webdelen. Begge webdelene må være koblet til hverandre for at filtre skal fungere korrekt."
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurer utvidelsesbibliotek som skal lastes ved oppstart.",
+                    PanelDescription: "Legg til / fjern ID-en til ditt tilpassede utvidelsesbibliotek her. Du kan angi et visningsnavn og bestemme om biblioteket skal lastes ved oppstart eller ikke. Har lastes kun tilpassede datakilder, maler, web-komponenter og Handlebars-hjelpere.",
+                }
+            },
+            CustomQueryModifier: {
+                EditQueryModifiersLabel: "Konfigurer tilgjengelige tilpassede spørringsmodifikatorer",
+                QueryModifiersLabel: "Tilpassede spørringsmodifikatorer",
+                QueryModifiersDescription: "Aktiver eller deaktiver individuelle tilpassede søkemodifikatorer",
+                EnabledPropertyLabel: "Aktivert",
+                ModifierNamePropertyLabel: "Navn",
+                ModifierDescriptionPropertyLabel: "Beskrivelse",
+                EndWhenSuccessfullPropertyLabel: "Avslutt når det er vellykket"
+            }
         },
-        InformationPage: {
-          Extensibility: {
-            PanelHeader: "Konfigurer utvidelsesbibliotek som skal lastes ved oppstart.",
-            PanelDescription: "Legg til / fjern ID-en til ditt tilpassede utvidelsesbibliotek her. Du kan angi et visningsnavn og bestemme om biblioteket skal lastes ved oppstart eller ikke. Har lastes kun tilpassede datakilder, maler, web-komponenter og Handlebars-hjelpere.",
-          }
-        },
-        CustomQueryModifier: {
-              EditQueryModifiersLabel: "Konfigurer tilgjengelige tilpassede spørringsmodifikatorer",
-              QueryModifiersLabel: "Tilpassede spørringsmodifikatorer",
-              QueryModifiersDescription: "Aktiver eller deaktiver individuelle tilpassede søkemodifikatorer",
-              EnabledPropertyLabel: "Aktivert",
-              ModifierNamePropertyLabel: "Navn",
-              ModifierDescriptionPropertyLabel: "Beskrivelse",
-              EndWhenSuccessfullPropertyLabel:"Avslutt når det er vellykket"          
+        Styling: {
+            StylingOptionsGroupName: "Stilalternativer",
+            ResultsBackgroundColorLabel: "Resultater bakgrunnsfarge",
+            ResultsBorderColorLabel: "Resultater kantfarge",
+            ResultsBorderThicknessLabel: "Resultater kanttykkelse",
+            ResetToDefaultLabel: "Tilbakestill til standardstil",
+            ResetToDefaultDescription: "Tilbakestill alle stilalternativer til sine standardverdier"
         }
-      },
-      Styling: {
-        StylingOptionsGroupName: "Stilalternativer",
-        ResultsBackgroundColorLabel: "Resultater bakgrunnsfarge",
-        ResultsBorderColorLabel: "Resultater kantfarge",
-        ResultsBorderThicknessLabel: "Resultater kanttykkelse",
-        ResetToDefaultLabel: "Tilbakestill til standardstil",
-        ResetToDefaultDescription: "Tilbakestill alle stilalternativer til sine standardverdier"
-      }
     }
-  });
+});

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -1,143 +1,146 @@
-define([], function() {
-  return {
-    General: {
-      PlaceHolder: {
-        EditLabel: "Bewerk",
-        IconText: "Zoekresultaten webonderdeel door @PnP",
-        Description: "Toont zoekresultaten uit SharePoint of Microsoft search.",
-        ConfigureBtnLabel: "Configureer"
-      },
-      WebPartDefaultTitle: "Zoekresultaten webonderdeel",
-      ShowBlankEditInfoMessage: "Geen resultaten gevonden voor deze zoekopdracht. Dit webonderdeel blijft leeg in weergave modus conform parameters.",
-      CurrentVerticalNotSelectedMessage: "De nu selecteerde zoekverticaal komt niet overeen met degene die geassocieerd is met dit webonderdeel. Dit webonderdeel blijft leeg in weergave modus."
-    },
-    PropertyPane: {
-      DataSourcePage: {
-        DataSourceConnectionGroupName: "Beschikbare databronnen",
-        PagingOptionsGroupName: "Pagineringsopties",
-        ItemsCountPerPageFieldName: "Aantal items per pagina",
-        PagingRangeFieldName: "Aantal pagina's in bereik tonen",
-        ShowPagingFieldName: "Toon paginering",
-        HidePageNumbersFieldName: "Verberg paginanummers",
-        HideNavigationFieldName: "Verberg navigatieknoppen (vorige pagina, volgende pagina)",
-        HideFirstLastPagesFieldName: "Verberg eerste/laatste navigatieknoppen",
-        HideDisabledFieldName: "Verberg navigatieknoppen (vorige, vorige, eerste, laatste) wanneer deze uitgeschakeld zijn.",
-        TemplateSlots: {
-          GroupName: "Indelingssleuven",
-          ConfigureSlotsLabel: "Bewerk indelingssleuven voor deze databron",
-          ConfigureSlotsBtnLabel: "Bewerk",
-          MissingSlotsMessage: "Ontbrekende sleuven gevonden in lay-outsjabloon: {0}",
-          ConfigureSlotsPanelHeader: "Indelingssleuven",
-          ConfigureSlotsPanelDescription: "Voeg hier sleuven toe voor gebruik in verschillende indelingen. Een sleuf is een placeholder variabele die je verwerkt in een sjabloon. De placeholder wordt dynamisch vervangen door een veldwaarde uit de databron. Op deze manier wordt je sjabloon meer generiek en herbruikbaar, ontkoppeld van specifieke velden uit de databron. Om deze te gebruiken, gebruik je de `{{slot item @root.slots.<SleufNaam>}}` Handlebars expressie.",
-          SlotNameFieldName: "Sleuf naam",
-          SlotFieldFieldName: "Sleuf veld",
-          SlotFieldPlaceholderName: "Kies een veld"
-        }
-      },
-      LayoutPage: {
-        LayoutSelectionGroupName: "Beschikbare indelingen",
-        LayoutTemplateOptionsGroupName: "Indelingsopties",
-        CommonOptionsGroupName: "Algemeen",
-        TemplateUrlFieldLabel: "Gebruik een externe sjabloon URL",
-        TemplateUrlPlaceholder: "https://mijnbestand.html",
-        ErrorTemplateExtension: "Het sjabloon moet een geldig .txt, .htm of .html bestand zijn",
-        ErrorTemplateResolve: "Kan het opgegeven template niet inladen. Foutmelding: '{0}'",
-        DialogButtonLabel: "Bewerk resulaten sjabloon",
-        DialogTitle: "Bewerk resultaten sjabloon",
-        MissingSlotsMessage: "De volgende slots zijn niet geconfigureerd: {0}",
-        ShowSelectedFilters: "Toon geselecteerde filters",
-        ShowBlankIfNoResult: "Verberg dit webonderdeel wanneer er niets te tonen is.",
-        ShowResultsCount: "Toon aantal resultaten",
-        HandlebarsRenderTypeLabel: "Handlebars/HTML",
-        HandlebarsRenderTypeDesc: "Selecteer lay-outs op basis van HTML, CSS en stuur",
-        AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
-        AdaptiveCardsRenderTypeDesc: "Selecteer lay-outs op basis van JSON-adaptieve kaarten",        
-        Handlebars: {
-          UseMicrosoftGraphToolkit: "Gebruik de Microsoft Graph Toolkit",
-          ResultTypes: {
-            ResultTypeslabel: "Resultaattypen",
-            ResultTypesDescription: "Voeg hier de sjablonen toe welke gebruikt worden voor zoekresultaten op basis van één of meer voorwaarden. Voorwaarden worden toegepast in de ingestelde volgorde. Externe templates krijgen voorrang op inline sjablonen. Zorg er ook voor dat de gebruikte velden uit de databron aanwezig zijn in de data van het antwoord.",
-            InlineTemplateContentLabel: "Inline sjabloon",
-            EditResultTypesLabel: "Bewerk resultaattypen",
-            ConditionPropertyLabel: "Databron veld",
-            ConditionValueLabel: "Voorwaarde",
-            CondtionOperatorValue: "Operator",
-            ExternalUrlLabel: "Externe sjabloon URL",
-            EqualOperator: "Gelijk aan",
-            NotEqualOperator: "Niet gelijk aan",
-            ContainsOperator: "Bevat",
-            StartsWithOperator: "Begint met",
-            NotNullOperator: "Is niet null",
-            GreaterOrEqualOperator: "Groter of gelijk",
-            GreaterThanOperator: "Groter dan",
-            LessOrEqualOperator: "Kleiner of gelijk",
-            LessThanOperator: "Kleiner dan",
-            CancelButtonText: "Annuleer",
-            DialogButtonText: "Bewerk sjabloon",
-            DialogTitle: "Bewerk resultaatsjabloon",
-            SaveButtonText: "Bewaar",
-          },
-          AllowItemSelection: "Selectie van items toestaan",
-          AllowMultipleItemSelection: "Meerdere selectie toestaan",
-          SelectionPreservedOnEmptyClick: "Selectie behouden bij lege klik",
-          SelectionModeLabel: "Selectiemodus",
-          AsTokensSelectionMode: "Verwerk geselecteerde waarden als tokens (handmatige modus)",
-          AsDataFiltersSelectionMode: "Verwerk geselecteerde waarden als filters (standaardmodus)",
-          AsDataFiltersDescription: "In deze modus worden geselecteerde waarden als gewone filters naar de gegevensbron verzonden",
-          AsTokensDescription: "In deze modus worden geselecteerde waarden handmatig gebruikt via tokens en beschikbare methoden. Voorbeeld met SharePoint-zoekopdrachtsjabloon: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
-          FilterValuesOperator: "De logische operator die tussen geselecteerde waarden moet worden gebruikt",
-          FieldToConsumeLabel: "Bronveld om te consumeren",
-          FieldToConsumeDescription: "Gebruik deze veldwaarde voor geselecteerde items"
+define([], function () {
+    return {
+        General: {
+            PlaceHolder: {
+                EditLabel: "Bewerk",
+                IconText: "Zoekresultaten webonderdeel door @PnP",
+                Description: "Toont zoekresultaten uit SharePoint of Microsoft search.",
+                ConfigureBtnLabel: "Configureer"
+            },
+            WebPartDefaultTitle: "Zoekresultaten webonderdeel",
+            ShowBlankEditInfoMessage: "Geen resultaten gevonden voor deze zoekopdracht. Dit webonderdeel blijft leeg in weergave modus conform parameters.",
+            CurrentVerticalNotSelectedMessage: "De nu selecteerde zoekverticaal komt niet overeen met degene die geassocieerd is met dit webonderdeel. Dit webonderdeel blijft leeg in weergave modus."
         },
-        AdaptiveCards: {
-          HostConfigFieldLabel: "Hostconfiguratie"
+        PropertyPane: {
+            DataSourcePage: {
+                DataSourceConnectionGroupName: "Beschikbare databronnen",
+                PagingOptionsGroupName: "Pagineringsopties",
+                ItemsCountPerPageFieldName: "Aantal items per pagina",
+                PagingRangeFieldName: "Aantal pagina's in bereik tonen",
+                ShowPagingFieldName: "Toon paginering",
+                HidePageNumbersFieldName: "Verberg paginanummers",
+                HideNavigationFieldName: "Verberg navigatieknoppen (vorige pagina, volgende pagina)",
+                HideFirstLastPagesFieldName: "Verberg eerste/laatste navigatieknoppen",
+                HideDisabledFieldName: "Verberg navigatieknoppen (vorige, vorige, eerste, laatste) wanneer deze uitgeschakeld zijn.",
+                TemplateSlots: {
+                    GroupName: "Indelingssleuven",
+                    ConfigureSlotsLabel: "Bewerk indelingssleuven voor deze databron",
+                    ConfigureSlotsBtnLabel: "Bewerk",
+                    MissingSlotsMessage: "Ontbrekende sleuven gevonden in lay-outsjabloon: {0}",
+                    ConfigureSlotsPanelHeader: "Indelingssleuven",
+                    ConfigureSlotsPanelDescription: "Voeg hier sleuven toe voor gebruik in verschillende indelingen. Een sleuf is een placeholder variabele die je verwerkt in een sjabloon. De placeholder wordt dynamisch vervangen door een veldwaarde uit de databron. Op deze manier wordt je sjabloon meer generiek en herbruikbaar, ontkoppeld van specifieke velden uit de databron. Om deze te gebruiken, gebruik je de `{{slot item @root.slots.<SleufNaam>}}` Handlebars expressie.",
+                    SlotNameFieldName: "Sleuf naam",
+                    SlotFieldFieldName: "Sleuf veld",
+                    SlotFieldPlaceholderName: "Kies een veld"
+                }
+            },
+            LayoutPage: {
+                LayoutSelectionGroupName: "Beschikbare indelingen",
+                LayoutTemplateOptionsGroupName: "Indelingsopties",
+                CommonOptionsGroupName: "Algemeen",
+                TemplateUrlFieldLabel: "Gebruik een externe sjabloon URL",
+                TemplateUrlPlaceholder: "https://mijnbestand.html",
+                ErrorTemplateExtension: "Het sjabloon moet een geldig .txt, .htm of .html bestand zijn",
+                ErrorTemplateResolve: "Kan het opgegeven template niet inladen. Foutmelding: '{0}'",
+                DialogButtonLabel: "Bewerk resulaten sjabloon",
+                DialogTitle: "Bewerk resultaten sjabloon",
+                MissingSlotsMessage: "De volgende slots zijn niet geconfigureerd: {0}",
+                ShowSelectedFilters: "Toon geselecteerde filters",
+                ShowBlankIfNoResult: "Verberg dit webonderdeel wanneer er niets te tonen is.",
+                ShowResultsCount: "Toon aantal resultaten",
+                HandlebarsRenderTypeLabel: "Handlebars/HTML",
+                HandlebarsRenderTypeDesc: "Selecteer lay-outs op basis van HTML, CSS en stuur",
+                AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
+                AdaptiveCardsRenderTypeDesc: "Selecteer lay-outs op basis van JSON-adaptieve kaarten",
+                Handlebars: {
+                    UseMicrosoftGraphToolkit: "Gebruik de Microsoft Graph Toolkit",
+                    ResultTypes: {
+                        ResultTypeslabel: "Resultaattypen",
+                        ResultTypesDescription: "Voeg hier de sjablonen toe welke gebruikt worden voor zoekresultaten op basis van één of meer voorwaarden. Voorwaarden worden toegepast in de ingestelde volgorde. Externe templates krijgen voorrang op inline sjablonen. Zorg er ook voor dat de gebruikte velden uit de databron aanwezig zijn in de data van het antwoord.",
+                        InlineTemplateContentLabel: "Inline sjabloon",
+                        EditResultTypesLabel: "Bewerk resultaattypen",
+                        ConditionPropertyLabel: "Databron veld",
+                        ConditionValueLabel: "Voorwaarde",
+                        CondtionOperatorValue: "Operator",
+                        ExternalUrlLabel: "Externe sjabloon URL",
+                        EqualOperator: "Gelijk aan",
+                        NotEqualOperator: "Niet gelijk aan",
+                        ContainsOperator: "Bevat",
+                        StartsWithOperator: "Begint met",
+                        NotNullOperator: "Is niet null",
+                        GreaterOrEqualOperator: "Groter of gelijk",
+                        GreaterThanOperator: "Groter dan",
+                        LessOrEqualOperator: "Kleiner of gelijk",
+                        LessThanOperator: "Kleiner dan",
+                        CancelButtonText: "Annuleer",
+                        DialogButtonText: "Bewerk sjabloon",
+                        DialogTitle: "Bewerk resultaatsjabloon",
+                        SaveButtonText: "Bewaar",
+                    },
+                    AllowItemSelection: "Selectie van items toestaan",
+                    AllowMultipleItemSelection: "Meerdere selectie toestaan",
+                    SelectionPreservedOnEmptyClick: "Selectie behouden bij lege klik",
+                    SelectionModeLabel: "Selectiemodus",
+                    AsTokensSelectionMode: "Verwerk geselecteerde waarden als tokens (handmatige modus)",
+                    AsDataFiltersSelectionMode: "Verwerk geselecteerde waarden als filters (standaardmodus)",
+                    AsDataFiltersDescription: "In deze modus worden geselecteerde waarden als gewone filters naar de gegevensbron verzonden",
+                    AsTokensDescription: "In deze modus worden geselecteerde waarden handmatig gebruikt via tokens en beschikbare methoden. Voorbeeld met SharePoint-zoekopdrachtsjabloon: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
+                    FilterValuesOperator: "De logische operator die tussen geselecteerde waarden moet worden gebruikt",
+                    FieldToConsumeLabel: "Bronveld om te consumeren",
+                    FieldToConsumeDescription: "Gebruik deze veldwaarde voor geselecteerde items"
+                },
+                AdaptiveCards: {
+                    HostConfigFieldLabel: "Hostconfiguratie"
+                }
+            },
+            ConnectionsPage: {
+                ConnectionsPageGroupName: "Beschikbare verbindingen",
+                UseFiltersWebPartLabel: "Verbind met een filter webonderdeel",
+                UseFiltersFromComponentLabel: "Gebruik filters van dit onderdeel",
+                UseDynamicFilteringsWebPartLabel: "Verbinding maken met een webonderdeel met gegevensresultaten",
+                UseDataResultsFromComponentsLabel: "Gegevens uit dit webonderdeel gebruiken",
+                UseDataResultsFromComponentsDescription: "Gegevens gebruiken van geselecteerde items in deze webonderdelen",
+                UseSearchVerticalsWebPartLabel: "Verbind met een zoekverticalen webonderdeel",
+                UseSearchVerticalsFromComponentLabel: "Gebruik zoekverticalen van dit onderdeel",
+                LinkToVerticalLabel: "Toon data alleen wanneer de volgende zoekverticaal geselecteerd is",
+                LinkToVerticalLabelHoverMessage: "De resultaten worden enkel getoond wanneer de geselecteerde zoekverticaal overeenkomt met degene die geconfigureerd is voor dit webonderdeel. Wanneer dit niet het geval is blijft dit webonderdeel leeg in weergave modus (zonder marge en zonder padding)",
+                UseInputQueryText: "Gebruik ingegeven zoekopdracht",
+                UseInputQueryTextHoverMessage: "Gebruik het {inputQueryText} token in je databron om de waarde op te halen",
+                SearchQueryTextFieldLabel: "Zoekopdracht",
+                SearchQueryTextFieldDescription: "",
+                SearchQueryPlaceHolderText: "Geef zoekopdracht...",
+                InputQueryTextStaticValue: "Statische waarde",
+                InputQueryTextDynamicValue: "Dynamische waarde",
+                SearchQueryTextUseDefaultQuery: "Gebruik een standaardwaarde",
+                SearchQueryTextDefaultValue: "Standaardwaarde",
+                SourceDestinationFieldLabel: "Naam van bestemmingsveld",
+                SourceDestinationFieldDescription: "Bestemmingsveld dat in dit webonderdeel moet worden gebruikt om overeen te komen met de geselecteerde waarden",
+                AvailableFieldValuesFromResults: "Veld met de filterwaarde",
+                BidirectionalConnectionWarning: "Het verbonden filters webonderdeel is niet geconfigureerd om terug te verbinden met dit zoekresultaten webonderdeel. Beide webonderdelen moeten met elkaar verbonden zijn om filters correct te laten werken."
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configureer inladen van uitbreidingsbibliotheken bij opstarten",
+                    PanelDescription: "Beheer hier je aangepaste uitbreidingsbibliotheek ID's. Je kan hier een weergavenaam specificeren en aangeven of de bibliotheek geladen moet worden. Alleen aangepaste databronnen, indelingen, web componenten en Handlebars helpers worden hier geladen.",
+                }
+            },
+            CustomQueryModifier: {
+                EditQueryModifiersLabel: "Beschikbare aangepaste query-aanpassingen configureren",
+                QueryModifiersLabel: "Aangepaste query-aanpassingen",
+                QueryModifiersDescription: "Individuele aangepaste query-aanpassingen in- of uitschakelen",
+                EnabledPropertyLabel: "Ingeschakeld",
+                ModifierNamePropertyLabel: "Naam",
+                ModifierDescriptionPropertyLabel: "Beschrijving",
+                EndWhenSuccessfullPropertyLabel: "Beëindig bij succes"
+            }
+        },
+        Styling: {
+            StylingOptionsGroupName: "Stijlopties",
+            ResultsBackgroundColorLabel: "Resultaten achtergrondkleur",
+            ResultsBorderColorLabel: "Resultaten randkleur",
+            ResultsBorderThicknessLabel: "Resultaten randdikte",
+            ResetToDefaultLabel: "Herstel naar standaard styling",
+            ResetToDefaultDescription: "Herstel alle styling opties naar hun standaardwaarden"
         }
-      },
-      ConnectionsPage: {
-        ConnectionsPageGroupName: "Beschikbare verbindingen",
-        UseFiltersWebPartLabel: "Verbind met een filter webonderdeel",
-        UseFiltersFromComponentLabel: "Gebruik filters van dit onderdeel",
-        UseDynamicFilteringsWebPartLabel: "Verbinding maken met een webonderdeel met gegevensresultaten",
-        UseDataResultsFromComponentsLabel: "Gegevens uit dit webonderdeel gebruiken",
-        UseDataResultsFromComponentsDescription: "Gegevens gebruiken van geselecteerde items in deze webonderdelen",
-        UseSearchVerticalsWebPartLabel: "Verbind met een zoekverticalen webonderdeel",
-        UseSearchVerticalsFromComponentLabel: "Gebruik zoekverticalen van dit onderdeel",
-        LinkToVerticalLabel: "Toon data alleen wanneer de volgende zoekverticaal geselecteerd is",
-        LinkToVerticalLabelHoverMessage: "De resultaten worden enkel getoond wanneer de geselecteerde zoekverticaal overeenkomt met degene die geconfigureerd is voor dit webonderdeel. Wanneer dit niet het geval is blijft dit webonderdeel leeg in weergave modus (zonder marge en zonder padding)",
-        UseInputQueryText: "Gebruik ingegeven zoekopdracht",
-        UseInputQueryTextHoverMessage: "Gebruik het {inputQueryText} token in je databron om de waarde op te halen",
-        SearchQueryTextFieldLabel: "Zoekopdracht",
-        SearchQueryTextFieldDescription: "",
-        SearchQueryPlaceHolderText: "Geef zoekopdracht...",
-        InputQueryTextStaticValue: "Statische waarde",
-        InputQueryTextDynamicValue: "Dynamische waarde",
-        SearchQueryTextUseDefaultQuery: "Gebruik een standaardwaarde",
-        SearchQueryTextDefaultValue: "Standaardwaarde",
-        SourceDestinationFieldLabel: "Naam van bestemmingsveld",
-        SourceDestinationFieldDescription: "Bestemmingsveld dat in dit webonderdeel moet worden gebruikt om overeen te komen met de geselecteerde waarden",
-        AvailableFieldValuesFromResults: "Veld met de filterwaarde"
-      },
-      InformationPage: {
-        Extensibility: {
-          PanelHeader: "Configureer inladen van uitbreidingsbibliotheken bij opstarten",
-          PanelDescription:"Beheer hier je aangepaste uitbreidingsbibliotheek ID's. Je kan hier een weergavenaam specificeren en aangeven of de bibliotheek geladen moet worden. Alleen aangepaste databronnen, indelingen, web componenten en Handlebars helpers worden hier geladen.",
-        }
-      },
-      CustomQueryModifier: {
-            EditQueryModifiersLabel: "Beschikbare aangepaste query-aanpassingen configureren",
-            QueryModifiersLabel: "Aangepaste query-aanpassingen",
-            QueryModifiersDescription: "Individuele aangepaste query-aanpassingen in- of uitschakelen",
-            EnabledPropertyLabel: "Ingeschakeld",
-            ModifierNamePropertyLabel: "Naam",
-            ModifierDescriptionPropertyLabel: "Beschrijving",
-            EndWhenSuccessfullPropertyLabel:"Beëindig bij succes"        
-      }    },
-    Styling: {
-      StylingOptionsGroupName: "Stijlopties",
-      ResultsBackgroundColorLabel: "Resultaten achtergrondkleur",
-      ResultsBorderColorLabel: "Resultaten randkleur",
-      ResultsBorderThicknessLabel: "Resultaten randdikte",
-      ResetToDefaultLabel: "Herstel naar standaard styling",
-      ResetToDefaultDescription: "Herstel alle styling opties naar hun standaardwaarden"    }
-  }
+    }
 });

--- a/search-parts/src/webparts/searchResults/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchResults/loc/pl-pl.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -91,7 +91,7 @@ define([], function() {
                 },
                 AdaptiveCards: {
                     HostConfigFieldLabel: "Konfiguracja hosta"
-                }                
+                }
             },
             ConnectionsPage: {
                 ConnectionsPageGroupName: "Dostępne połączenia",
@@ -115,7 +115,8 @@ define([], function() {
                 SearchQueryTextDefaultValue: "Wartość domyślna",
                 SourceDestinationFieldLabel: "Nazwa pola docelowego",
                 SourceDestinationFieldDescription: "Pole docelowe do użycia w tym składniku Web Part w celu dopasowania wybranych wartości",
-                AvailableFieldValuesFromResults: "Pole zawierające wartość filtra"
+                AvailableFieldValuesFromResults: "Pole zawierające wartość filtra",
+                BidirectionalConnectionWarning: "Połączony składnik Web Part filtrów nie został skonfigurowany do połączenia zwrotnego z tym składnikiem Web Part wyników wyszukiwania. Oba składniki Web Part muszą być ze sobą połączone, aby filtry działały poprawnie."
             },
             InformationPage: {
                 Extensibility: {
@@ -124,13 +125,13 @@ define([], function() {
                 }
             },
             CustomQueryModifier: {
-                  EditQueryModifiersLabel: "Konfiguracja dostępnych niestandardowych modyfikatorów zapytań",
-                  QueryModifiersLabel: "Własne modyfikatory zapytań",
-                  QueryModifiersDescription: "Włączanie lub wyłączanie poszczególnych własnych modyfikatorów zapytań",
-                  EnabledPropertyLabel: "Włączone",
-                  ModifierNamePropertyLabel: "Nazwa",
-                  ModifierDescriptionPropertyLabel: "Opis",
-                  EndWhenSuccessfullPropertyLabel:"Zakończ po pomyślnym zakończeniu"              
+                EditQueryModifiersLabel: "Konfiguracja dostępnych niestandardowych modyfikatorów zapytań",
+                QueryModifiersLabel: "Własne modyfikatory zapytań",
+                QueryModifiersDescription: "Włączanie lub wyłączanie poszczególnych własnych modyfikatorów zapytań",
+                EnabledPropertyLabel: "Włączone",
+                ModifierNamePropertyLabel: "Nazwa",
+                ModifierDescriptionPropertyLabel: "Opis",
+                EndWhenSuccessfullPropertyLabel: "Zakończ po pomyślnym zakończeniu"
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchResults/loc/pt-br.js
+++ b/search-parts/src/webparts/searchResults/loc/pt-br.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
     return {
         General: {
             PlaceHolder: {
@@ -99,7 +99,7 @@ define([], function() {
                 UseFiltersFromComponentLabel: "Usar filtros deste componente",
                 UseDynamicFilteringsWebPartLabel: "Conectar a uma Web Part de resultados de busca",
                 UseDataResultsFromComponentsLabel: "Usar os dados desta Web Part",
-                UseDataResultsFromComponentsDescription: "Usar dados de itens selecionados destas Web Parts",                
+                UseDataResultsFromComponentsDescription: "Usar dados de itens selecionados destas Web Parts",
                 UseSearchVerticalsWebPartLabel: "Conectar com uma Web Part de verticais",
                 UseSearchVerticalsFromComponentLabel: "Usar as verticais deste componente",
                 LinkToVerticalLabel: "Exibir dados somente quando a seguinte vertical estiver selecionada",
@@ -115,7 +115,8 @@ define([], function() {
                 SearchQueryTextDefaultValue: "Valor padrão",
                 SourceDestinationFieldLabel: "Nome do campo de destino",
                 SourceDestinationFieldDescription: "Campo de destino para usar nesta WebPart mara combinar com os valores selecionados",
-                AvailableFieldValuesFromResults: "Campo contendo o valor do filtro"
+                AvailableFieldValuesFromResults: "Campo contendo o valor do filtro",
+                BidirectionalConnectionWarning: "A Web Part de filtros conectada não foi configurada para se conectar de volta a esta Web Part de resultados de pesquisa. Ambas as Web Parts devem estar conectadas entre si para que os filtros funcionem corretamente."
             },
             InformationPage: {
                 Extensibility: {
@@ -130,7 +131,7 @@ define([], function() {
                 EnabledPropertyLabel: "Ativado",
                 ModifierNamePropertyLabel: "Nome",
                 ModifierDescriptionPropertyLabel: "Descrição",
-                EndWhenSuccessfullPropertyLabel:"Terminar quando bem sucedido!"                
+                EndWhenSuccessfullPropertyLabel: "Terminar quando bem sucedido!"
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchResults/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchResults/loc/sv-SE.js
@@ -1,143 +1,146 @@
-define([], function() {
-  return {
-    General: {
-      PlaceHolder: {
-        EditLabel: "Redigera",
-        IconText: "Sökresultat webbdel av @PnP",
-        Description: "Visa sökresultat från SharePoint- eller Microsoft-sökning.",
-        ConfigureBtnLabel: "Konfigurera"
-      },
-      WebPartDefaultTitle: "Sökresultat webbdel",
-      ShowBlankEditInfoMessage: "Inget resultat returneras för denna fråga. Denna webbdel förblir tom i visningsläge enligt parametrarna.",
-      CurrentVerticalNotSelectedMessage: "Den valda vertikalen matchar inte den som är associerad med den här webbdelen. Den förblir tom i visningsläge."
-    },
-    PropertyPane: {
-      DataSourcePage: {
-        DataSourceConnectionGroupName: "Tillgängliga datakällor",
-        PagingOptionsGroupName: "Inställningar för sidindelning",
-        ItemsCountPerPageFieldName: "Antal objekt per sida",
-        PagingRangeFieldName: "Antal sidor att visa i sidnavigation",
-        ShowPagingFieldName: "Visa sidnavigation",
-        HidePageNumbersFieldName: "Dölj sidnummer",
-        HideNavigationFieldName: "Dölj navigeringsval (föregående sida, nästa sida)",
-        HideFirstLastPagesFieldName: "Dölj första/sista navigeringsknapparna",
-        HideDisabledFieldName: "Dölj navigeringsval (föregående, nästa, första, sista) om de är inaktiverade",
-        TemplateSlots: {
-          GroupName: "Layout",
-          ConfigureSlotsLabel: "Redigera layout för den här datakällan",
-          ConfigureSlotsBtnLabel: "Anpassa",
-          MissingSlotsMessage: "Saknade slots hittades i layoutmall: {0}",
-          ConfigureSlotsPanelHeader: "Layout",
-          ConfigureSlotsPanelDescription: "Här kan du lägga till namn och fält som ska användas för de olika layouterna. Ett fält är en platshållarvariabel som du infogar i din mall, där värdet kommer att ersättas med ett fältvärde från en datakälla. På så sätt blir dina mallar mer generiska och lättare att återanvända. Om du vill använda dem använder du `{{slot item @root.slots.<SlotName>}}` Handlebars-uttrycket.",
-          SlotNameFieldName: "Namn",
-          SlotFieldFieldName: "Fält",
-          SlotFieldPlaceholderName: "Välj ett fält"
-        }
-      },
-      LayoutPage: {
-        LayoutSelectionGroupName: "Tillgängliga layouter",
-        LayoutTemplateOptionsGroupName: "Layoutalternativ",
-        CommonOptionsGroupName: "Vanlig",
-        TemplateUrlFieldLabel: "Använd en extern URL för mall",
-        TemplateUrlPlaceholder: "https://myfile.html",
-        ErrorTemplateExtension: "Mallen måste vara en giltig .txt-, .htm- eller .html-fil",
-        ErrorTemplateResolve: "Det går inte att läsa den angivna mallen. Felbeskrivning: '{0}'",
-        DialogButtonLabel: "Redigera resultatmallen",
-        DialogTitle: "Redigera resultatmallen",
-        MissingSlotsMessage: "Följande slots har inte konfigurerats: {0}",
-        ShowSelectedFilters: "Visa valda filter",
-        ShowBlankIfNoResult: "Dölj den här webbdelen om det inte finns något att visa",
-        ShowResultsCount: "Visa antalet resultat",
-        HandlebarsRenderTypeLabel: "Handlebars/HTML",
-        HandlebarsRenderTypeDesc: "Välj layouter baserade på HTML, CSS och Handlebars",
-        AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
-        AdaptiveCardsRenderTypeDesc: "Välj layouter baserade på adaptiva JSON-kort",        
-        Handlebars: {
-          UseMicrosoftGraphToolkit: "Använd Microsoft Graph Toolkit",
-          ResultTypes: {
-            ResultTypeslabel: "Resultattyper",
-            ResultTypesDescription: "Här kan du lägga till de mallar som du vill använda i resultaten enligt ett eller flera villkor. Villkoren utvärderas i den konfigurerade ordningen och externa mallar har företräde framför integrerade mallar. Se till att fälten på den datakälla du använder finns i datasvaret.",
-            InlineTemplateContentLabel: "Integrerad mall",
-            EditResultTypesLabel: "Redigera resultattyper",
-            ConditionPropertyLabel: "Fält på datakälla",
-            ConditionValueLabel: "Villkorsvärde",
-            CondtionOperatorValue: "Operator",
-            ExternalUrlLabel: "Extern mall-URL",
-            EqualOperator: "Är lika med",
-            NotEqualOperator: "Inte lika med",
-            ContainsOperator: "Innehåller",
-            StartsWithOperator: "Startar med",
-            NotNullOperator: "Är inte null",
-            GreaterOrEqualOperator: "Större eller lika med",
-            GreaterThanOperator: "Större än",
-            LessOrEqualOperator: "Mindre eller lika med",
-            LessThanOperator: "Mindre än",
-            CancelButtonText: "Avbryt",
-            DialogButtonText: "Redigera mall",
-            DialogTitle: "Redigera resultatmall",
-            SaveButtonText: "Spara"
-          },
-          AllowItemSelection: "Tillåt val av objekt",
-          AllowMultipleItemSelection: "Tillåt flera val",
-          SelectionPreservedOnEmptyClick: "Behåll val vid tomt klick",
-          SelectionModeLabel: "Urvalsläge",
-          AsTokensSelectionMode: "Bearbeta valda värden som tokens (manuellt läge)",
-          AsDataFiltersSelectionMode: "Bearbeta valda värden som filter (standardläge)",
-          AsDataFiltersDescription: "I det här läget skickas valda värden till datakällan som vanliga filter",
-          AsTokensDescription: "I det här läget används valda värden manuellt genom tokens och tillgängliga metoder. Exempel med SharePoint-sökfrågemall: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
-          FilterValuesOperator: "Den logiska operatorn att använda mellan valda värden",
-          FieldToConsumeLabel: "Källfält att konsumera",
-          FieldToConsumeDescription: "Använd detta fältvärde för valda objekt"
+define([], function () {
+    return {
+        General: {
+            PlaceHolder: {
+                EditLabel: "Redigera",
+                IconText: "Sökresultat webbdel av @PnP",
+                Description: "Visa sökresultat från SharePoint- eller Microsoft-sökning.",
+                ConfigureBtnLabel: "Konfigurera"
+            },
+            WebPartDefaultTitle: "Sökresultat webbdel",
+            ShowBlankEditInfoMessage: "Inget resultat returneras för denna fråga. Denna webbdel förblir tom i visningsläge enligt parametrarna.",
+            CurrentVerticalNotSelectedMessage: "Den valda vertikalen matchar inte den som är associerad med den här webbdelen. Den förblir tom i visningsläge."
         },
-        AdaptiveCards: {
-          HostConfigFieldLabel: "Värdkonfiguration"
-        }        
-      },
-      ConnectionsPage: {
-        ConnectionsPageGroupName: "Tillgängliga anslutningar",
-        UseFiltersWebPartLabel: "Anslut till en filter-webbdel",
-        UseFiltersFromComponentLabel: "Använd filter från den här komponenten",
-        UseDynamicFilteringsWebPartLabel: "Anslut till en webbdel för dataresultat",
-        UseDataResultsFromComponentsLabel: "Använd data från denna webbdel",
-        UseDataResultsFromComponentsDescription: "Use data from selected items in these Web Parts",
-        UseSearchVerticalsWebPartLabel: "Använd data från valda objekt i dessa webbdelar",
-        UseSearchVerticalsFromComponentLabel: "Använd vertikaler från denna komponent",
-        LinkToVerticalLabel: "Visa endast data när följande vertikaler är valda",
-        LinkToVerticalLabelHoverMessage: "Resultaten visas endast om de valda vertikalerna matchar den som har konfigurerats för denna webbdel. Annars är den här webbdelen tom.",
-        UseInputQueryText: "Använd inmatning för sökfrågetext",
-        UseInputQueryTextHoverMessage: "Använd {inputQueryText} i din datakälla för att hämta detta värde",
-        SearchQueryTextFieldLabel: "Sökfrågetext",
-        SearchQueryTextFieldDescription: "",
-        SearchQueryPlaceHolderText: "Ange frågetext ...",
-        InputQueryTextStaticValue: "Statiskt värde",
-        InputQueryTextDynamicValue: "Dynamiskt värde",
-        SearchQueryTextUseDefaultQuery: "Använd ett standardvärde",
-        SearchQueryTextDefaultValue: "Standardvärde",
-        SourceDestinationFieldLabel: "Destinationsfältets namn",
-        SourceDestinationFieldDescription: "Destinationsfält som ska användas i den här webbdelen för att matcha de valda värdena",
-        AvailableFieldValuesFromResults: "Fält som innehåller filtervärdet"
-      },
-      InformationPage: {
-        Extensibility: {
-          PanelHeader: "Konfigurera utbyggnadsbibliotek som ska laddas vid start.",
-          PanelDescription: "Lägg till/ta bort anpassade utbyggnadsbiblioteket-ID:n här. Du kan ange ett visningsnamn och bestämma om biblioteket ska laddas eller ej vid start. Här laddas bara anpassade datakällor, layouter, webbkomponenter och styrhjälpmedel.",
+        PropertyPane: {
+            DataSourcePage: {
+                DataSourceConnectionGroupName: "Tillgängliga datakällor",
+                PagingOptionsGroupName: "Inställningar för sidindelning",
+                ItemsCountPerPageFieldName: "Antal objekt per sida",
+                PagingRangeFieldName: "Antal sidor att visa i sidnavigation",
+                ShowPagingFieldName: "Visa sidnavigation",
+                HidePageNumbersFieldName: "Dölj sidnummer",
+                HideNavigationFieldName: "Dölj navigeringsval (föregående sida, nästa sida)",
+                HideFirstLastPagesFieldName: "Dölj första/sista navigeringsknapparna",
+                HideDisabledFieldName: "Dölj navigeringsval (föregående, nästa, första, sista) om de är inaktiverade",
+                TemplateSlots: {
+                    GroupName: "Layout",
+                    ConfigureSlotsLabel: "Redigera layout för den här datakällan",
+                    ConfigureSlotsBtnLabel: "Anpassa",
+                    MissingSlotsMessage: "Saknade slots hittades i layoutmall: {0}",
+                    ConfigureSlotsPanelHeader: "Layout",
+                    ConfigureSlotsPanelDescription: "Här kan du lägga till namn och fält som ska användas för de olika layouterna. Ett fält är en platshållarvariabel som du infogar i din mall, där värdet kommer att ersättas med ett fältvärde från en datakälla. På så sätt blir dina mallar mer generiska och lättare att återanvända. Om du vill använda dem använder du `{{slot item @root.slots.<SlotName>}}` Handlebars-uttrycket.",
+                    SlotNameFieldName: "Namn",
+                    SlotFieldFieldName: "Fält",
+                    SlotFieldPlaceholderName: "Välj ett fält"
+                }
+            },
+            LayoutPage: {
+                LayoutSelectionGroupName: "Tillgängliga layouter",
+                LayoutTemplateOptionsGroupName: "Layoutalternativ",
+                CommonOptionsGroupName: "Vanlig",
+                TemplateUrlFieldLabel: "Använd en extern URL för mall",
+                TemplateUrlPlaceholder: "https://myfile.html",
+                ErrorTemplateExtension: "Mallen måste vara en giltig .txt-, .htm- eller .html-fil",
+                ErrorTemplateResolve: "Det går inte att läsa den angivna mallen. Felbeskrivning: '{0}'",
+                DialogButtonLabel: "Redigera resultatmallen",
+                DialogTitle: "Redigera resultatmallen",
+                MissingSlotsMessage: "Följande slots har inte konfigurerats: {0}",
+                ShowSelectedFilters: "Visa valda filter",
+                ShowBlankIfNoResult: "Dölj den här webbdelen om det inte finns något att visa",
+                ShowResultsCount: "Visa antalet resultat",
+                HandlebarsRenderTypeLabel: "Handlebars/HTML",
+                HandlebarsRenderTypeDesc: "Välj layouter baserade på HTML, CSS och Handlebars",
+                AdaptiveCardsRenderTypeLabel: "Adaptive Cards",
+                AdaptiveCardsRenderTypeDesc: "Välj layouter baserade på adaptiva JSON-kort",
+                Handlebars: {
+                    UseMicrosoftGraphToolkit: "Använd Microsoft Graph Toolkit",
+                    ResultTypes: {
+                        ResultTypeslabel: "Resultattyper",
+                        ResultTypesDescription: "Här kan du lägga till de mallar som du vill använda i resultaten enligt ett eller flera villkor. Villkoren utvärderas i den konfigurerade ordningen och externa mallar har företräde framför integrerade mallar. Se till att fälten på den datakälla du använder finns i datasvaret.",
+                        InlineTemplateContentLabel: "Integrerad mall",
+                        EditResultTypesLabel: "Redigera resultattyper",
+                        ConditionPropertyLabel: "Fält på datakälla",
+                        ConditionValueLabel: "Villkorsvärde",
+                        CondtionOperatorValue: "Operator",
+                        ExternalUrlLabel: "Extern mall-URL",
+                        EqualOperator: "Är lika med",
+                        NotEqualOperator: "Inte lika med",
+                        ContainsOperator: "Innehåller",
+                        StartsWithOperator: "Startar med",
+                        NotNullOperator: "Är inte null",
+                        GreaterOrEqualOperator: "Större eller lika med",
+                        GreaterThanOperator: "Större än",
+                        LessOrEqualOperator: "Mindre eller lika med",
+                        LessThanOperator: "Mindre än",
+                        CancelButtonText: "Avbryt",
+                        DialogButtonText: "Redigera mall",
+                        DialogTitle: "Redigera resultatmall",
+                        SaveButtonText: "Spara"
+                    },
+                    AllowItemSelection: "Tillåt val av objekt",
+                    AllowMultipleItemSelection: "Tillåt flera val",
+                    SelectionPreservedOnEmptyClick: "Behåll val vid tomt klick",
+                    SelectionModeLabel: "Urvalsläge",
+                    AsTokensSelectionMode: "Bearbeta valda värden som tokens (manuellt läge)",
+                    AsDataFiltersSelectionMode: "Bearbeta valda värden som filter (standardläge)",
+                    AsDataFiltersDescription: "I det här läget skickas valda värden till datakällan som vanliga filter",
+                    AsTokensDescription: "I det här läget används valda värden manuellt genom tokens och tillgängliga metoder. Exempel med SharePoint-sökfrågemall: {?Title:{filters.&lt;destination_field_name&gt;.valueAsText}}",
+                    FilterValuesOperator: "Den logiska operatorn att använda mellan valda värden",
+                    FieldToConsumeLabel: "Källfält att konsumera",
+                    FieldToConsumeDescription: "Använd detta fältvärde för valda objekt"
+                },
+                AdaptiveCards: {
+                    HostConfigFieldLabel: "Värdkonfiguration"
+                }
+            },
+            ConnectionsPage: {
+                ConnectionsPageGroupName: "Tillgängliga anslutningar",
+                UseFiltersWebPartLabel: "Anslut till en filter-webbdel",
+                UseFiltersFromComponentLabel: "Använd filter från den här komponenten",
+                UseDynamicFilteringsWebPartLabel: "Anslut till en webbdel för dataresultat",
+                UseDataResultsFromComponentsLabel: "Använd data från denna webbdel",
+                UseDataResultsFromComponentsDescription: "Use data from selected items in these Web Parts",
+                UseSearchVerticalsWebPartLabel: "Använd data från valda objekt i dessa webbdelar",
+                UseSearchVerticalsFromComponentLabel: "Använd vertikaler från denna komponent",
+                LinkToVerticalLabel: "Visa endast data när följande vertikaler är valda",
+                LinkToVerticalLabelHoverMessage: "Resultaten visas endast om de valda vertikalerna matchar den som har konfigurerats för denna webbdel. Annars är den här webbdelen tom.",
+                UseInputQueryText: "Använd inmatning för sökfrågetext",
+                UseInputQueryTextHoverMessage: "Använd {inputQueryText} i din datakälla för att hämta detta värde",
+                SearchQueryTextFieldLabel: "Sökfrågetext",
+                SearchQueryTextFieldDescription: "",
+                SearchQueryPlaceHolderText: "Ange frågetext ...",
+                InputQueryTextStaticValue: "Statiskt värde",
+                InputQueryTextDynamicValue: "Dynamiskt värde",
+                SearchQueryTextUseDefaultQuery: "Använd ett standardvärde",
+                SearchQueryTextDefaultValue: "Standardvärde",
+                SourceDestinationFieldLabel: "Destinationsfältets namn",
+                SourceDestinationFieldDescription: "Destinationsfält som ska användas i den här webbdelen för att matcha de valda värdena",
+                AvailableFieldValuesFromResults: "Fält som innehåller filtervärdet",
+                BidirectionalConnectionWarning: "Den anslutna filterwebbdelen har inte konfigurerats för att ansluta tillbaka till denna sökresultatwebbdel. Båda webbdelarna måste vara anslutna till varandra för att filtren ska fungera korrekt."
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurera utbyggnadsbibliotek som ska laddas vid start.",
+                    PanelDescription: "Lägg till/ta bort anpassade utbyggnadsbiblioteket-ID:n här. Du kan ange ett visningsnamn och bestämma om biblioteket ska laddas eller ej vid start. Här laddas bara anpassade datakällor, layouter, webbkomponenter och styrhjälpmedel.",
+                }
+            },
+            CustomQueryModifier: {
+                EditQueryModifiersLabel: "Konfigurera tillgängliga modifieringar för anpassade frågor",
+                QueryModifiersLabel: "Modifiering av anpassade frågor",
+                QueryModifiersDescription: "Aktivera eller inaktivera enskilda anpassade frågeändringar.",
+                EnabledPropertyLabel: "Aktiverad",
+                ModifierNamePropertyLabel: "Namn",
+                ModifierDescriptionPropertyLabel: "Beskrivning",
+                EndWhenSuccessfullPropertyLabel: "Avsluta när det är lyckat"
+            }
+        },
+        Styling: {
+            StylingOptionsGroupName: "Stilalternativ",
+            ResultsBackgroundColorLabel: "Resultat bakgrundsfärg",
+            ResultsBorderColorLabel: "Resultat kantfärg",
+            ResultsBorderThicknessLabel: "Resultat kanttjocklek",
+            ResetToDefaultLabel: "Återställ till standardstil",
+            ResetToDefaultDescription: "Återställ alla stilalternativ till sina standardvärden"
         }
-      },
-      CustomQueryModifier: {
-            EditQueryModifiersLabel: "Konfigurera tillgängliga modifieringar för anpassade frågor",
-            QueryModifiersLabel: "Modifiering av anpassade frågor",
-            QueryModifiersDescription: "Aktivera eller inaktivera enskilda anpassade frågeändringar.",
-            EnabledPropertyLabel: "Aktiverad",
-            ModifierNamePropertyLabel: "Namn",
-            ModifierDescriptionPropertyLabel: "Beskrivning",
-            EndWhenSuccessfullPropertyLabel:"Avsluta när det är lyckat"        
-      }    },
-    Styling: {
-      StylingOptionsGroupName: "Stilalternativ",
-      ResultsBackgroundColorLabel: "Resultat bakgrundsfärg",
-      ResultsBorderColorLabel: "Resultat kantfärg",
-      ResultsBorderThicknessLabel: "Resultat kanttjocklek",
-      ResetToDefaultLabel: "Återställ till standardstil",
-      ResetToDefaultDescription: "Återställ alla stilalternativ till sina standardvärden"    }
-  }
+    }
 });


### PR DESCRIPTION
## Summary

When a search results web part connects to a filters web part (or vice versa), a warning is now shown in the property pane if the other web part has not been configured to connect back. Both web parts must reference each other for filters to work correctly.

## Changes

- Extended `IDataFilterSourceData` with `connectedResultsSourceReferences` and `IDataResultSourceData` with `connectedFilterSourceReference` to allow cross-validation of connections
- Added a warning message in the **Search Results** web part property pane (connections section) when the connected filters web part hasn't connected back
- Added a warning message in the **Search Filters** web part property pane (connections section) when connected results web parts haven't connected back
- Loaded `PropertyPaneWebPartInformation` in the filters web part to render the warning
- Added `BidirectionalConnectionWarning` locale string translations for all 13 supported languages (en-us, fr-fr, de-de, es-es, it-it, nl-nl, pt-br, da-dk, nb-no, sv-SE, fi-fi, cs-cz, pl-pl)