### PR TITLE
Add built-in string hex template helpers

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -243,6 +243,40 @@ Supported output format tokens include all [dayjs format tokens](https://day.js.
 
 **Example** `{{slot item "property.subproperty"}}`
 
+#### stringToHex
+
+**Syntax** `{{stringToHex <value>}}`
+
+**Description** Convert a string value to a UTF-8 hexadecimal string. This is useful when you need to generate the encoded filter value used by the Search Filters deep-link format.
+
+**Example** `{{stringToHex "Keogh’s Crisps"}}` returns `4b656f6768e280997320437269737073`.
+
+#### hexToString
+
+**Syntax** `{{hexToString <value>}}`
+
+**Description** Convert a UTF-8 hexadecimal string back to text. The helper also accepts the filter value format used in deep links, including optional surrounding quotes and the `ǂǂ` prefix.
+
+**Example** `{{hexToString '"ǂǂ4b656f6768e280997320437269737073"'}}` returns `Keogh’s Crisps`.
+
+#### Deep Link Example For Search Filters
+
+If you want a value rendered in a custom results template to open a page with a filter already selected, you can build the filter payload yourself.
+
+The deep-link query string parameter is `f_<Search Filters instance ID>`. The filter `value` must contain the UTF-8 hex form of the label, prefixed with `ǂǂ` and wrapped in escaped quotes.
+
+```handlebars
+{{!-- Example for a Search Filters web part whose instance ID is known --}}
+{{!-- Replace the GUID below with the instance ID of your Search Filters web part --}}
+<a
+    href="/sites/contoso/SitePages/Search.aspx?f_4b43307b-8891-42d5-9a62-7bfb83c11de9=%5B%7B%22filterName%22%3A%22RefinableString109%22%2C%22values%22%3A%5B%7B%22name%22%3A%22{{slot item @root.slots.Title}}%22%2C%22value%22%3A%22%5C%22%C7%82%C7%82{{stringToHex (slot item @root.slots.Title)}}%5C%22%22%2C%22operator%22%3A0%2C%22disabled%22%3Afalse%7D%5D%2C%22operator%22%3A%22or%22%7D%5D"
+>
+    {{slot item @root.slots.Title}}
+</a>
+```
+
+In practice, the safest approach is still to select a filter once in the UI, copy the generated URL, and then replace only the `name` and hex-encoded `value` parts in your template.
+
 #### #times
 
 **Syntax** `{{#times <number>}}`

--- a/docs/usage/search-filters/index.md
+++ b/docs/usage/search-filters/index.md
@@ -121,9 +121,11 @@ These taxonomy values can then be used in the Filters Web Part using a `Refinabl
 
 ## Filter deep linking
 
-The Search Filter Web Part supports deep linking, meaning you can preselect filters from the URL at page load. When filter values are selected, a query string parameter `f` is append to the current URL containing the current filter values data.
+The Search Filter Web Part supports deep linking, meaning you can preselect filters from the URL at page load. When filter values are selected, a query string parameter named `f_<instanceId>` is appended to the current URL containing the current filter values data. This instance-specific parameter name avoids conflicts when multiple Search Filters web parts are present on the same page.
 
 > If you have connected the search result web part to a search box, ensure the search term is set to be dynamic and part of the URL in the search box web part. If not, copying the URL will not contain the search terms."
+
+If you need to build those links yourself in a custom results template, you can use the built-in `stringToHex` helper documented in the [templating helpers documentation](../../extensibility/templating.md#stringtohex).
 
 !["Filters deep linking"](../../assets/webparts/search-filters/filter_deep_linking.png){: .center}
 

--- a/search-parts/src/helpers/HandlebarsHelpers.ts
+++ b/search-parts/src/helpers/HandlebarsHelpers.ts
@@ -4,6 +4,7 @@ import * as strings from "CommonStrings";
 import { isEmpty, uniqBy, uniq } from "@microsoft/sp-lodash-subset";
 import { UrlHelper } from "./UrlHelper";
 import { ObjectHelper } from "./ObjectHelper";
+import { StringHelper } from "./StringHelper";
 
 /**
  * Internalized subset of handlebars-helpers.
@@ -223,6 +224,16 @@ function helperStartsWith(this: any, prefix: string, str: string, options: any):
         return options.fn(this);
     }
     return typeof options.inverse === 'function' ? options.inverse(this) : '';
+}
+
+function helperStringToHex(str: any): string {
+    if (str === null || str === undefined) return '';
+    return StringHelper._bytesToHex(StringHelper._stringToUTF8Bytes(String(str)));
+}
+
+function helperHexToString(hex: any): string {
+    if (hex === null || hex === undefined) return '';
+    return StringHelper.hexToString(String(hex));
 }
 
 // ─── Object helpers ───────────────────────────────────────────────────────────
@@ -493,6 +504,8 @@ export function getHandlebarsHelpers(): Record<string, (...args: any[]) => any> 
         split: helperSplit,
         trim: helperTrim,
         startsWith: helperStartsWith,
+        stringToHex: helperStringToHex,
+        hexToString: helperHexToString,
 
         // object
         JSONstringify: helperJSONstringify,

--- a/search-parts/src/helpers/StringHelper.ts
+++ b/search-parts/src/helpers/StringHelper.ts
@@ -1,18 +1,42 @@
 export class StringHelper {
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
-    public static escapeRegExp(string) {
+    public static escapeRegExp(string: string) {
         return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
     }
 
-    public static _bytesToHex(bytes) {
+    public static _bytesToHex(bytes: Uint8Array) {
         return Array.from(
             bytes,
             byte => (byte as any).toString(16).padStart(2, "0")
         ).join("");
     }
     
-    public static _stringToUTF8Bytes(string) {
+    public static _stringToUTF8Bytes(string: string) {
         return new TextEncoder().encode(string);
+    }
+
+    public static _hexToBytes(hex: string) {
+        if (!hex) {
+            return new Uint8Array();
+        }
+
+        const normalizedHex = hex
+            .trim()
+            .replace(/^"/, "")
+            .replace(/"$/, "")
+            .replace(/^ǂǂ/, "")
+            .replaceAll(/\s+/g, "");
+
+        const bytePairs = normalizedHex.match(/[0-9a-fA-F]{2}/g) || [];
+        return new Uint8Array(bytePairs.map((bytePair) => Number.parseInt(bytePair, 16)));
+    }
+
+    public static _utf8BytesToString(bytes: Uint8Array) {
+        return new TextDecoder().decode(bytes);
+    }
+
+    public static hexToString(hex: string) {
+        return StringHelper._utf8BytesToString(StringHelper._hexToBytes(hex));
     }
 }


### PR DESCRIPTION
## Summary
- add built-in Handlebars helpers to convert between plain strings and UTF-8 hex values
- document the new helpers in the templating documentation
- document how to use `stringToHex` when building Search Filters deep links in custom templates

