### PR TITLE
4752-Add search results paging information in the URL as a query string

### DIFF
--- a/docs/usage/search-results/common/paging.md
+++ b/docs/usage/search-results/common/paging.md
@@ -2,9 +2,10 @@ The paging options are available for all data sources.
 
 | Setting | Description | Default value |
 | --------| ----------- |---------------|
-|**Show paging** | Hide or display the paging control.
-|**Number of items per page** | Specify the number of items to show per page.
-|**Number of pages to display in range** | Determines the number of pages to display in range.
-|**Hide navigation buttons (prev page, next page)** | Self explicit.
-|**Hide first/last navigation buttons** | Self explicit.
-|**Hide navigation buttons (prev, next, first, last) if they are disabled.** | Self explicit.
+| **Show paging** | Hide or display the paging control. | `true` |
+| **Number of items per page** | Specify the number of items to show per page. | `10` |
+| **Number of pages to display in range** | Determines the number of pages to display in range. | `5` |
+| **Hide navigation buttons (prev page, next page)** | Self explicit. | `false` |
+| **Hide first/last navigation buttons** | Self explicit. | `false` |
+| **Hide navigation buttons (prev, next, first, last) if they are disabled.** | Self explicit. | `true` |
+| **Enable page number in query string** | When enabled, the current page number is written to the URL as a `?page=N` query string parameter so pages can be deep-linked and the browser back/forward buttons navigate between result pages instead of leaving the page. | `false` |

--- a/search-parts/.vscode/launch.json
+++ b/search-parts/.vscode/launch.json
@@ -24,7 +24,7 @@
       "name": "Hosted workbench",
       "type": "chrome",
       "request": "launch",
-      "url": "https://ntssdev.sharepoint.com/sites/MRA-TestingSite/_layouts/15/workbench.aspx",
+      "url": "https://sonbaedev.sharepoint.com/sites/ThePerspective/_layouts/15/workbench.aspx",
       "webRoot": "${workspaceRoot}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {

--- a/search-parts/.vscode/launch.json
+++ b/search-parts/.vscode/launch.json
@@ -24,7 +24,7 @@
       "name": "Hosted workbench",
       "type": "chrome",
       "request": "launch",
-      "url": "https://sonbaedev.sharepoint.com/sites/ThePerspective/_layouts/15/workbench.aspx",
+      "url": "https://ntssdev.sharepoint.com/sites/MRA-TestingSite/_layouts/15/workbench.aspx",
       "webRoot": "${workspaceRoot}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.20.0",
+    "version": "4.21.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pnp/modern-search-web-parts",
-            "version": "4.20.0",
+            "version": "4.21.0",
             "dependencies": {
                 "@fluentui/font-icons-mdl2": "^8.5.67",
                 "@fluentui/react": "8.125.4",
@@ -35,7 +35,7 @@
                 "adaptivecards": "2.11.2",
                 "adaptivecards-templating": "2.3.1",
                 "dayjs": "1.11.19",
-                "dompurify": "3.3.2",
+                "dompurify": "3.4.0",
                 "handlebars": "4.7.9",
                 "immutability-helper": "3.1.1",
                 "jspath": "0.4.0",
@@ -19284,13 +19284,10 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-            "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "engines": {
-                "node": ">=20"
-            },
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }

--- a/search-parts/src/models/common/IPagingSettings.ts
+++ b/search-parts/src/models/common/IPagingSettings.ts
@@ -34,4 +34,9 @@ export interface IPagingSettings {
      * Flag indicating if the data source use @odata.nextLink to handle server-side paging
      */
     useNextLinks: boolean;
+
+    /**
+     * Flag indicating if the page number should be added in the query string for deep linking and browser navigation
+     */
+    enableQueryString: boolean;
 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2352,10 +2352,13 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 dataContext.pageNumber = 1;
                 this.currentPageNumber = 1;
                 // Clear any stale `page` query param so the URL stays in sync with the reset.
-                // Use the native pushState so this does not trigger a duplicate render().
-                const cleanedUrl = UrlHelper.removeQueryStringParam('page', globalThis.location.href);
-                if (cleanedUrl !== globalThis.location.href) {
-                    History.prototype.pushState.call(globalThis.history, {}, '', cleanedUrl);
+                // Use the URL API (preserves the hash, unlike UrlHelper.removeQueryStringParam which
+                // drops it when no other query params remain) and the native pushState so this does
+                // not trigger a duplicate render().
+                const currentUrl = new URL(globalThis.location.href);
+                if (currentUrl.searchParams.has('page')) {
+                    currentUrl.searchParams.delete('page');
+                    History.prototype.pushState.call(globalThis.history, {}, '', currentUrl.toString());
                 }
             } else {
                 // Classic page navigation with query string (ex: ?page=2)

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1306,7 +1306,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Backfill `enableQueryString` for web parts saved before this setting existed so
         // the property pane Toggle binds to a defined boolean instead of `undefined`.
-        this.properties.paging.enableQueryString = this.properties.paging.enableQueryString !== undefined ? this.properties.paging.enableQueryString : false;
+        this.properties.paging.enableQueryString = this.properties.paging.enableQueryString ?? false;
 
         // Default adaptive cards host config
         if (!this.properties.adaptiveCardsHostConfig) {

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -236,6 +236,14 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _popStateHandler: () => void = null;
 
     /**
+     * Tracks whether the initial `?page=N` query string parameter has already been
+     * applied to `currentPageNumber`. Used by `getDataContext()` to honor deep-links
+     * on the first render and switch to URL-write mode thereafter, without relying
+     * on `_lastInputQueryText` (which can legitimately stay `undefined`).
+     */
+    private _hasInitializedPagingFromQueryString = false;
+
+    /**
      * The available connections as property pane group
      */
     private propertyPaneConnectionsGroup: IPropertyPaneGroup[] = [];
@@ -1362,13 +1370,22 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * Sets `?page=N` for N > 1, removes the parameter for N <= 1 (the default page),
      * and no-ops when the URL is already in sync.
      *
-     * Uses the native pushState (via History.prototype) so an updated URL
-     * does not trigger an extra render() through `_handleQueryStringChange()`'s
-     * monkey-patched pushState — the caller is responsible for the render.
-     * @param pageNumber the desired page number
+     * Uses the native pushState / replaceState (via History.prototype) so the URL
+     * update does not trigger an extra render() through `_handleQueryStringChange()`'s
+     * monkey-patched pushState.
+     *
+     * Pass `replace = true` when reconciling the URL to match an already-derived page
+     * number (e.g. from `getDataContext()` after a filter / query reset). That avoids
+     * polluting browser history with normalization entries — in particular it prevents
+     * the back-button loop that would otherwise occur for a `?page=1` deep-link
+     * (push-delete → back → push-delete …). The default (push) is intended for explicit
+     * user-initiated page navigation so the back button steps through prior pages.
+     *
+     * @param pageNumber the desired page number (must be a valid positive integer)
+     * @param replace use `replaceState` instead of `pushState`; defaults to false
      * @returns true when the URL was updated, false when it was already in sync
      */
-    private _syncPageQueryString(pageNumber: number): boolean {
+    private _syncPageQueryString(pageNumber: number, replace: boolean = false): boolean {
         const url = new URL(globalThis.location.href);
         const actual = url.searchParams.get('page');
         const desired = pageNumber > 1 ? pageNumber.toString() : null;
@@ -1380,7 +1397,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         } else {
             url.searchParams.set('page', desired);
         }
-        History.prototype.pushState.call(globalThis.history, {}, '', url.toString());
+        if (replace) {
+            History.prototype.replaceState.call(globalThis.history, {}, '', url.toString());
+        } else {
+            History.prototype.pushState.call(globalThis.history, {}, '', url.toString());
+        }
         return true;
     }
 
@@ -2363,7 +2384,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Pagination in query string
         if (this.properties.paging.enableQueryString) {
-            if (this._lastInputQueryText === undefined) {
+            if (!this._hasInitializedPagingFromQueryString) {
+                this._hasInitializedPagingFromQueryString = true;
                 // Initial render: honor `?page=N` from the URL so deep-links work.
                 const pageNumberFromQueryString = Number.parseInt(dataContext.queryStringParameters['page'], 10);
                 if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
@@ -2374,8 +2396,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 // Any subsequent render: keep the URL aligned with the (possibly just-reset)
                 // page number. Centralizing here covers every reset path — input query text
                 // change, connected filters change, vertical change, etc. — without each one
-                // having to duplicate URL cleanup logic.
-                const urlChanged = this._syncPageQueryString(dataContext.pageNumber);
+                // having to duplicate URL cleanup logic. Use `replaceState` so URL
+                // normalization doesn't add browser history entries (which would otherwise
+                // create a back-button loop for a `?page=1` deep-link, or surface stale
+                // page numbers when the user navigates back across a filter change).
+                const urlChanged = this._syncPageQueryString(dataContext.pageNumber, true);
                 if (urlChanged && dataContext.queryStringParameters) {
                     if (dataContext.pageNumber > 1) {
                         dataContext.queryStringParameters['page'] = dataContext.pageNumber.toString();

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1355,9 +1355,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * @param pageNumber 
      */
     private _updatePageNumberInQueryString(pageNumber: number): void {
-        const url = new URL(window.location.href);
+        const url = new URL(globalThis.location.href);
         url.searchParams.set('page', pageNumber.toString());
-        window.history.pushState({}, '', url.toString());
+        globalThis.history.pushState({}, '', url.toString());
     }
 
 
@@ -2358,10 +2358,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         return dataContext;
     }
 
-    private _handlePageQueryString() {
-        
-    }
-
 
     private async getModifiedInputQueryText(inputQueryText: string): Promise<string> {
         let queryText = inputQueryText;
@@ -2514,7 +2510,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _handlePopStatePagination() {
         if (this.properties.paging.enableQueryString) {
 
-            window.addEventListener('popstate', (event) => {
+            globalThis.addEventListener('popstate', (event) => {
                 const queryStringParams = UrlHelper.getQueryStringParams();
                 const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
                 if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1304,6 +1304,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             };
         }
 
+        // Backfill `enableQueryString` for web parts saved before this setting existed so
+        // the property pane Toggle binds to a defined boolean instead of `undefined`.
+        this.properties.paging.enableQueryString = this.properties.paging.enableQueryString !== undefined ? this.properties.paging.enableQueryString : false;
+
         // Default adaptive cards host config
         if (!this.properties.adaptiveCardsHostConfig) {
             this.properties.adaptiveCardsHostConfig = JSON.stringify({

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1401,10 +1401,16 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         } else {
             url.searchParams.set('page', desired);
         }
+        // Preserve any existing `history.state` (e.g., set by SearchBoxWebPart with
+        // `{ path }`) and the current document title rather than overwriting them with
+        // empty values — `pushState({}, '', url)` would silently drop state other
+        // components on the page may be relying on.
+        const state = globalThis.history.state;
+        const title = globalThis.document.title;
         if (replace) {
-            History.prototype.replaceState.call(globalThis.history, {}, '', url.toString());
+            History.prototype.replaceState.call(globalThis.history, state, title, url.toString());
         } else {
-            History.prototype.pushState.call(globalThis.history, {}, '', url.toString());
+            History.prototype.pushState.call(globalThis.history, state, title, url.toString());
         }
         return true;
     }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2346,8 +2346,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             } else {
                 // Classic page navigation with query string (ex: ?page=2)
                 const queryStringParams = UrlHelper.getQueryStringParams();
-                const pageNumberFromQueryString = parseInt(queryStringParams['page'], 10);
-                if (!isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
+                const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
+                if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
                     dataContext.pageNumber = pageNumberFromQueryString;
                     this.currentPageNumber = pageNumberFromQueryString;
                 }
@@ -2356,6 +2356,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._lastInputQueryText = dataContext.inputQueryText;
         return dataContext;
+    }
+
+    private _handlePageQueryString() {
+        
     }
 
 
@@ -2512,8 +2516,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             window.addEventListener('popstate', (event) => {
                 const queryStringParams = UrlHelper.getQueryStringParams();
-                const pageNumberFromQueryString = parseInt(queryStringParams['page'], 10);
-                if (!isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
+                const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
+                if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
                     this.currentPageNumber = pageNumberFromQueryString;
                     this.render();
                 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2359,6 +2359,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 if (currentUrl.searchParams.has('page')) {
                     currentUrl.searchParams.delete('page');
                     History.prototype.pushState.call(globalThis.history, {}, '', currentUrl.toString());
+                    // Keep dataContext.queryStringParameters in sync so downstream consumers
+                    // (custom data sources, extensibility) don't see the stale `page` value.
+                    if (dataContext.queryStringParameters) {
+                        delete dataContext.queryStringParameters['page'];
+                    }
                 }
             } else {
                 // Classic page navigation with query string (ex: ?page=2)

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1175,6 +1175,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // These information comes from the PaginationWebComponent class
             this.currentPageNumber = eventDetails.pageNumber;
 
+            // Bind to query string if enabled
+            if (this.properties.paging.enableQueryString) {
+                this._updatePageNumberInQueryString(eventDetails.pageNumber);
+            }
+
             this.render();
 
         };
@@ -1278,7 +1283,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 hideDisabled: true,
                 hideFirstLastPages: false,
                 hideNavigation: false,
-                useNextLinks: false
+                useNextLinks: false,
+                enableQueryString: false
             };
         }
 
@@ -1344,6 +1350,18 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
 
     /**
+     * Updates the page number in the query string 
+     * @param pageNumber 
+     */
+    private _updatePageNumberInQueryString(pageNumber: number): void {
+        const url = new URL(window.location.href);
+        url.searchParams.set('page', pageNumber.toString());
+        window.history.replaceState({}, '', url.toString());
+    }
+
+
+
+    /**
      * Returns property pane 'Paging' group fields
      */
     private getPagingGroupFields(): IPropertyPaneField<any>[] {
@@ -1387,6 +1405,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     }),
                     PropertyPaneToggle('paging.hideDisabled', {
                         label: webPartStrings.PropertyPane.DataSourcePage.HideDisabledFieldName,
+                        disabled: !this.properties.paging.showPaging
+                    }),
+                    PropertyPaneToggle('paging.enableQueryString', {
+                        label: webPartStrings.PropertyPane.DataSourcePage.EnableQueryStringFieldName,
                         disabled: !this.properties.paging.showPaging
                     })
                 );
@@ -2308,11 +2330,27 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             }
         }
 
-
         // If input query text changes, then we need to reset the paging
         if (!isEqual(dataContext.inputQueryText, this._lastInputQueryText)) {
             dataContext.pageNumber = 1;
             this.currentPageNumber = 1;
+        }
+
+        // Pagination in query string
+        if (this.properties.paging.enableQueryString) {
+            // If input query text changes and this is not a browser page refresh
+            if (this._lastInputQueryText != undefined && !isEqual(dataContext.inputQueryText, this._lastInputQueryText)) {
+                dataContext.pageNumber = 1;
+                this.currentPageNumber = 1;
+            } else {
+                // Classic page navigation with query string (ex: ?page=2)
+                const queryStringParams = UrlHelper.getQueryStringParams();
+                const pageNumberFromQueryString = parseInt(queryStringParams['page'], 10);
+                if (!isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
+                    dataContext.pageNumber = pageNumberFromQueryString;
+                    this.currentPageNumber = pageNumberFromQueryString;
+                }
+            }
         }
 
         this._lastInputQueryText = dataContext.inputQueryText;

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -233,6 +233,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      */
     private _pagingEventHandler: (ev: CustomEvent) => void = null;
     private _sortingEventHandler: (ev: CustomEvent) => void = null;
+    private _popStateHandler: () => void = null;
 
     /**
      * The available connections as property pane group
@@ -641,6 +642,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     protected onDispose(): void {
         if (this._pushStateCallback) {
             window.history.pushState = this._pushStateCallback;
+        }
+        if (this._popStateHandler) {
+            globalThis.removeEventListener('popstate', this._popStateHandler);
+            this._popStateHandler = null;
         }
         // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- paired with render in renderCompleted
         ReactDom.unmountComponentAtNode(this.domElement);
@@ -1351,13 +1356,16 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
 
     /**
-     * Updates the page number in the query string 
-     * @param pageNumber 
+     * Updates the page number in the query string
+     * Uses the native pushState (via History.prototype) so an updated URL
+     * does not trigger an extra render() through `_handleQueryStringChange()`'s
+     * monkey-patched pushState — the caller is responsible for the render.
+     * @param pageNumber
      */
     private _updatePageNumberInQueryString(pageNumber: number): void {
         const url = new URL(globalThis.location.href);
         url.searchParams.set('page', pageNumber.toString());
-        globalThis.history.pushState({}, '', url.toString());
+        History.prototype.pushState.call(globalThis.history, {}, '', url.toString());
     }
 
 
@@ -2343,6 +2351,12 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             if (this._lastInputQueryText != undefined && !isEqual(dataContext.inputQueryText, this._lastInputQueryText)) {
                 dataContext.pageNumber = 1;
                 this.currentPageNumber = 1;
+                // Clear any stale `page` query param so the URL stays in sync with the reset.
+                // Use the native pushState so this does not trigger a duplicate render().
+                const cleanedUrl = UrlHelper.removeQueryStringParam('page', globalThis.location.href);
+                if (cleanedUrl !== globalThis.location.href) {
+                    History.prototype.pushState.call(globalThis.history, {}, '', cleanedUrl);
+                }
             } else {
                 // Classic page navigation with query string (ex: ?page=2)
                 const queryStringParams = UrlHelper.getQueryStringParams();
@@ -2505,21 +2519,29 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     }
 
     /**
-     * Subscribes to browser navigation events to handle pagination with query string (ex: ?page=2)
+     * Subscribes to browser navigation events to handle pagination with query string (ex: ?page=2).
+     * The listener is always attached so that toggling `paging.enableQueryString` from the property
+     * pane does not require a full page refresh; the toggle is checked inside the handler instead.
      */
     private _handlePopStatePagination() {
-        if (this.properties.paging.enableQueryString) {
-
-            globalThis.addEventListener('popstate', (event) => {
-                const queryStringParams = UrlHelper.getQueryStringParams();
-                const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
-                if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
-                    this.currentPageNumber = pageNumberFromQueryString;
-                    this.render();
-                }
-            });
+        this._popStateHandler = () => {
+            if (!this.properties.paging.enableQueryString) {
+                return;
+            }
+            const queryStringParams = UrlHelper.getQueryStringParams();
+            const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
+            // Missing or invalid `page` param (e.g. navigating back to the initial results URL)
+            // should be treated as page 1, otherwise the web part stays on the previous page.
+            const pageNumber = !Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0
+                ? pageNumberFromQueryString
+                : 1;
+            if (this.currentPageNumber !== pageNumber) {
+                this.currentPageNumber = pageNumber;
+                this.render();
+            }
+        };
+        globalThis.addEventListener('popstate', this._popStateHandler);
     }
-}
 
     private async initializeQueryModifiers(queryModifierConfiguration: IQueryModifierConfiguration[]): Promise<IQueryModifier[]> {
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -598,6 +598,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._bindHashChange();
         this._handleQueryStringChange();
+        this._handlePopStatePagination();
 
         // Load extensibility libaries extensions
         await this.loadExtensions(this.properties.extensibilityLibraryConfiguration);
@@ -1356,7 +1357,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _updatePageNumberInQueryString(pageNumber: number): void {
         const url = new URL(window.location.href);
         url.searchParams.set('page', pageNumber.toString());
-        window.history.replaceState({}, '', url.toString());
+        window.history.pushState({}, '', url.toString());
     }
 
 
@@ -2502,6 +2503,23 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.render();
         }
     }
+
+    /**
+     * Subscribes to browser navigation events to handle pagination with query string (ex: ?page=2)
+     */
+    private _handlePopStatePagination() {
+        if (this.properties.paging.enableQueryString) {
+
+            window.addEventListener('popstate', (event) => {
+                const queryStringParams = UrlHelper.getQueryStringParams();
+                const pageNumberFromQueryString = parseInt(queryStringParams['page'], 10);
+                if (!isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
+                    this.currentPageNumber = pageNumberFromQueryString;
+                    this.render();
+                }
+            });
+    }
+}
 
     private async initializeQueryModifiers(queryModifierConfiguration: IQueryModifierConfiguration[]): Promise<IQueryModifier[]> {
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1181,9 +1181,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // These information comes from the PaginationWebComponent class
             this.currentPageNumber = eventDetails.pageNumber;
 
-            // Bind to query string if enabled
+            // Bind to query string if enabled. The render() call below will also keep the URL in
+            // sync via getDataContext(), but we update it eagerly here so the address bar reflects
+            // the click without waiting for the next render cycle.
             if (this.properties.paging.enableQueryString) {
-                this._updatePageNumberInQueryString(eventDetails.pageNumber);
+                this._syncPageQueryString(eventDetails.pageNumber);
             }
 
             this.render();
@@ -1356,16 +1358,30 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
 
     /**
-     * Updates the page number in the query string
+     * Synchronizes the `page` query string parameter with the given page number.
+     * Sets `?page=N` for N > 1, removes the parameter for N <= 1 (the default page),
+     * and no-ops when the URL is already in sync.
+     *
      * Uses the native pushState (via History.prototype) so an updated URL
      * does not trigger an extra render() through `_handleQueryStringChange()`'s
      * monkey-patched pushState — the caller is responsible for the render.
-     * @param pageNumber
+     * @param pageNumber the desired page number
+     * @returns true when the URL was updated, false when it was already in sync
      */
-    private _updatePageNumberInQueryString(pageNumber: number): void {
+    private _syncPageQueryString(pageNumber: number): boolean {
         const url = new URL(globalThis.location.href);
-        url.searchParams.set('page', pageNumber.toString());
+        const actual = url.searchParams.get('page');
+        const desired = pageNumber > 1 ? pageNumber.toString() : null;
+        if (desired === actual) {
+            return false;
+        }
+        if (desired === null) {
+            url.searchParams.delete('page');
+        } else {
+            url.searchParams.set('page', desired);
+        }
         History.prototype.pushState.call(globalThis.history, {}, '', url.toString());
+        return true;
     }
 
 
@@ -2347,31 +2363,25 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Pagination in query string
         if (this.properties.paging.enableQueryString) {
-            // If input query text changes and this is not a browser page refresh
-            if (this._lastInputQueryText != undefined && !isEqual(dataContext.inputQueryText, this._lastInputQueryText)) {
-                dataContext.pageNumber = 1;
-                this.currentPageNumber = 1;
-                // Clear any stale `page` query param so the URL stays in sync with the reset.
-                // Use the URL API (preserves the hash, unlike UrlHelper.removeQueryStringParam which
-                // drops it when no other query params remain) and the native pushState so this does
-                // not trigger a duplicate render().
-                const currentUrl = new URL(globalThis.location.href);
-                if (currentUrl.searchParams.has('page')) {
-                    currentUrl.searchParams.delete('page');
-                    History.prototype.pushState.call(globalThis.history, {}, '', currentUrl.toString());
-                    // Keep dataContext.queryStringParameters in sync so downstream consumers
-                    // (custom data sources, extensibility) don't see the stale `page` value.
-                    if (dataContext.queryStringParameters) {
-                        delete dataContext.queryStringParameters['page'];
-                    }
-                }
-            } else {
-                // Classic page navigation with query string (ex: ?page=2)
-                const queryStringParams = UrlHelper.getQueryStringParams();
-                const pageNumberFromQueryString = Number.parseInt(queryStringParams['page'], 10);
+            if (this._lastInputQueryText === undefined) {
+                // Initial render: honor `?page=N` from the URL so deep-links work.
+                const pageNumberFromQueryString = Number.parseInt(dataContext.queryStringParameters['page'], 10);
                 if (!Number.isNaN(pageNumberFromQueryString) && pageNumberFromQueryString > 0) {
                     dataContext.pageNumber = pageNumberFromQueryString;
                     this.currentPageNumber = pageNumberFromQueryString;
+                }
+            } else {
+                // Any subsequent render: keep the URL aligned with the (possibly just-reset)
+                // page number. Centralizing here covers every reset path — input query text
+                // change, connected filters change, vertical change, etc. — without each one
+                // having to duplicate URL cleanup logic.
+                const urlChanged = this._syncPageQueryString(dataContext.pageNumber);
+                if (urlChanged && dataContext.queryStringParameters) {
+                    if (dataContext.pageNumber > 1) {
+                        dataContext.queryStringParameters['page'] = dataContext.pageNumber.toString();
+                    } else {
+                        delete dataContext.queryStringParameters['page'];
+                    }
                 }
             }
         }

--- a/search-parts/src/webparts/searchResults/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchResults/loc/cs-cz.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Skrýt navigační tlačítka (předchozí stránka, další stránka)",
                 HideFirstLastPagesFieldName: "Skrýt první/poslední navigační tlačítka",
                 HideDisabledFieldName: "Skrýt navigační tlačítka (předchozí, další, první, poslední), pokud jsou zakázána.",
+                EnableQueryStringFieldName: "Povolit číslo stránky v URL",
                 TemplateSlots: {
                     GroupName: "Sloty rozvržení",
                     ConfigureSlotsLabel: "Upravit sloty rozvržení pro tento datový zdroj",

--- a/search-parts/src/webparts/searchResults/loc/da-dk.js
+++ b/search-parts/src/webparts/searchResults/loc/da-dk.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Skjul navigationsknapper (foregående side, næste side)",
                 HideFirstLastPagesFieldName: "Skjul første/sidste navigationsknapper",
                 HideDisabledFieldName: "Skjul navigationsknapper (foregående, næste, første, sidste), hvis de er deaktiveret.",
+                EnableQueryStringFieldName: "Aktivér sidetal i URL'en",
                 TemplateSlots: {
                     GroupName: "Layout-slots",
                     ConfigureSlotsLabel: "Redigér layout-slots for denne datakilde",

--- a/search-parts/src/webparts/searchResults/loc/de-de.js
+++ b/search-parts/src/webparts/searchResults/loc/de-de.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Navigationsknopf verstecken (Seite vor/zurück)",
                 HideFirstLastPagesFieldName: "Anfang/Ende Navigationsknöpfe verstecken",
                 HideDisabledFieldName: "Navigationsknöpfe verstecken (vor, zurück, Anfang, Ende), wenn sie deaktiviert sind",
+                EnableQueryStringFieldName: "Seitenzahl in der URL aktivieren",
                 TemplateSlots: {
                     GroupName: "Layout Slots",
                     ConfigureSlotsLabel: "Layout Slots für diese Datenquelle bearbeiten",

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Hide navigation buttons (prev page, next page)",
                 HideFirstLastPagesFieldName: "Hide first/last navigation buttons",
                 HideDisabledFieldName: "Hide navigation buttons (prev, next, first, last) if they are disabled.",
+                EnableQueryStringFieldName: "Enable page number in query string",
                 TemplateSlots: {
                     GroupName: "Layout slots",
                     ConfigureSlotsLabel: "Edit layout slots for this data source",

--- a/search-parts/src/webparts/searchResults/loc/es-es.js
+++ b/search-parts/src/webparts/searchResults/loc/es-es.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Ocultar los botones de navegación (página anterior, página siguiente)",
                 HideFirstLastPagesFieldName: "Ocultar los botones de navegación primero/último",
                 HideDisabledFieldName: "Ocultar los botones de navegación (anterior, siguiente, primero, ultimo) si están desactivados.",
+                EnableQueryStringFieldName: "Activar el número de página en la URL",
                 TemplateSlots: {
                     GroupName: "Ranuras de diseño",
                     ConfigureSlotsLabel: "Editar ranuras de diseño para esta fuente de datos",

--- a/search-parts/src/webparts/searchResults/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchResults/loc/fi-fi.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Piilota siirtymäpainikkeet (edellinen sivu, seuraava sivu)",
                 HideFirstLastPagesFieldName: "Piilota ensimmäinen/viimeinen siirtymäpainikkeet",
                 HideDisabledFieldName: "Piilota siirtymäpainikkeet (edellinen, seuraava, ensimmäinen, viimeinen) jos ne eivät ole käytössä.",
+                EnableQueryStringFieldName: "Ota sivunumero käyttöön URL-osoitteessa",
                 TemplateSlots: {
                     GroupName: "Muotoilumääreet (slots)",
                     ConfigureSlotsLabel: "Muokkaa muotoilumääreitä tälle sisältölähteelle",

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -22,7 +22,6 @@ define([], function () {
                 HideNavigationFieldName: "Masquer les boutons de navigation (page précédente, page suivante)",
                 HideFirstLastPagesFieldName: "Masquer les boutons de navigation (première, dernière)",
                 HideDisabledFieldName: "Masquer les boutons de navigation (précédente, suivante, première, dernière) s’ils sont désactivés.",
-                EnableQueryStringFieldName: "Activer la pagination dans l'URL",
                 TemplateSlots: {
                     GroupName: "Emplacements de la mise en page",
                     ConfigureSlotsLabel: "Modifier les emplacements de la mise en page pour cette source de données",

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Masquer les boutons de navigation (page précédente, page suivante)",
                 HideFirstLastPagesFieldName: "Masquer les boutons de navigation (première, dernière)",
                 HideDisabledFieldName: "Masquer les boutons de navigation (précédente, suivante, première, dernière) s’ils sont désactivés.",
+                EnableQueryStringFieldName: "Activer le numéro de page dans l'URL",
                 TemplateSlots: {
                     GroupName: "Emplacements de la mise en page",
                     ConfigureSlotsLabel: "Modifier les emplacements de la mise en page pour cette source de données",

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Masquer les boutons de navigation (page précédente, page suivante)",
                 HideFirstLastPagesFieldName: "Masquer les boutons de navigation (première, dernière)",
                 HideDisabledFieldName: "Masquer les boutons de navigation (précédente, suivante, première, dernière) s’ils sont désactivés.",
+                EnableQueryStringFieldName: "Activer la pagination dans l'URL",
                 TemplateSlots: {
                     GroupName: "Emplacements de la mise en page",
                     ConfigureSlotsLabel: "Modifier les emplacements de la mise en page pour cette source de données",

--- a/search-parts/src/webparts/searchResults/loc/it-it.js
+++ b/search-parts/src/webparts/searchResults/loc/it-it.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Nascondi pulsanti di navigazione (pagina precedente, pagina successiva)",
                 HideFirstLastPagesFieldName: "Nascondi pulsanti di navigazione prima/ultima pagina",
                 HideDisabledFieldName: "Nascondi pulsanti di navigazione (precedente, successiva, prima, ultima) se disabilitati.",
+                EnableQueryStringFieldName: "Attiva il numero di pagina nell'URL",
                 TemplateSlots: {
                     GroupName: "Slot di layout",
                     ConfigureSlotsLabel: "Modifica slot di layout per questa fonte di dati",

--- a/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
@@ -21,6 +21,7 @@ declare interface ISearchResultsWebPartStrings {
             HideNavigationFieldName: string;
             HideFirstLastPagesFieldName: string;
             HideDisabledFieldName: string;
+            EnableQueryStringFieldName: string;
             TemplateSlots: {
                 GroupName: string;
                 ConfigureSlotsLabel: string;

--- a/search-parts/src/webparts/searchResults/loc/nb-no.js
+++ b/search-parts/src/webparts/searchResults/loc/nb-no.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Skjul navigeringslenker forrige side / neste side",
                 HideFirstLastPagesFieldName: "Skjul navigeringslenkene første/siste",
                 HideDisabledFieldName: "Skjul navigeringslenker (forrige, neste, første, siste) hvis de er deaktivert.",
+                EnableQueryStringFieldName: "Aktiver sidetall i URL-en",
                 TemplateSlots: {
                     GroupName: "Mal",
                     ConfigureSlotsLabel: "Rediger mal-slots for denne datakilden",

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Verberg navigatieknoppen (vorige pagina, volgende pagina)",
                 HideFirstLastPagesFieldName: "Verberg eerste/laatste navigatieknoppen",
                 HideDisabledFieldName: "Verberg navigatieknoppen (vorige, vorige, eerste, laatste) wanneer deze uitgeschakeld zijn.",
+                EnableQueryStringFieldName: "Schakel paginanummer in URL in",
                 TemplateSlots: {
                     GroupName: "Indelingssleuven",
                     ConfigureSlotsLabel: "Bewerk indelingssleuven voor deze databron",

--- a/search-parts/src/webparts/searchResults/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchResults/loc/pl-pl.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Ukryj przyciski nawigacyjne (poprzednia strona, następna strona)",
                 HideFirstLastPagesFieldName: "Ukruj przyciski początek/koniec",
                 HideDisabledFieldName: "Ukryj przyciski nawigacyjne (poprzednia strona, następna strona, początek, koniec) gdy są nieaktywne.",
+                EnableQueryStringFieldName: "Włącz numer strony w URL",
                 TemplateSlots: {
                     GroupName: "Sloty układu",
                     ConfigureSlotsLabel: "Edytuje sloty dla tego źródła danych",

--- a/search-parts/src/webparts/searchResults/loc/pt-br.js
+++ b/search-parts/src/webparts/searchResults/loc/pt-br.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Esconder botões de navegação (próxima página, página anterior)",
                 HideFirstLastPagesFieldName: "Esconder botões de navegação primeiro/último",
                 HideDisabledFieldName: "Esconder botões de navegação (anterior, próximo, primeiro, último) de eles estiverem desativados.",
+                EnableQueryStringFieldName: "Ativar número da página na URL",
                 TemplateSlots: {
                     GroupName: "Slots do layout",
                     ConfigureSlotsLabel: "Editar slots do layout para esta fonte de dados",

--- a/search-parts/src/webparts/searchResults/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchResults/loc/sv-SE.js
@@ -22,6 +22,7 @@ define([], function () {
                 HideNavigationFieldName: "Dölj navigeringsval (föregående sida, nästa sida)",
                 HideFirstLastPagesFieldName: "Dölj första/sista navigeringsknapparna",
                 HideDisabledFieldName: "Dölj navigeringsval (föregående, nästa, första, sista) om de är inaktiverade",
+                EnableQueryStringFieldName: "Aktivera sidnummer i URL",
                 TemplateSlots: {
                     GroupName: "Layout",
                     ConfigureSlotsLabel: "Redigera layout för den här datakällan",


### PR DESCRIPTION
**Problem**
When clicking on back & fordward buttons of the brower while navigating in the search results with pagination, we leave the page. Fix for #4752

**Cause**
Search results pages are not added to the URL query string.

**Solution**
- I added a property pane parameter _paging.enableQueryString_ 
- When enabled, pagination events are added to the query string in the format _?page=2_ 
- When enabled, a listener to _popState_ events force render of the page when back/forward button are clicked in the browser
- When enabled, currentPageNumber is synced with the query string page number
