### PR TITLE
chore(deps): apply pending Dependabot bumps (fast-uri, fast-xml-builder, fast-xml-parser)

### DIFF
--- a/search-extensibility/package-lock.json
+++ b/search-extensibility/package-lock.json
@@ -4512,17 +4512,16 @@
             "license": "MIT"
         },
         "node_modules/@nodable/entities": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-            "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
             "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/nodable"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -10471,9 +10470,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-            "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+            "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
             "dev": true,
             "funding": [
                 {
@@ -10481,10 +10480,9 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^1.1.0",
-                "fast-xml-builder": "^1.1.4",
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
                 "path-expression-matcher": "^1.5.0",
                 "strnum": "^2.2.3"
             },
@@ -17773,8 +17771,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/stylehacks": {
             "version": "5.1.1",
@@ -23022,9 +23019,9 @@
             }
         },
         "@nodable/entities": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-            "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
             "dev": true
         },
         "@nodelib/fs.scandir": {
@@ -27181,13 +27178,13 @@
             }
         },
         "fast-xml-parser": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-            "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+            "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
             "dev": true,
             "requires": {
-                "@nodable/entities": "^1.1.0",
-                "fast-xml-builder": "^1.1.4",
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
                 "path-expression-matcher": "^1.5.0",
                 "strnum": "^2.2.3"
             }

--- a/search-extensibility/package-lock.json
+++ b/search-extensibility/package-lock.json
@@ -10440,9 +10440,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
                     "type": "github",
@@ -27151,9 +27151,9 @@
             "dev": true
         },
         "fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
         },
         "fast-xml-builder": {
             "version": "1.1.4",

--- a/search-extensibility/package-lock.json
+++ b/search-extensibility/package-lock.json
@@ -10455,9 +10455,9 @@
             ]
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "dev": true,
             "funding": [
                 {
@@ -10465,9 +10465,9 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "path-expression-matcher": "^1.1.3"
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
             }
         },
         "node_modules/fast-xml-parser": {
@@ -19548,6 +19548,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -27156,12 +27171,13 @@
             "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
         },
         "fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "dev": true,
             "requires": {
-                "path-expression-matcher": "^1.1.3"
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
             }
         },
         "fast-xml-parser": {
@@ -33219,6 +33235,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
             "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+            "dev": true
+        },
+        "xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
             "dev": true
         },
         "xmlchars": {

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.20.0",
+    "version": "4.21.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pnp/modern-search-web-parts",
-            "version": "4.20.0",
+            "version": "4.21.0",
             "dependencies": {
                 "@fluentui/font-icons-mdl2": "^8.5.67",
                 "@fluentui/react": "8.125.4",
@@ -35,7 +35,7 @@
                 "adaptivecards": "2.11.2",
                 "adaptivecards-templating": "2.3.1",
                 "dayjs": "1.11.19",
-                "dompurify": "3.3.2",
+                "dompurify": "3.4.0",
                 "handlebars": "4.7.9",
                 "immutability-helper": "3.1.1",
                 "jspath": "0.4.0",
@@ -5188,49 +5188,6 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/sp-component-base/node_modules/@fluentui/react": {
-            "version": "8.125.3",
-            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.3.tgz",
-            "integrity": "sha512-GCSIB9SXkQDvvBYNMjrJKu4OP7aPD8U5wry/g/yQ9G9r4JmtoEvnQi6JhUescgXal2ANVAhex5HBrHBgEdhJFA==",
-            "license": "MIT",
-            "dependencies": {
-                "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.70",
-                "@fluentui/foundation-legacy": "^8.6.3",
-                "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.3",
-                "@fluentui/react-hooks": "^8.10.2",
-                "@fluentui/react-portal-compat-context": "^9.0.15",
-                "@fluentui/react-window-provider": "^2.3.2",
-                "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.13.6",
-                "@fluentui/theme": "^2.7.2",
-                "@fluentui/utilities": "^8.17.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16.8.0 <20.0.0",
-                "@types/react-dom": ">=16.8.0 <20.0.0",
-                "react": ">=16.8.0 <20.0.0",
-                "react-dom": ">=16.8.0 <20.0.0"
-            }
-        },
-        "node_modules/@microsoft/sp-component-base/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-component-base/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-component-base/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -6437,21 +6394,6 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/sp-dynamic-data/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-dynamic-data/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-dynamic-data/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -7156,21 +7098,6 @@
                 "tslib": "2.3.1"
             }
         },
-        "node_modules/@microsoft/sp-http/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-http/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-http/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -7520,34 +7447,6 @@
                 "@types/react-dom": ">=16.9.8 <18.0.0"
             }
         },
-        "node_modules/@microsoft/sp-loader/node_modules/@fluentui/react": {
-            "version": "8.125.3",
-            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.3.tgz",
-            "integrity": "sha512-GCSIB9SXkQDvvBYNMjrJKu4OP7aPD8U5wry/g/yQ9G9r4JmtoEvnQi6JhUescgXal2ANVAhex5HBrHBgEdhJFA==",
-            "license": "MIT",
-            "dependencies": {
-                "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.70",
-                "@fluentui/foundation-legacy": "^8.6.3",
-                "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.3",
-                "@fluentui/react-hooks": "^8.10.2",
-                "@fluentui/react-portal-compat-context": "^9.0.15",
-                "@fluentui/react-window-provider": "^2.3.2",
-                "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.13.6",
-                "@fluentui/theme": "^2.7.2",
-                "@fluentui/utilities": "^8.17.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16.8.0 <20.0.0",
-                "@types/react-dom": ">=16.8.0 <20.0.0",
-                "react": ">=16.8.0 <20.0.0",
-                "react-dom": ">=16.8.0 <20.0.0"
-            }
-        },
         "node_modules/@microsoft/sp-loader/node_modules/@microsoft/sp-http-base": {
             "version": "1.22.2",
             "resolved": "https://registry.npmjs.org/@microsoft/sp-http-base/-/sp-http-base-1.22.2.tgz",
@@ -7575,21 +7474,6 @@
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
-        },
-        "node_modules/@microsoft/sp-loader/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-loader/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@microsoft/sp-loader/node_modules/tslib": {
             "version": "2.3.1",
@@ -7866,21 +7750,6 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/sp-page-context/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-page-context/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-page-context/node_modules/tslib": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -7918,34 +7787,6 @@
                 "@types/react-dom": ">=16.9.8 <18.0.0"
             }
         },
-        "node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react": {
-            "version": "8.125.3",
-            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.3.tgz",
-            "integrity": "sha512-GCSIB9SXkQDvvBYNMjrJKu4OP7aPD8U5wry/g/yQ9G9r4JmtoEvnQi6JhUescgXal2ANVAhex5HBrHBgEdhJFA==",
-            "license": "MIT",
-            "dependencies": {
-                "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.70",
-                "@fluentui/foundation-legacy": "^8.6.3",
-                "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.3",
-                "@fluentui/react-hooks": "^8.10.2",
-                "@fluentui/react-portal-compat-context": "^9.0.15",
-                "@fluentui/react-window-provider": "^2.3.2",
-                "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.13.6",
-                "@fluentui/theme": "^2.7.2",
-                "@fluentui/utilities": "^8.17.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16.8.0 <20.0.0",
-                "@types/react-dom": ">=16.8.0 <20.0.0",
-                "react": ">=16.8.0 <20.0.0",
-                "react-dom": ">=16.8.0 <20.0.0"
-            }
-        },
         "node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react-icons": {
             "version": "2.0.306",
             "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.306.tgz",
@@ -7958,21 +7799,6 @@
             "peerDependencies": {
                 "react": ">=16.8.0 <19.0.0"
             }
-        },
-        "node_modules/@microsoft/sp-property-pane/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
-            "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-property-pane/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@microsoft/sp-property-pane/node_modules/tslib": {
             "version": "2.3.1",
@@ -11477,16 +11303,29 @@
             }
         },
         "node_modules/@pnp/odata/node_modules/@pnp/common": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@pnp/common/-/common-2.5.0.tgz",
-            "integrity": "sha512-ea4zTNC3sjLolrHZXP+/2SrJM+yC8PygmPW/yRfgbErdvdwYMUSogT69dW+NUaqhkfYZfkkAoWn42irlLMSpdw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.3.11.tgz",
+            "integrity": "sha512-RhYKcfMP+h0pAzORZRHSPPLOBB58djN/pfnorpWPjsx6ZxMqbiDqTzAtTF4m8z/mdNnxJr0Q3kwt4ImU3FjwnA==",
             "license": "MIT",
             "dependencies": {
-                "tslib": "2.2.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://github.com/sponsors/patrick-rodgers/"
+                "adal-angular": "1.0.17",
+                "tslib": "1.10.0"
+            }
+        },
+        "node_modules/@pnp/odata/node_modules/@pnp/common/node_modules/tslib": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@pnp/odata/node_modules/adal-angular": {
+            "version": "1.0.17",
+            "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.17.tgz",
+            "integrity": "sha512-+Z9aq7L25OncsaVcnhSsi7AMR/dlg0gWVNptsdtkL9Ih7hA1oJ14mhWB60CB83JF6DlzamVKLMGbrAcgFQqhCg==",
+            "deprecated": "This package is no longer supported. Please migrate to @azure/msal-angular.",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/@pnp/odata/node_modules/tslib": {
@@ -15608,15 +15447,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/normalize-package-data": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@types/office-js": {
             "version": "1.0.36",
             "resolved": "https://registry.npmjs.org/@types/office-js/-/office-js-1.0.36.tgz",
@@ -17876,27 +17706,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/browser-resolve": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "resolve": "1.1.7"
-            }
-        },
-        "node_modules/browser-resolve/node_modules/resolve": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-            "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/browserslist": {
             "version": "4.28.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -19284,13 +19093,10 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-            "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "engines": {
-                "node": ">=20"
-            },
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -20447,9 +20253,9 @@
             "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
                     "type": "github",
@@ -21290,15 +21096,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/growly": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/handle-thing": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -21983,24 +21780,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -22375,21 +22154,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -23413,29 +23177,6 @@
                 "jest-resolve": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jest-resolve": {
-            "version": "25.5.1",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
-            "integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^25.5.0",
-                "browser-resolve": "^1.11.3",
-                "chalk": "^3.0.0",
-                "graceful-fs": "^4.2.4",
-                "jest-pnp-resolver": "^1.2.1",
-                "read-pkg-up": "^7.0.1",
-                "realpath-native": "^2.0.0",
-                "resolve": "^1.17.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8.3"
             }
         },
         "node_modules/jju": {
@@ -24692,35 +24433,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/node-notifier": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-            "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "growly": "^1.3.0",
-                "is-wsl": "^2.2.0",
-                "semver": "^7.3.5",
-                "shellwords": "^0.1.1",
-                "uuid": "^8.3.2",
-                "which": "^2.0.2"
-            }
-        },
-        "node_modules/node-notifier/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -25968,92 +25680,6 @@
                 "tslib": "*"
             }
         },
-        "node_modules/read-pkg-up": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "find-up": "^4.1.0",
-                "read-pkg": "^5.2.0",
-                "type-fest": "^0.8.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/hosted-git-info": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/read-pkg-up/node_modules/normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/read-pkg": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^2.5.0",
-                "parse-json": "^5.0.0",
-                "type-fest": "^0.6.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -26088,18 +25714,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/realpath-native": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -27267,15 +26881,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/shellwords": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/side-channel": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -27541,50 +27146,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/spdx-correct": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-exceptions": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-            "dev": true,
-            "license": "CC-BY-3.0",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-            "dev": true,
-            "license": "CC0-1.0",
-            "optional": true,
-            "peer": true
         },
         "node_modules/spdy": {
             "version": "4.0.2",
@@ -28947,19 +28508,6 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
             }
         },
         "node_modules/validator": {

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -20269,9 +20269,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-            "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "dev": true,
             "funding": [
                 {
@@ -20279,7 +20279,11 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
         },
         "node_modules/fast-xml-parser": {
             "version": "5.4.2",
@@ -24998,6 +25002,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -29467,6 +29487,22 @@
             "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/xmlchars": {
             "version": "2.2.0",


### PR DESCRIPTION
Manual resolution of all open Dependabot lockfile bumps, retargeted to `develop`.

Bundles cherry-picked Dependabot commits (originally opened against `main`) so they merge directly into `develop`:

| Source PR | Package | From → To | Folder |
|-----------|---------|-----------|--------|
| #4758 | `fast-uri` | 3.1.0 → 3.1.2 | `search-extensibility` |
| #4755 | `fast-xml-builder` | 1.1.4 → 1.2.0 | `search-extensibility` |
| #4739 | `fast-xml-parser` | 5.6.0 → 5.7.1 | `search-extensibility` |
| #4757 | `fast-uri` | 3.1.0 → 3.1.2 | `search-parts` |
| #4756 | `fast-xml-builder` | 1.0.0 → 1.2.0 | `search-parts` |

Only `package-lock.json` files are touched (all bumps are transitive). A conflict between the `fast-xml-builder` bump (PR #4755) and the `fast-xml-parser` bump (PR #4739) inside `search-extensibility/package-lock.json` was resolved manually by keeping `fast-xml-builder@1.2.0` (which satisfies the `^1.1.5` constraint introduced by `fast-xml-parser@5.7.1`).

Closes #4758, #4757, #4756, #4755, #4739.
