### PR TITLE
Fix #4741 (getDate 'X' broken) and #4772 (workbench toolbox missing webparts)

### DIFF
--- a/search-parts/config/serve.json
+++ b/search-parts/config/serve.json
@@ -2,22 +2,22 @@
     "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
     "port": 4321,
     "https": true,
-    "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx",
+    "initialPage": "https://{tenantDomain}/_layouts/15/workbench.aspx",
     "serveConfigurations": {
         "default": {
-            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+            "pageUrl": "https://{tenantDomain}/_layouts/15/workbench.aspx"
         },
         "modern-search-results-web-part": {
-            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+            "pageUrl": "https://{tenantDomain}/_layouts/15/workbench.aspx"
         },
         "modern-search-filters-web-part": {
-            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+            "pageUrl": "https://{tenantDomain}/_layouts/15/workbench.aspx"
         },
         "modern-search-box-web-part": {
-            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+            "pageUrl": "https://{tenantDomain}/_layouts/15/workbench.aspx"
         },
         "modern-search-verticals-web-part": {
-            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+            "pageUrl": "https://{tenantDomain}/_layouts/15/workbench.aspx"
         }
     }
 }

--- a/search-parts/config/serve.json
+++ b/search-parts/config/serve.json
@@ -2,5 +2,22 @@
     "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/spfx-serve.schema.json",
     "port": 4321,
     "https": true,
-    "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx"
+    "initialPage": "https://{tenantDomain}/_layouts/workbench.aspx",
+    "serveConfigurations": {
+        "default": {
+            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+        },
+        "modern-search-results-web-part": {
+            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+        },
+        "modern-search-filters-web-part": {
+            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+        },
+        "modern-search-box-web-part": {
+            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+        },
+        "modern-search-verticals-web-part": {
+            "pageUrl": "https://{tenantDomain}/_layouts/workbench.aspx"
+        }
+    }
 }

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -12,7 +12,15 @@ import {
     trimEnd,
     get,
 } from "@microsoft/sp-lodash-subset";
+import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
 import { DateHelper } from "../../helpers/DateHelper";
+
+// Ensure `advancedFormat` is registered on the shared dayjs singleton before any
+// helper that uses tokens like `X` / `x` runs. Without this, `dayjs(...).format('X')`
+// would echo back the literal "X" — breaking handlebars templates that compare
+// Unix timestamps (see #4741).
+dayjs.extend(advancedFormat);
 import { PageContext } from "@microsoft/sp-page-context";
 import {
     IComponentDefinition,
@@ -64,9 +72,13 @@ export class TemplateService implements ITemplateService {
     private _extendedHelpersPromise: Promise<void> | null = null;
 
     /**
-     * The dayjs library reference
+     * The dayjs library reference. Initialized synchronously to the imported
+     * singleton so helpers that depend on it (e.g. `getDate`, `dayDiff`) can be
+     * invoked from templates rendered before `dateHelper.moment()` resolves its
+     * locale chunk. The async assignment below still runs and updates the same
+     * singleton's locale configuration.
      */
-    private dayjs: any;
+    private dayjs: any = dayjs;
 
     private timeZoneBias = {
         WebBias: 0,


### PR DESCRIPTION
Two small fixes targeting open v4.21.0 issues ahead of the next release.

## #4741 — `getDate ... 'X'` returns the raw input instead of a Unix timestamp

`TemplateService.dayjs` was assigned asynchronously via `dateHelper.moment().then(d => this.dayjs = d)`. Any template rendered before that promise resolved hit the helper's catch path (`this.dayjs is not a function`) and silently returned the original input string, breaking expressions like:

```handlebars
{{#lt (getDate (slot item @root.slots.Date) 'X') (moment 'X')}}
```

Fix:
- Import `dayjs` directly in `TemplateService.ts` and initialize `this.dayjs` synchronously to the shared singleton.
- Explicitly `dayjs.extend(advancedFormat)` in this module as a guard so `'X'` / `'x'` format tokens always work, even if `DateHelper` hasn't been loaded yet.
- The async `dateHelper.moment()` call is kept for locale configuration (same singleton; just updates the locale state).

## #4772 — web parts not appearing in local workbench

`search-parts/config/serve.json` only declared `initialPage`. Modern SPFx tooling (Heft + spfx-heft-plugins) expects a `serveConfigurations` map; without it, `heft start --config <bundle>` has no entry to resolve and the toolbox can fail to register the web parts.

Fix:
- Added a `default` config plus one named entry per bundle (`modern-search-results-web-part`, `-filters-`, `-box-`, `-verticals-`) — aligning with what the SPFx generator emits for new projects.

## Issues addressed
- Closes #4741
- Closes #4772

## Out of scope
- #4751 (taxonomy filter blocking downstream filter submission) — handled separately.