### PR TITLE
Add column header tooltips to the Details List layout

### DIFF
--- a/search-parts/src/components/DetailsListComponent.module.scss
+++ b/search-parts/src/components/DetailsListComponent.module.scss
@@ -1,3 +1,19 @@
 .detailsListHeader {
   content: '';
 }
+
+.columnHeaderWithInfo {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+}
+
+.columnHeaderTitle {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -11,8 +11,6 @@ import {
   StickyPositionType,
   ScrollablePane,
   ScrollbarVisibility,
-} from "@fluentui/react";
-import {
   ITooltipHostProps,
   TooltipHost,
   ITooltipStyles,
@@ -23,6 +21,7 @@ import {
   mergeStyleSets,
   ITheme,
   Selection,
+  IconButton,
 } from "@fluentui/react";
 import * as Handlebars from "handlebars";
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
@@ -56,7 +55,6 @@ import {
   IDetailsList,
   IDetailsColumnProps,
 } from "@fluentui/react/lib/DetailsList";
-import { IconButton } from "@fluentui/react";
 import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext";
 import { ObjectHelper } from "../helpers/ObjectHelper";
 import { ITemplateService } from "../services/templateService/ITemplateService";
@@ -907,7 +905,7 @@ export class DetailsListComponent extends React.Component<
     );
   }
 
-  private _onRenderColumnHeaderWithInfo = (column: IDetailsListColumnConfiguration, headerProps?: IDetailsColumnProps): JSX.Element => {
+  private readonly _onRenderColumnHeaderWithInfo = (column: IDetailsListColumnConfiguration, headerProps?: IDetailsColumnProps): JSX.Element => {
     const hasDescription = !!column.columnDescription?.trim();
     const columnWidth = headerProps?.column?.calculatedWidth ?? headerProps?.column?.currentWidth ?? 999;
     const showIcon = hasDescription && columnWidth >= 30;

--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -54,7 +54,9 @@ import {
   IDetailsCheckboxProps,
   ConstrainMode,
   IDetailsList,
+  IDetailsColumnProps,
 } from "@fluentui/react/lib/DetailsList";
+import { IconButton } from "@fluentui/react";
 import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext";
 import { ObjectHelper } from "../helpers/ObjectHelper";
 import { ITemplateService } from "../services/templateService/ITemplateService";
@@ -158,6 +160,12 @@ export interface IDetailsListColumnConfiguration {
    * Enable multiline column
    */
   isMultiline: boolean;
+
+  /**
+   * Optional description shown as a tooltip on an info icon in the column header.
+   * Leave empty to show no icon.
+   */
+  columnDescription?: string;
 
   /**
    * Callback handler when a sort field and direction are selected
@@ -441,6 +449,9 @@ export class DetailsListComponent extends React.Component<
               value: column.valueSorting,
             },
             isPadded: true,
+            onRenderHeader: (headerProps?: IDetailsColumnProps) => {
+              return this._onRenderColumnHeaderWithInfo(column, headerProps);
+            },
             onRender: (item: any) => {
               let value: any;
               let renderColumnValue: JSX.Element = null;
@@ -895,6 +906,47 @@ export class DetailsListComponent extends React.Component<
       </div>
     );
   }
+
+  private _onRenderColumnHeaderWithInfo = (column: IDetailsListColumnConfiguration, headerProps?: IDetailsColumnProps): JSX.Element => {
+    const hasDescription = !!column.columnDescription?.trim();
+    const columnWidth = headerProps?.column?.calculatedWidth ?? headerProps?.column?.currentWidth ?? 999;
+    const showIcon = hasDescription && columnWidth >= 30;
+
+    return (
+      <div className={detailsListStyles.columnHeaderWithInfo}>
+        <span
+          className={detailsListStyles.columnHeaderTitle}
+          title={column.name}
+        >
+          {column.name}
+        </span>
+        {showIcon && (
+          <TooltipHost content={column.columnDescription} calloutProps={{ gapSpace: 0 }}>
+            <IconButton
+              iconProps={{ iconName: "Info" }}
+              styles={{
+                root: {
+                  padding: "0 4px",
+                  height: "24px",
+                  width: "24px",
+                  minWidth: "24px",
+                  flexShrink: 0,
+                },
+                icon: {
+                  color: this.props.themeVariant?.semanticColors.bodySubtext,
+                  fontSize: "12px",
+                },
+                rootHovered: {
+                  backgroundColor: this.props.themeVariant?.semanticColors.listHeaderBackgroundHovered,
+                },
+              }}
+              ariaLabel={`More information about ${column.name}`}
+            />
+          </TooltipHost>
+        )}
+      </div>
+    );
+  };
 
   private _onRenderColumnHeaderTooltip = (tooltipHostProps: ITooltipHostProps): JSX.Element => {
     const customStyles: Partial<ITooltipStyles> = {};

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -308,11 +308,15 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                 placeholder: "",
                 searchAsYouType: false,
                 defaultSelectedKeys: this.properties.entityTypes,
-                onPropertyChange: (targetProperty?: string, newValue?: EntityType[]) => {
+                onPropertyChange: (targetProperty: string, newValue: IComboBoxOption | IComboBoxOption[]) => {
                     const previousEnableResultTypes = this.properties.enableResultTypes;
                     this.onCustomPropertyUpdate(targetProperty, newValue);
 
-                    if (supportsResultTypes(newValue) && previousEnableResultTypes) {
+                    const selectedEntityTypes = (Array.isArray(newValue) ? newValue : [newValue])
+                        .filter(Boolean)
+                        .map((option) => option.key as EntityType);
+
+                    if (supportsResultTypes(selectedEntityTypes) && previousEnableResultTypes) {
                         this.properties.enableResultTypes = previousEnableResultTypes;
                     }
                 },

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -276,6 +276,13 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
                         type: this._customCollectionFieldType.boolean,
                         defaultValue: false,
                         required: false
+                    },
+                    {
+                        id: 'columnDescription',
+                        title: strings.Layouts.DetailsList.ColumnDescriptionFieldLabel,
+                        type: this._customCollectionFieldType.string,
+                        defaultValue: '',
+                        required: false
                     }
                 ]
             }),

--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -244,6 +244,7 @@ declare interface ICommonStrings {
         StickyHeaderListViewHeight: string;
         EnableDownload: string;
         UseAlternatingBackgroundColor:string;
+        ColumnDescriptionFieldLabel: string;
       };
       Cards: {
         Name: string;

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -244,7 +244,8 @@ define([], function () {
                 EnableStickyHeader: "Enable sticky header",
                 StickyHeaderListViewHeight: "List view height (in px)",
                 EnableDownload: "Enable download",
-                UseAlternatingBackgroundColor: "Use Alternating Background Color"
+                UseAlternatingBackgroundColor: "Use Alternating Background Color",
+                ColumnDescriptionFieldLabel: "Column description (tooltip)"
             },
             Cards: {
                 Name: "Cards",


### PR DESCRIPTION
## Summary

This PR adds support for optional column header tooltips in the built-in Search Results `Details List` layout.

When a column has a description configured, an info icon is shown in the header and displays the configured tooltip text. If the description is empty or missing, no icon is shown.

Related discussion: https://github.com/microsoft-search/pnp-modern-search/discussions/4745

## Changes

- add `columnDescription` support to Details List column configuration
- add a property pane field for column descriptions
- render an info icon in Details List column headers when a description is present
- add the corresponding localization label

## Additional fix included

While validating this change, I hit an unrelated TypeScript build error in `MicrosoftSearchDataSource.ts` caused by a callback type mismatch. A small type-correctness fix for that callback is included so the branch builds successfully.

## Validation

Tested via local page-based debugging and by deploying the packaged solution to a dev tenant:

- configured tooltip text for multiple Details List columns
- verified headers with descriptions show the info icon and tooltip
- verified headers with empty descriptions show no icon
- verified values persist in web part data
- verified existing columns without `columnDescription` continue to behave normally
- verified full `search-parts` build passes
