### PR TITLE
Fix Webpart title styles

### DIFF
--- a/search-parts/src/styles/Common.module.scss
+++ b/search-parts/src/styles/Common.module.scss
@@ -1,11 +1,8 @@
 .wpTitle {
-    > div:first-child {
-        textarea,
-        span {
-            font-size: 20px!important;
-            font-weight: 600!important;
-            font-family: var(--fontFamilyCustomFont1300, var(--fontFamilyBase));
-        }
+    textarea, span {
+        font-size: 20px!important;
+        font-weight: 600!important;
+        font-family: var(--fontFamilyCustomFont1300, var(--fontFamilyBase));
     }
 }
 


### PR DESCRIPTION
Fixes a small bug setting the font-size of the Webpart title as discussed [here](https://github.com/microsoft-search/pnp-modern-search/discussions/4621#discussioncomment-17064006).