### PR TITLE
Suggest the 'Search Rollup' variant for unconnected Search Results in edit mode

### DIFF
--- a/docs/usage/search-results/index.md
+++ b/docs/usage/search-results/index.md
@@ -4,12 +4,44 @@ The _'Search Results' Web Part_ is the fundamental building block of whole globa
 
 This Web Part can be used **alone** or **connected to other Web Parts** to add dyanmic interactions (filters, search box or verticals). To use the Web Part on a SharePoint page:
 1. Edit your SharePoint modern page.
-2. Search for the _'PnP - Search Results'_ Web Part and add it to your page.<br><br>
-    _You may use "PnP - Search Rollup" instead if you don't need to connect web parts. This version support being lazy loaded in the SharePoint framework to optimize page loading._
+2. Search for the _'PnP - Search Results'_ Web Part and add it to your page.
 
 !["PnP Search Results"](../../assets/webparts/search-results/search_results_wp_picker.png){: .center}
 
 !["PnP Search Results"](../../assets/webparts/search-results/search_results_wp_placeholder.png){: .center}
+
+### Which version to choose: _'PnP - Search Results'_ vs _'PnP - Search Rollup'_
+
+Two preconfigured variants of this Web Part are available in the Web Part picker. They share the **same codebase, features, layouts, data sources and configuration options** — they differ only in how SharePoint loads them on the page.
+
+| Variant | When to use it | Behavior on the page |
+| --- | --- | --- |
+| **PnP - Search Results** | You **might want to connect this Web Part to other Web Parts** on the same page (a Search Box, Search Filters, Search Verticals, or another Search Results for dynamic filtering / item selection). Connections are optional — you can leave them unconfigured — but the Web Part remains *able* to participate in them. | Registers as a SharePoint dynamic data source/consumer as soon as the page loads, so it must be initialized eagerly — its bundle is downloaded and its data source query is issued during the page's initial load, even if the Web Part is far below the fold. |
+| **PnP - Search Rollup** | You are using the Web Part **standalone** — typically a content roll-up (latest news, recent documents, page hit highlights, etc.) where you know it will not need to react to or feed any other Web Part, and you do not need to drive the query from a SharePoint page-environment value (URL fragment, query-string parameter, page search query, etc.). | Opts out of dynamic data connections (`allowWebPartConnections: false`). This lets SharePoint **defer-load the Web Part** until it actually scrolls into the viewport, so its JavaScript bundle, dependent chunks and underlying search query are not fetched at all on initial page load. |
+
+#### Why this matters for performance
+
+SharePoint Framework only defer-loads a Web Part when it is certain no other component will try to read from it. As soon as a Web Part registers itself as a dynamic data source/consumer, SPFx is forced to initialize it eagerly on page load to make the connection available — defeating any below-the-fold lazy-loading optimization.
+
+The _'PnP - Search Rollup'_ variant exists precisely to opt out of that registration. The practical impact on a page with a roll-up below the fold:
+
+- The Web Part's JavaScript bundle and its dependent chunks (data source, layout, templating engine, etc.) are **not downloaded** until the user scrolls the rollup into view.
+- The data source query (SharePoint Search, Microsoft Search, etc.) is **not executed** on initial page load — saving an API round-trip, search throttling capacity and bandwidth for every visitor who never scrolls to it.
+- Initial page render, Largest Contentful Paint and Total Blocking Time all improve, because the page no longer waits on (or competes with) the roll-up's resources during the critical load phase.
+
+#### What the Rollup variant can and cannot consume
+
+It's important to distinguish two very different ways the Web Part can be parameterized at runtime — only one of them is disabled by the rollup variant:
+
+| Input mechanism | Where it's configured | Works in _Search Results_ | Works in _Search Rollup_ | Why |
+| --- | --- | --- | --- | --- |
+| **SPFx dynamic data — other Web Parts** (Search Box, Filters, Verticals, dynamic filtering / item selection) | _Connections_ property-pane page | ✅ Yes | ❌ No | Requires registering as a dynamic data source/consumer; SPFx must initialize the Web Part eagerly to wire the connection. |
+| **SPFx dynamic data — page environment** (URL fragment binding, `?param=` binding via the dynamic property picker, `PageContext:SearchData:searchQuery`) | _Connections_ → "Use input query text" → _Dynamic value_ | ✅ Yes | ❌ No | Same reason — these are SPFx dynamic data sources too. |
+| **Tokens** in Query text, Query template, refiners, sort, etc. — including `{QueryString.<name>}`, `{Page.<field>}`, `{Site}`, `{User.<prop>}`, date tokens, `{Me}`, … | Wherever the property pane accepts a value | ✅ Yes | ✅ Yes | Tokens are resolved by the built-in `TokenService` at render time directly from `window.location.href`, the page context and the current user — they do **not** go through SPFx dynamic data, so the Rollup's lazy-load benefit is preserved. |
+
+> **TL;DR:** The Rollup variant gives up SPFx **Web Part connections** and SPFx **dynamic page-environment bindings**, but it keeps the full **token system** — including `{QueryString.q}`, `{QueryString.dept}`, etc. So a URL-driven search results page (`?q=foo`, `?category=news`, …) still works perfectly with the rollup variant — just use a token instead of a dynamic property binding. See [Tokens](./tokens.md) for the full list.
+
+If you later decide a roll-up needs to be connected to a filter or search box, simply switch to the _'PnP - Search Results'_ variant — all properties and templates are compatible. While you are editing a _'PnP - Search Results'_ Web Part that is not connected to anything on the page, the Web Part will also surface an inline warning suggesting you switch to the rollup variant.
 
 ## Configuration
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2122,7 +2122,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             }
 
             const refs = filterData?.connectedResultsSourceReferences;
-            if (refs && refs.some(ref => ref.split(':')[0]?.endsWith(instanceId))) {
+            if (refs?.some(ref => ref.split(':')[0]?.endsWith(instanceId))) {
                 Log.verbose(LogSource, `[_checkPotentialIncomingConnections] Detected incoming filter connection from source '${sourceInfo.id}' for instance '${instanceId}'.`, this.webPartInstanceServiceScope);
                 return true;
             }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -11,18 +11,11 @@ import {
     IPropertyPaneConfiguration,
     IPropertyPaneChoiceGroupOption,
     IPropertyPaneGroup,
-    PropertyPaneChoiceGroup,
     IPropertyPaneField,
     PropertyPaneHorizontalRule,
     PropertyPaneToggle,
-    PropertyPaneTextField,
     PropertyPaneSlider,
-    IPropertyPanePage,
-    PropertyPaneDropdown,
-    PropertyPaneCheckbox,
-    PropertyPaneDynamicField,
-    DynamicDataSharedDepth,
-    PropertyPaneDynamicFieldSet
+    IPropertyPanePage
 } from "@microsoft/sp-property-pane";
 import ISearchResultsWebPartProps, { QueryTextSource } from './ISearchResultsWebPartProps';
 import { AvailableDataSources, BuiltinDataSourceProviderKeys } from '../../dataSources/AvailableDataSources';
@@ -58,12 +51,12 @@ import commonStyles from '../../styles/Common.module.scss';
 import { UrlHelper } from '../../helpers/UrlHelper';
 import { ObjectHelper } from '../../helpers/ObjectHelper';
 import { ItemSelectionMode } from '../../models/common/IItemSelectionProps';
-import { PropertyPaneAsyncCombo } from '../../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo';
 import { DynamicPropertyHelper } from '../../helpers/DynamicPropertyHelper';
 import { IQueryModifierConfiguration } from '../../queryModifier/IQueryModifierConfiguration';
 import { loadMsGraphToolkit } from '../../helpers/GraphToolKitHelper';
 import { DataSourcePropertyPaneBuilder } from './propertyPane/DataSourcePropertyPaneBuilder';
 import { AboutPropertyPaneBuilder } from './propertyPane/AboutPropertyPaneBuilder';
+import type { ConnectionsPropertyPaneBuilder as ConnectionsPropertyPaneBuilderType } from './propertyPane/ConnectionsPropertyPaneBuilder';
 import { TokenSetter } from './services/TokenSetter';
 import { StylingPageGroupsBuilder } from './propertyPane/StylingPageGroupsBuilder';
 
@@ -123,6 +116,13 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _customCollectionFieldType: any = null;
     private _textDialogComponent: any = null;
     private _propertyPanePropertyEditor = null;
+
+    /**
+     * Lazily-loaded `ConnectionsPropertyPaneBuilder` class reference. Loaded as part of the
+     * `'pnp-modern-search-property-pane'` chunk in `loadPropertyPaneResources()`, so it is only
+     * downloaded when the property pane is opened. View-mode page loads do not pull it.
+     */
+    private _connectionsPropertyPaneBuilderClass: typeof ConnectionsPropertyPaneBuilderType = null;
 
     /**
      * The selected data source for the WebPart
@@ -252,6 +252,15 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * The current DataContext - is updated in render method
      */
     private _currentDataContext: IDataContext;
+
+    /**
+     * Tracks whether other Web Parts on the page could potentially consume data from this Search
+     * Results Web Part. Default `false` (no incoming detected) so a brand-new, unconnected Web Part
+     * surfaces the rollup-version suggestion on the very first render; the async re-evaluation only
+     * needs to flip it to `true` when other consumer-capable Web Parts (Search Filters, other Search
+     * Results) are present on the page.
+     */
+    private _hasPotentialIncomingConnections: boolean = false;
 
     constructor() {
         super();
@@ -561,6 +570,33 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             }
         }
 
+        // Suggestion: when in edit mode and this Web Part is not (and is unlikely to be) connected to
+        // any other Web Part, surface a warning recommending the lazy-loadable "Search Rollup" variant.
+        // Outgoing connections are checked synchronously here; incoming connections are checked
+        // asynchronously in `_evaluateRollupSuggestion()` and reflected via `_hasPotentialIncomingConnections`.
+        const shouldShowRollupSuggestion = this.displayMode === DisplayMode.Edit
+            && this.properties.allowWebPartConnections === true
+            && !this._hasOutgoingConnections()
+            && !this._hasPotentialIncomingConnections;
+
+        if (shouldShowRollupSuggestion && renderRootElement) {
+            const docsHref = 'https://microsoft-search.github.io/pnp-modern-search/usage/search-results/';
+            renderRootElement = React.createElement('div', {},
+                React.createElement(
+                    MessageBar, {
+                    messageBarType: MessageBarType.warning,
+                },
+                    webPartStrings.General.RollupSuggestionMessage,
+                    ' ',
+                    React.createElement(Link, {
+                        target: '_blank',
+                        href: docsHref
+                    }, webPartStrings.General.RollupSuggestionLinkText)
+                ),
+                renderRootElement
+            );
+        }
+
         // Error message
         if (this.errorMessage) {
             renderRootElement = React.createElement(MessageBar, {
@@ -643,6 +679,23 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Initializes dynamic data connections. This could trigger a render if a connection is made with an other component resulting to a render race condition.
         await this.ensureDynamicDataSourcesConnection();
+
+        // Re-evaluate the rollup-version suggestion whenever the set of available dynamic data
+        // sources on the page changes (i.e. another Web Part is added or removed). This keeps the
+        // inline warning in sync without requiring a property pane change or page refresh.
+        if (this.displayMode === DisplayMode.Edit && this.context.dynamicDataProvider) {
+            this.context.dynamicDataProvider.registerAvailableSourcesChanged(() => {
+                this._evaluateRollupSuggestion().catch(error => {
+                    Log.warn(LogSource, `Failed to evaluate rollup suggestion: ${error}`, this.webPartInstanceServiceScope);
+                });
+            });
+
+            // Initial evaluation. Fire-and-forget: it triggers an additional render only if the
+            // computed state actually changes (so an unconnected new Web Part avoids a redundant render).
+            this._evaluateRollupSuggestion().catch(error => {
+                Log.warn(LogSource, `Failed to evaluate rollup suggestion: ${error}`, this.webPartInstanceServiceScope);
+            });
+        }
 
         return super.onInit();
     }
@@ -1181,6 +1234,12 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._propertyFieldNumber = PropertyFieldNumber;
 
+        const { ConnectionsPropertyPaneBuilder } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            './propertyPane/ConnectionsPropertyPaneBuilder'
+        );
+        this._connectionsPropertyPaneBuilderClass = ConnectionsPropertyPaneBuilder;
+
         this.propertyPaneConnectionsGroup = await this.getConnectionOptionsGroup();
     }
 
@@ -1675,336 +1734,34 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         return templateSlotFields;
     }
 
-    private getSearchQueryTextFields(): IPropertyPaneField<any>[] {
-        let searchQueryTextFields: IPropertyPaneField<any>[] = [
-            this._propertyFieldToogleWithCallout('useInputQueryText', {
-                label: webPartStrings.PropertyPane.ConnectionsPage.UseInputQueryText,
-                calloutTrigger: this._propertyFieldCalloutTriggers.Hover,
-                key: 'useInputQueryText',
-                calloutContent: React.createElement('p', { style: { maxWidth: 250, wordBreak: 'break-word' } }, webPartStrings.PropertyPane.ConnectionsPage.UseInputQueryTextHoverMessage),
-                onText: commonStrings.General.OnTextLabel,
-                offText: commonStrings.General.OffTextLabel,
-                checked: this.properties.useInputQueryText
-            })
-        ];
-
-        if (this.properties.useInputQueryText) {
-
-            searchQueryTextFields.push(
-                PropertyPaneChoiceGroup('queryTextSource', {
-                    options: [
-                        {
-                            key: QueryTextSource.StaticValue,
-                            text: webPartStrings.PropertyPane.ConnectionsPage.InputQueryTextStaticValue
-                        },
-                        {
-                            key: QueryTextSource.DynamicValue,
-                            text: webPartStrings.PropertyPane.ConnectionsPage.InputQueryTextDynamicValue
-                        }
-                    ]
-                })
-            );
-
-            switch (this.properties.queryTextSource) {
-
-                case QueryTextSource.StaticValue:
-                    searchQueryTextFields.push(
-                        PropertyPaneTextField('queryText', {
-                            label: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextFieldLabel,
-                            description: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextFieldDescription,
-                            multiline: true,
-                            resizable: true,
-                            placeholder: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryPlaceHolderText,
-                            onGetErrorMessage: this._validateEmptyField.bind(this),
-                            deferredValidationTime: 500
-                        })
-                    );
-                    break;
-
-                case QueryTextSource.DynamicValue:
-                    searchQueryTextFields.push(
-                        PropertyPaneDynamicField('queryText', {
-                            label: ''
-                        }),
-                        PropertyPaneCheckbox('useDefaultQueryText', {
-                            text: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextUseDefaultQuery,
-                            disabled: this.properties.queryText.reference === undefined
-                        })
-                    );
-
-                    if (this.properties.useDefaultQueryText && this.properties.queryText.reference !== undefined) {
-                        searchQueryTextFields.push(
-                            PropertyPaneTextField('defaultQueryText', {
-                                label: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextDefaultValue,
-                                multiline: true
-                            })
-                        );
-                    }
-
-                    break;
-
-                default:
-                    break;
-            }
-
-            if (this.availableCustomQueryModifierDefinitions.length > 0) {
-
-                searchQueryTextFields = searchQueryTextFields.concat(this.getQueryModifierFields());
-            }
-
-        }
-
-        return searchQueryTextFields;
-    }
-
-    private async getDataResultsConnectionFields(): Promise<IPropertyPaneField<any>[]> {
-
-        let dataResultsConnectionFields: IPropertyPaneField<any>[] = [
-            PropertyPaneToggle('useDynamicFiltering', {
-                label: webPartStrings.PropertyPane.ConnectionsPage.UseDynamicFilteringsWebPartLabel,
-                checked: this.properties.useDynamicFiltering
-            })
-        ];
-
-        if (this.properties.useDynamicFiltering) {
-
-            let isSourceFieldConfigured: boolean = false;
-
-            // Make sure a property is selected in the source according to the reference format.
-            // Ex: PageContext:UrlData:queryParameters.q = Page environment
-            // Ex: WebPart.544c1372-42df-47c3-94d6-017428cd2baf.1272b161-3435-4815-99a1-996590334cff:AvailableFieldValuesFromResults:FileType = Search Results
-            if (this.properties.selectedItemFieldValue.reference) {
-                isSourceFieldConfigured = /^.+:.+:(.+)$/.test(this.properties.selectedItemFieldValue.reference);
-            }
-
-            dataResultsConnectionFields.push(
-
-                // Allow both 'Search Results' Web Parts and OOTB SharePoint List Web Parts 
-                PropertyPaneDynamicFieldSet({
-                    label: webPartStrings.PropertyPane.ConnectionsPage.UseDataResultsFromComponentsLabel,
-                    fields: [
-                        PropertyPaneDynamicField('selectedItemFieldValue', {
-                            label: webPartStrings.PropertyPane.ConnectionsPage.UseDataResultsFromComponentsLabel,
-                        })
-                    ],
-                    sharedConfiguration: {
-                        depth: DynamicDataSharedDepth.Property,
-                        property: {
-                            filters: {
-                                propertyId: DynamicDataProperties.AvailableFieldValuesFromResults
-                            }
-                        }
-                    }
-                })
-            );
-
-            if (isSourceFieldConfigured) {
-
-                const availableOptions: IComboBoxOption[] = this.getSelectedProperties().map((field: string) => {
-                    return {
-                        key: field,
-                        text: field
-                    };
-                });
-
-                dataResultsConnectionFields.splice(4, 0,
-                    new PropertyPaneAsyncCombo('itemSelectionProps.destinationFieldName', {
-                        label: webPartStrings.PropertyPane.ConnectionsPage.SourceDestinationFieldLabel,
-                        availableOptions: availableOptions,
-                        description: webPartStrings.PropertyPane.ConnectionsPage.SourceDestinationFieldDescription,
-                        allowMultiSelect: false,
-                        allowFreeform: true,
-                        searchAsYouType: false,
-                        defaultSelectedKeys: this.properties.selectedVerticalKeys,
-                        textDisplayValue: this.properties.itemSelectionProps.destinationFieldName,
-                        onPropertyChange: this.onCustomPropertyUpdate.bind(this),
-                    })
-                );
-            }
-
-            if (isSourceFieldConfigured && this.properties.itemSelectionProps.destinationFieldName) {
-
-                dataResultsConnectionFields.splice(4, 0,
-                    PropertyPaneChoiceGroup('itemSelectionProps.selectionMode', {
-                        options: [
-                            {
-                                key: ItemSelectionMode.AsDataFilter,
-                                text: webPartStrings.PropertyPane.LayoutPage.Handlebars.AsDataFiltersSelectionMode
-                            },
-                            {
-                                key: ItemSelectionMode.AsTokenValue,
-                                text: webPartStrings.PropertyPane.LayoutPage.Handlebars.AsTokensSelectionMode
-                            }
-                        ],
-                        label: webPartStrings.PropertyPane.LayoutPage.Handlebars.SelectionModeLabel,
-                    })
-                );
-
-                if (this.properties.itemSelectionProps.selectionMode === ItemSelectionMode.AsDataFilter) {
-                    dataResultsConnectionFields.splice(5, 0,
-                        this._propertyPaneWebPartInformation({
-                            description: `<em>${webPartStrings.PropertyPane.LayoutPage.Handlebars.AsDataFiltersDescription}</em>`,
-                            key: 'selectionModeText'
-                        }),
-                        PropertyPaneChoiceGroup('itemSelectionProps.valuesOperator', {
-                            options: [
-                                {
-                                    key: FilterConditionOperator.OR,
-                                    text: 'OR'
-                                },
-                                {
-                                    key: FilterConditionOperator.AND,
-                                    text: 'AND'
-                                },
-                            ],
-                            label: webPartStrings.PropertyPane.LayoutPage.Handlebars.FilterValuesOperator
-                        })
-                    );
-                } else {
-                    dataResultsConnectionFields.splice(4, 0,
-                        this._propertyPaneWebPartInformation({
-                            description: `<em>${webPartStrings.PropertyPane.LayoutPage.Handlebars.AsTokensDescription}</em>`,
-                            key: 'selectionModeText'
-                        })
-                    );
-                }
-            }
-        }
-
-        return dataResultsConnectionFields;
-    }
-
-    private async getFiltersConnectionFields(): Promise<IPropertyPaneField<any>[]> {
-
-        let filtersConnectionFields: IPropertyPaneField<any>[] = [
-            PropertyPaneToggle('useFilters', {
-                label: webPartStrings.PropertyPane.ConnectionsPage.UseFiltersWebPartLabel,
-                checked: this.properties.useFilters
-            })
-        ];
-
-        if (this.properties.useFilters) {
-            filtersConnectionFields.splice(1, 0,
-                PropertyPaneDropdown('filtersDataSourceReference', {
-                    options: await this.dynamicDataService.getAvailableDataSourcesByType(ComponentType.SearchFilters),
-                    label: webPartStrings.PropertyPane.ConnectionsPage.UseFiltersFromComponentLabel
-                })
-            );
-
-            // Check bidirectional connection: does the filter web part also connect back to this results web part?
-            if (this.properties.filtersDataSourceReference && this._filtersConnectionSourceData) {
-                const filterData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
-                if (filterData && filterData.connectedResultsSourceReferences) {
-                    // Extract sourceId from each reference (format: "sourceId:propertyId") and check if it ends with this web part's instanceId
-                    const isConnectedBack = filterData.connectedResultsSourceReferences.some(
-                        ref => {
-                            const sourceId = ref.split(':')[0];
-                            return sourceId.endsWith(this.instanceId);
-                        }
-                    );
-                    if (!isConnectedBack) {
-                        filtersConnectionFields.push(
-                            this._propertyPaneWebPartInformation({
-                                description: `<span style="color: #d83b01;">⚠ ${webPartStrings.PropertyPane.ConnectionsPage.BidirectionalConnectionWarning}</span>`,
-                                key: 'bidirectionalFilterWarning'
-                            })
-                        );
-                    }
-                }
-            }
-        }
-
-        return filtersConnectionFields;
-    }
-
-    private async getVerticalsConnectionFields(): Promise<IPropertyPaneField<any>[]> {
-
-        let verticalsConnectionFields: IPropertyPaneField<any>[] = [
-            PropertyPaneToggle('useVerticals', {
-                label: webPartStrings.PropertyPane.ConnectionsPage.UseSearchVerticalsWebPartLabel,
-                checked: this.properties.useVerticals
-            })
-        ];
-
-        if (this.properties.useVerticals) {
-            verticalsConnectionFields.splice(1, 0,
-                PropertyPaneDropdown('verticalsDataSourceReference', {
-                    options: await this.dynamicDataService.getAvailableDataSourcesByType(ComponentType.SearchVerticals),
-                    label: webPartStrings.PropertyPane.ConnectionsPage.UseSearchVerticalsFromComponentLabel
-                })
-            );
-
-            if (this.properties.verticalsDataSourceReference) {
-
-                // Get all available verticals
-                if (this._verticalsConnectionSourceData) {
-                    const availableVerticals = DynamicPropertyHelper.tryGetValueSafe(this._verticalsConnectionSourceData);
-
-                    if (availableVerticals) {
-
-                        // Get the corresponding text for selected keys
-                        let selectedKeysAsText: string[] = [];
-
-                        availableVerticals.verticalsConfiguration.forEach(verticalConfiguration => {
-                            if (this.properties.selectedVerticalKeys.indexOf(verticalConfiguration.key) !== -1) {
-                                selectedKeysAsText.push(verticalConfiguration.tabName);
-                            }
-                        });
-
-                        verticalsConnectionFields.push(
-                            new PropertyPaneAsyncCombo('selectedVerticalKeys', {
-                                availableOptions: availableVerticals.verticalsConfiguration.filter(v => !v.isLink).map(verticalConfiguration => {
-                                    return {
-                                        key: verticalConfiguration.key,
-                                        text: verticalConfiguration.tabName
-                                    };
-                                }),
-                                allowMultiSelect: true,
-                                allowFreeform: false,
-                                description: webPartStrings.PropertyPane.ConnectionsPage.LinkToVerticalLabelHoverMessage,
-                                label: webPartStrings.PropertyPane.ConnectionsPage.LinkToVerticalLabel,
-                                searchAsYouType: false,
-                                defaultSelectedKeys: this.properties.selectedVerticalKeys,
-                                textDisplayValue: selectedKeysAsText.join(','),
-                                onPropertyChange: this.onCustomPropertyUpdate.bind(this),
-                            }),
-                        );
-                    }
-                }
-            }
-        }
-
-        return verticalsConnectionFields;
-    }
-
     private async getConnectionOptionsGroup(): Promise<IPropertyPaneGroup[]> {
-        const filterConnectionFields = await this.getFiltersConnectionFields();
-        const verticalConnectionFields = await this.getVerticalsConnectionFields();
-        const dataResultsConnectionsFields = await this.getDataResultsConnectionFields();
 
-        let dynamicDataToggles = [];
-        if (this.properties.allowWebPartConnections) {
-            dynamicDataToggles = [
-                ...this.getSearchQueryTextFields(),
-                PropertyPaneHorizontalRule(),
-                ...filterConnectionFields,
-                PropertyPaneHorizontalRule(),
-                ...verticalConnectionFields,
-                PropertyPaneHorizontalRule(),
-                ...dataResultsConnectionsFields
-            ]
+        // Class is lazily loaded in `loadPropertyPaneResources()` as part of the property-pane
+        // chunk. If the pane was never opened yet (e.g. property-pane refresh fired before
+        // `onPropertyPaneConfigurationStart`) we have nothing to render, so return an empty group.
+        if (!this._connectionsPropertyPaneBuilderClass) {
+            return [];
         }
 
-        let availableConnectionsGroup: IPropertyPaneGroup[] = [
-            {
-                groupName: webPartStrings.PropertyPane.ConnectionsPage.ConnectionsPageGroupName,
-                groupFields: [
-                    ...dynamicDataToggles
-                ]
-            }
-        ];
+        const builder = new this._connectionsPropertyPaneBuilderClass({
+            properties: this.properties,
+            instanceId: this.instanceId,
+            webPartStrings: webPartStrings,
+            commonStrings: commonStrings,
+            dynamicDataService: this.dynamicDataService,
+            filtersConnectionSourceData: this._filtersConnectionSourceData,
+            verticalsConnectionSourceData: this._verticalsConnectionSourceData,
+            hasCustomQueryModifiers: this.availableCustomQueryModifierDefinitions.length > 0,
+            propertyFieldToogleWithCallout: this._propertyFieldToogleWithCallout,
+            propertyFieldCalloutTriggers: this._propertyFieldCalloutTriggers,
+            propertyFieldCollectionData: this._propertyFieldCollectionData,
+            customCollectionFieldType: this._customCollectionFieldType,
+            propertyPaneWebPartInformation: this._propertyPaneWebPartInformation,
+            getSelectedProperties: this.getSelectedProperties.bind(this),
+            onCustomPropertyUpdate: this.onCustomPropertyUpdate.bind(this)
+        });
 
-        return availableConnectionsGroup;
+        return builder.buildConnectionsGroup();
     }
 
     /**
@@ -2299,16 +2056,99 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     }
 
     /**
-     * Checks if a field if empty or not
-     * @param value the value to check
+     * Returns true if any 'Available connections' toggle is on AND a source has actually been
+     * selected for it. Toggling without picking a source doesn't yet consume anything, so it
+     * shouldn't suppress the "consider Rollup" suggestion.
      */
-    private _validateEmptyField(value: string): string {
+    private _hasOutgoingConnections(): boolean {
 
-        if (!value) {
-            return commonStrings.General.EmptyFieldErrorMessage;
+        const hasInputQueryConnection = this.properties.useInputQueryText === true
+            && !!DynamicPropertyHelper.tryGetSourceSafe(this.properties.queryText);
+        const hasFiltersConnection = this.properties.useFilters === true
+            && !!this.properties.filtersDataSourceReference;
+        const hasVerticalsConnection = this.properties.useVerticals === true
+            && !!this.properties.verticalsDataSourceReference;
+        const hasDynamicFilteringConnection = this.properties.useDynamicFiltering === true
+            && !!DynamicPropertyHelper.tryGetSourceSafe(this.properties.selectedItemFieldValue);
+
+        return hasInputQueryConnection
+            || hasFiltersConnection
+            || hasVerticalsConnection
+            || hasDynamicFilteringConnection;
+    }
+
+    /**
+     * Determines whether any Search Filters Web Part on the page declares a connection back to this
+     * instance, by reading each filter source's published `connectedResultsSourceReferences`. This is
+     * the one incoming-direction signal we can read reliably; SPFx doesn't otherwise expose
+     * subscribers, so consumers like dynamic filtering from another Search Results, OOTB SharePoint
+     * List Web Parts, or custom consumers cannot be detected and will not suppress the warning.
+     */
+    private async _checkPotentialIncomingConnections(): Promise<boolean> {
+
+        const dynamicDataProvider = this.context?.dynamicDataProvider;
+        if (!dynamicDataProvider || dynamicDataProvider.isDisposed) {
+            return false;
         }
 
-        return '';
+        const instanceId = this.tryGetInstanceId();
+        if (!instanceId) {
+            return false;
+        }
+
+        const availableSources = dynamicDataProvider.getAvailableSources();
+        for (const sourceInfo of availableSources) {
+            const source = dynamicDataProvider.tryGetSource(sourceInfo.id);
+            if (!source) {
+                continue;
+            }
+
+            let exposesFilterProperty: boolean;
+            try {
+                const properties = await source.getPropertyDefinitionsAsync();
+                exposesFilterProperty = properties.some(prop => prop.id === ComponentType.SearchFilters);
+            } catch {
+                continue;
+            }
+            if (!exposesFilterProperty) {
+                continue;
+            }
+
+            let filterData: IDataFilterSourceData;
+            try {
+                filterData = source.getPropertyValue(ComponentType.SearchFilters) as IDataFilterSourceData;
+            } catch {
+                continue;
+            }
+
+            const refs = filterData?.connectedResultsSourceReferences;
+            if (refs && refs.some(ref => ref.split(':')[0]?.endsWith(instanceId))) {
+                Log.verbose(LogSource, `[_checkPotentialIncomingConnections] Detected incoming filter connection from source '${sourceInfo.id}' for instance '${instanceId}'.`, this.webPartInstanceServiceScope);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Re-evaluates the asynchronous "potential incoming connections" signal used by the rollup
+     * suggestion in `renderCompleted()`. Triggers a re-render only if the resulting state actually
+     * changes, so it's safe to call frequently (e.g. from `registerAvailableSourcesChanged`).
+     */
+    private async _evaluateRollupSuggestion(): Promise<void> {
+
+        // Outside edit mode the suggestion is never shown, so the async check is unnecessary.
+        if (this.displayMode !== DisplayMode.Edit) {
+            return;
+        }
+
+        const hasIncoming = await this._checkPotentialIncomingConnections();
+        Log.verbose(LogSource, `[_evaluateRollupSuggestion] outgoing=${this._hasOutgoingConnections()} incoming=${hasIncoming} allowConnections=${this.properties.allowWebPartConnections} (previous incoming=${this._hasPotentialIncomingConnections})`, this.webPartInstanceServiceScope);
+        if (hasIncoming !== this._hasPotentialIncomingConnections) {
+            this._hasPotentialIncomingConnections = hasIncoming;
+            await this.render();
+        }
     }
 
     /**
@@ -2767,85 +2607,5 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 });
             });
         }
-    }
-
-    private getQueryModifierFields(): IPropertyPaneField<any>[] {
-
-        let queryTransformationFields: IPropertyPaneField<any>[] = [];
-
-        queryTransformationFields.push(
-            this._propertyFieldCollectionData('queryModifierConfiguration', {
-                manageBtnLabel: webPartStrings.PropertyPane.CustomQueryModifier.EditQueryModifiersLabel,
-                key: 'queryModifierConfiguration',
-                panelHeader: webPartStrings.PropertyPane.CustomQueryModifier.EditQueryModifiersLabel,
-                panelDescription: webPartStrings.PropertyPane.CustomQueryModifier.QueryModifiersDescription,
-                disableItemCreation: true,
-                disableItemDeletion: true,
-                enableSorting: true,
-                label: webPartStrings.PropertyPane.CustomQueryModifier.QueryModifiersLabel,
-                value: this.properties.queryModifierConfiguration,
-                tableClassName: commonStyles.slotTable,
-                fields: [
-                    {
-                        id: 'enabled',
-                        title: webPartStrings.PropertyPane.CustomQueryModifier.EnabledPropertyLabel,
-                        type: this._customCollectionFieldType.custom,
-                        onCustomRender: (field, value, onUpdate, item, itemId) => {
-                            return (
-                                React.createElement("div", null,
-                                    React.createElement(Toggle, {
-                                        key: itemId, checked: value, onChange: (evt, checked) => {
-                                            onUpdate(field.id, checked);
-                                        },
-                                        offText: commonStrings.General.OffTextLabel,
-                                        onText: commonStrings.General.OnTextLabel
-                                    })
-                                )
-                            );
-                        }
-                    },
-                    {
-                        id: 'endWhenSuccessfull',
-                        title: webPartStrings.PropertyPane.CustomQueryModifier.EndWhenSuccessfullPropertyLabel,
-                        type: this._customCollectionFieldType.custom,
-                        onCustomRender: (field, value, onUpdate, item, itemId) => {
-                            return (
-                                React.createElement("div", null,
-                                    React.createElement(Toggle, {
-                                        key: itemId, checked: value, onChange: (evt, checked) => {
-                                            onUpdate(field.id, checked);
-                                        },
-                                        offText: commonStrings.General.OffTextLabel,
-                                        onText: commonStrings.General.OnTextLabel
-                                    })
-                                )
-                            );
-                        }
-                    },
-                    {
-                        id: 'name',
-                        title: webPartStrings.PropertyPane.CustomQueryModifier.ModifierNamePropertyLabel,
-                        type: this._customCollectionFieldType.custom,
-                        onCustomRender: (field, value) => {
-                            return (
-                                React.createElement("div", { style: { 'fontWeight': 600 } }, value)
-                            );
-                        }
-                    },
-                    {
-                        id: 'description',
-                        title: webPartStrings.PropertyPane.CustomQueryModifier.ModifierDescriptionPropertyLabel,
-                        type: this._customCollectionFieldType.custom,
-                        onCustomRender: (field, value) => {
-                            return (
-                                React.createElement("div", null, value)
-                            );
-                        }
-                    }
-                ]
-            })
-        );
-
-        return queryTransformationFields;
     }
 }

--- a/search-parts/src/webparts/searchResults/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchResults/loc/cs-cz.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Webový díl výsledků vyhledávání",
             ShowBlankEditInfoMessage: "Pro tento dotaz nebyl vrácen žádný výsledek. Tento webový díl zůstane v režimu zobrazení prázdný podle parametrů.",
-            CurrentVerticalNotSelectedMessage: "Aktuálně vybraná vertikála neodpovídá té, která je spojena s tímto webovým dílem. V režimu zobrazení zůstane prázdná."
+            CurrentVerticalNotSelectedMessage: "Aktuálně vybraná vertikála neodpovídá té, která je spojena s tímto webovým dílem. V režimu zobrazení zůstane prázdná.",
+            RollupSuggestionMessage: "Tato webová část Výsledky vyhledávání není připojena k žádné jiné webové části na stránce. Zvažte použití verze 'PnP - Search Rollup' — může být líně načtena SharePointem a nespustí dotazy na zdroj dat, dokud nebude posunuta do zobrazení, což zlepší výkon načítání stránky.",
+            RollupSuggestionLinkText: "Další informace"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/da-dk.js
+++ b/search-parts/src/webparts/searchResults/loc/da-dk.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Søgeresultats-webpart",
             ShowBlankEditInfoMessage: "Intet resultat returneret på denne forespørgsel. Denne webpart vil forblive blank i visningstilstand ifølge parametrene.",
-            CurrentVerticalNotSelectedMessage: "Den valgte vertikal matcher ikke med den, der er associeret denne webpart. Den vil forblive blank i visningstilstand."
+            CurrentVerticalNotSelectedMessage: "Den valgte vertikal matcher ikke med den, der er associeret denne webpart. Den vil forblive blank i visningstilstand.",
+            RollupSuggestionMessage: "Denne Søgeresultater-webdel er ikke forbundet til nogen anden webdel på siden. Overvej at bruge 'PnP - Search Rollup'-versionen i stedet — den kan loades dovent af SharePoint og udfører ikke datakildeforespørgsler, før den rulles ind i visningen, hvilket forbedrer sideindlæsningens ydeevne.",
+            RollupSuggestionLinkText: "Læs mere"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/de-de.js
+++ b/search-parts/src/webparts/searchResults/loc/de-de.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Suchergebnis Webpart",
             ShowBlankEditInfoMessage: "Keine Ergebnisse für diese Abfrage. Dieses Webpart bleibt im Anzeigemodus entsprechend den Parametern leer.",
-            CurrentVerticalNotSelectedMessage: "Die aktuell ausgewählte Vertikale stimmt nicht mit der für dieses Webpart zugeordneten überein. Sie bleibt im Anzeigemodus leer."
+            CurrentVerticalNotSelectedMessage: "Die aktuell ausgewählte Vertikale stimmt nicht mit der für dieses Webpart zugeordneten überein. Sie bleibt im Anzeigemodus leer.",
+            RollupSuggestionMessage: "Dieses Suchergebnisse-Webpart ist nicht mit einem anderen Webpart auf der Seite verbunden. Erwägen Sie stattdessen die Verwendung der Version 'PnP - Search Rollup' — sie kann von SharePoint verzögert geladen werden und löst keine Datenquellenabfragen aus, bis sie in den sichtbaren Bereich gescrollt wird, wodurch die Seitenladeleistung verbessert wird.",
+            RollupSuggestionLinkText: "Weitere Informationen"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/en-us.js
+++ b/search-parts/src/webparts/searchResults/loc/en-us.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Search Results Web Part",
             ShowBlankEditInfoMessage: "No result returned for this query. This Web Part will remain blank in display mode according to parameters.",
-            CurrentVerticalNotSelectedMessage: "The current selected vertical does not match with the one associated for this Web Part. It will remains blank in display mode."
+            CurrentVerticalNotSelectedMessage: "The current selected vertical does not match with the one associated for this Web Part. It will remains blank in display mode.",
+            RollupSuggestionMessage: "This Search Results Web Part is not connected to any other Web Part on the page. Consider using the 'PnP - Search Rollup' version instead — it can be lazy loaded by SharePoint and will not fire data source queries until scrolled into view, improving page load performance.",
+            RollupSuggestionLinkText: "Learn more"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/es-es.js
+++ b/search-parts/src/webparts/searchResults/loc/es-es.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Web Part de resultados de búsqueda",
             ShowBlankEditInfoMessage: "No se devuelve ningún resultado para esta consulta. Este Web Part permanecerá en blanco en el modo de visualización según los parámetros.",
-            CurrentVerticalNotSelectedMessage: "La vertical seleccionada actualmente no coincide con la asociada a este Web Part. Permanecerá en blanco en el modo de visualización."
+            CurrentVerticalNotSelectedMessage: "La vertical seleccionada actualmente no coincide con la asociada a este Web Part. Permanecerá en blanco en el modo de visualización.",
+            RollupSuggestionMessage: "Este Web Part de Resultados de búsqueda no está conectado a ningún otro Web Part en la página. Considere usar la versión 'PnP - Search Rollup' en su lugar — puede ser cargada de forma diferida por SharePoint y no ejecutará consultas al origen de datos hasta que se desplace a la vista, mejorando el rendimiento de carga de la página.",
+            RollupSuggestionLinkText: "Más información"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchResults/loc/fi-fi.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Hakutulosten webosa",
             ShowBlankEditInfoMessage: "Ei tuloksia tälle hakukyselylle. Näillä parametreillä webosa on tyhjä sivun lukutilassa.",
-            CurrentVerticalNotSelectedMessage: "Valittu vertikaali ei ole yhdistetty tähän tuloswebosaan. Tuloswebosa on tyhjä sivun lukutilassa."
+            CurrentVerticalNotSelectedMessage: "Valittu vertikaali ei ole yhdistetty tähän tuloswebosaan. Tuloswebosa on tyhjä sivun lukutilassa.",
+            RollupSuggestionMessage: "Tämä Hakutulokset-webosa ei ole yhdistetty mihinkään muuhun sivun webosaan. Harkitse 'PnP - Search Rollup' -version käyttämistä — SharePoint voi ladata sen laiskasti, eikä se suorita tietolähdekyselyjä ennen kuin se vieritetään näkyviin, mikä parantaa sivun latauksen suorituskykyä.",
+            RollupSuggestionLinkText: "Lue lisää"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchResults/loc/fr-fr.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Composant Web des résultats de recherche",
             ShowBlankEditInfoMessage: "Cette requête n’a donné aucun résultat. Ce composant Web doit demeurer vide en mode d’affichage en fonction des critères.",
-            CurrentVerticalNotSelectedMessage: "Le secteur vertical sélectionné ne correspond pas à ce composant Web. Il doit demeurer vide en mode d’affichage."
+            CurrentVerticalNotSelectedMessage: "Le secteur vertical sélectionné ne correspond pas à ce composant Web. Il doit demeurer vide en mode d’affichage.",
+            RollupSuggestionMessage: "Ce composant WebPart Résultats de recherche n'est connecté à aucun autre composant WebPart sur la page. Envisagez plutôt d'utiliser la version 'PnP - Search Rollup' — elle peut être chargée à la demande par SharePoint et ne déclenchera pas de requêtes vers la source de données tant qu'elle n'est pas visible à l'écran, améliorant ainsi les performances de chargement de la page.",
+            RollupSuggestionLinkText: "En savoir plus"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/it-it.js
+++ b/search-parts/src/webparts/searchResults/loc/it-it.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Web Part dei Risultati di Ricerca",
             ShowBlankEditInfoMessage: "Nessun risultato restituito per questa query. Questa Web Part rimarrà vuota in modalità di visualizzazione secondo i parametri.",
-            CurrentVerticalNotSelectedMessage: "Il verticale selezionato attualmente non corrisponde a quello associato a questa Web Part. Rimarrà vuoto in modalità di visualizzazione."
+            CurrentVerticalNotSelectedMessage: "Il verticale selezionato attualmente non corrisponde a quello associato a questa Web Part. Rimarrà vuoto in modalità di visualizzazione.",
+            RollupSuggestionMessage: "Questa Web Part Risultati di ricerca non è collegata a nessun'altra Web Part nella pagina. Considera l'utilizzo della versione 'PnP - Search Rollup' — può essere caricata in modalità lazy da SharePoint e non eseguirà query sulla sorgente dati finché non verrà visualizzata, migliorando le prestazioni di caricamento della pagina.",
+            RollupSuggestionLinkText: "Ulteriori informazioni"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchResults/loc/mystrings.d.ts
@@ -9,6 +9,8 @@ declare interface ISearchResultsWebPartStrings {
         WebPartDefaultTitle: string;
         ShowBlankEditInfoMessage: string;
         CurrentVerticalNotSelectedMessage: string;
+        RollupSuggestionMessage: string;
+        RollupSuggestionLinkText: string;
     },
     PropertyPane: {
         DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/nb-no.js
+++ b/search-parts/src/webparts/searchResults/loc/nb-no.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Søkeresultat",
             ShowBlankEditInfoMessage: "Fant ikke noe med denne spørringen. Nettdelen vil være tom i visningsmodus, i tråd med innstillingene.",
-            CurrentVerticalNotSelectedMessage: "Den valgte vertikalen matcher ikke den som er assosiert med denne nettdelen. Den vil være tom i visningsmodus."
+            CurrentVerticalNotSelectedMessage: "Den valgte vertikalen matcher ikke den som er assosiert med denne nettdelen. Den vil være tom i visningsmodus.",
+            RollupSuggestionMessage: "Denne Søkeresultatnettdelen er ikke koblet til noen annen nettdel på siden. Vurder å bruke 'PnP - Search Rollup'-versjonen i stedet — den kan lastes inn ved behov av SharePoint og kjører ikke datakildespørringer før den rulles inn i visningen, noe som forbedrer sideinnlastingsytelsen.",
+            RollupSuggestionLinkText: "Les mer"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchResults/loc/nl-nl.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Zoekresultaten webonderdeel",
             ShowBlankEditInfoMessage: "Geen resultaten gevonden voor deze zoekopdracht. Dit webonderdeel blijft leeg in weergave modus conform parameters.",
-            CurrentVerticalNotSelectedMessage: "De nu selecteerde zoekverticaal komt niet overeen met degene die geassocieerd is met dit webonderdeel. Dit webonderdeel blijft leeg in weergave modus."
+            CurrentVerticalNotSelectedMessage: "De nu selecteerde zoekverticaal komt niet overeen met degene die geassocieerd is met dit webonderdeel. Dit webonderdeel blijft leeg in weergave modus.",
+            RollupSuggestionMessage: "Dit Zoekresultaten-webonderdeel is niet verbonden met een ander webonderdeel op de pagina. Overweeg in plaats daarvan de versie 'PnP - Search Rollup' te gebruiken — deze kan lazy worden geladen door SharePoint en zal geen gegevensbronaanvragen activeren totdat deze in beeld komt, wat de prestaties bij het laden van de pagina verbetert.",
+            RollupSuggestionLinkText: "Meer informatie"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchResults/loc/pl-pl.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Web Part Wyników Wyszukiwania",
             ShowBlankEditInfoMessage: "Brak wyników dla zapytania. Zgodnie z parametrami ten Web Part pozostanie pusty.",
-            CurrentVerticalNotSelectedMessage: "Obecnie wybrany wertykał nie odpowiada żadnemu powiązanemu składnikowi Web Part i pozostanie pusty w trybie wyświetlania."
+            CurrentVerticalNotSelectedMessage: "Obecnie wybrany wertykał nie odpowiada żadnemu powiązanemu składnikowi Web Part i pozostanie pusty w trybie wyświetlania.",
+            RollupSuggestionMessage: "Ten składnik Web Part Wyniki wyszukiwania nie jest połączony z żadnym innym składnikiem Web Part na stronie. Rozważ użycie wersji 'PnP - Search Rollup' — może być ładowana leniwie przez SharePoint i nie będzie uruchamiać zapytań do źródła danych, dopóki nie zostanie przewinięta do widoku, co poprawia wydajność ładowania strony.",
+            RollupSuggestionLinkText: "Dowiedz się więcej"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/pt-br.js
+++ b/search-parts/src/webparts/searchResults/loc/pt-br.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Web Part de resultados de busca",
             ShowBlankEditInfoMessage: "Nenhum resultado retornado para esta consulta. Esta WebPart vai permanecer em branco em modo de exibição de acordo com os parâmetros.",
-            CurrentVerticalNotSelectedMessage: "A vertical selecionada atualmente não combina com a associada a esta Web Part. Ela permanecerá em branco no modo de exibição."
+            CurrentVerticalNotSelectedMessage: "A vertical selecionada atualmente não combina com a associada a esta Web Part. Ela permanecerá em branco no modo de exibição.",
+            RollupSuggestionMessage: "Esta Web Part de Resultados de Pesquisa não está conectada a nenhuma outra Web Part na página. Considere usar a versão 'PnP - Search Rollup' em vez disso — ela pode ser carregada de forma preguiçosa pelo SharePoint e não disparará consultas à fonte de dados até ser rolada para a visualização, melhorando o desempenho de carregamento da página.",
+            RollupSuggestionLinkText: "Saiba mais"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchResults/loc/sv-SE.js
@@ -9,7 +9,9 @@ define([], function () {
             },
             WebPartDefaultTitle: "Sökresultat webbdel",
             ShowBlankEditInfoMessage: "Inget resultat returneras för denna fråga. Denna webbdel förblir tom i visningsläge enligt parametrarna.",
-            CurrentVerticalNotSelectedMessage: "Den valda vertikalen matchar inte den som är associerad med den här webbdelen. Den förblir tom i visningsläge."
+            CurrentVerticalNotSelectedMessage: "Den valda vertikalen matchar inte den som är associerad med den här webbdelen. Den förblir tom i visningsläge.",
+            RollupSuggestionMessage: "Denna Sökresultat-webbdel är inte ansluten till någon annan webbdel på sidan. Överväg att använda versionen 'PnP - Search Rollup' istället — den kan laddas lat av SharePoint och utför inte datakällsfrågor förrän den rullas in i vyn, vilket förbättrar sidans laddningsprestanda.",
+            RollupSuggestionLinkText: "Läs mer"
         },
         PropertyPane: {
             DataSourcePage: {

--- a/search-parts/src/webparts/searchResults/propertyPane/ConnectionsPropertyPaneBuilder.ts
+++ b/search-parts/src/webparts/searchResults/propertyPane/ConnectionsPropertyPaneBuilder.ts
@@ -1,25 +1,532 @@
-import { IPropertyPaneGroup } from "@microsoft/sp-property-pane";
-import { IQueryModifier } from '@pnp/modern-search-extensibility';
+import * as React from 'react';
+import { Text } from '@microsoft/sp-core-library';
+import { DynamicProperty } from '@microsoft/sp-component-base';
+import {
+    IPropertyPaneGroup,
+    IPropertyPaneField,
+    PropertyPaneToggle,
+    PropertyPaneTextField,
+    PropertyPaneCheckbox,
+    PropertyPaneDropdown,
+    PropertyPaneChoiceGroup,
+    PropertyPaneDynamicField,
+    PropertyPaneDynamicFieldSet,
+    DynamicDataSharedDepth,
+    PropertyPaneHorizontalRule
+} from "@microsoft/sp-property-pane";
+import { FilterConditionOperator } from "@pnp/modern-search-extensibility";
+import { IComboBoxOption } from "@fluentui/react/lib/ComboBox";
+import { Toggle } from "@fluentui/react/lib/Toggle";
 
+import { ComponentType, DynamicDataProperties } from "../../../common/ComponentType";
+import IDynamicDataService from "../../../services/dynamicDataService/IDynamicDataService";
+import { DynamicPropertyHelper } from "../../../helpers/DynamicPropertyHelper";
+import { IDataFilterSourceData } from "../../../models/dynamicData/IDataFilterSourceData";
+import { IDataVerticalSourceData } from "../../../models/dynamicData/IDataVerticalSourceData";
+import { PropertyPaneAsyncCombo } from "../../../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo";
+import { ItemSelectionMode } from "../../../models/common/IItemSelectionProps";
+import ISearchResultsWebPartProps, { QueryTextSource } from "../ISearchResultsWebPartProps";
+import commonStyles from "../../../styles/Common.module.scss";
+
+export interface IConnectionsPropertyPaneBuilderOptions {
+
+    properties: ISearchResultsWebPartProps;
+    instanceId: string;
+    webPartStrings: any;
+    commonStrings: any;
+    dynamicDataService: IDynamicDataService;
+    filtersConnectionSourceData: DynamicProperty<IDataFilterSourceData> | undefined;
+    verticalsConnectionSourceData: DynamicProperty<IDataVerticalSourceData> | undefined;
+    hasCustomQueryModifiers: boolean;
+
+    // Lazily-loaded property field components (loaded by `loadPropertyPaneResources()` on the web part)
+    propertyFieldToogleWithCallout: any;
+    propertyFieldCalloutTriggers: any;
+    propertyFieldCollectionData: any;
+    customCollectionFieldType: any;
+    propertyPaneWebPartInformation: any;
+
+    // Bound callbacks back into the web part
+    getSelectedProperties: () => string[];
+    onCustomPropertyUpdate: (
+        propertyPath: string,
+        newValue: any,
+        changeCallback?: (targetProperty?: string, newValue?: any) => void
+    ) => void;
+}
+
+/**
+ * Builds the property pane fields shown in the Search Results Web Part 'Connections' page.
+ *
+ * Extracted from `SearchResultsWebPart` to keep the web part class focused on lifecycle and
+ * shared rendering. Constructed fresh each time the property pane group is rebuilt; all state
+ * is captured at construction time from the calling web part.
+ */
 export class ConnectionsPropertyPaneBuilder {
-    
-    constructor(
-        private getPropertyPaneConnectionsGroup: () => IPropertyPaneGroup[],
-        private selectedCustomQueryModifier: IQueryModifier[]
-    ) {}
 
-    public buildConnectionsPage(): IPropertyPaneGroup[] {
-        const queryTransformationGroups: IPropertyPaneGroup[] = [];
-        
-        if (this.selectedCustomQueryModifier.length > 0) {
-            this.selectedCustomQueryModifier.forEach(modifier => {
-                queryTransformationGroups.push(...modifier.getPropertyPaneGroupsConfiguration());
-            });
+    constructor(private readonly options: IConnectionsPropertyPaneBuilderOptions) { }
+
+    /**
+     * Returns the single 'Available connections' group displayed on the Connections property
+     * pane page. Hidden entirely when `allowWebPartConnections` is false (i.e. the Rollup
+     * variant), preserving the original behavior.
+     */
+    public async buildConnectionsGroup(): Promise<IPropertyPaneGroup[]> {
+
+        const { properties, webPartStrings } = this.options;
+
+        const filterConnectionFields = await this.buildFiltersConnectionFields();
+        const verticalConnectionFields = await this.buildVerticalsConnectionFields();
+        const dataResultsConnectionFields = await this.buildDataResultsConnectionFields();
+
+        let dynamicDataToggles: IPropertyPaneField<any>[] = [];
+        if (properties.allowWebPartConnections) {
+            dynamicDataToggles = [
+                ...this.buildSearchQueryTextFields(),
+                PropertyPaneHorizontalRule(),
+                ...filterConnectionFields,
+                PropertyPaneHorizontalRule(),
+                ...verticalConnectionFields,
+                PropertyPaneHorizontalRule(),
+                ...dataResultsConnectionFields
+            ];
         }
 
         return [
-            ...this.getPropertyPaneConnectionsGroup(),
-            ...queryTransformationGroups
+            {
+                groupName: webPartStrings.PropertyPane.ConnectionsPage.ConnectionsPageGroupName,
+                groupFields: [...dynamicDataToggles]
+            }
         ];
+    }
+
+    private buildSearchQueryTextFields(): IPropertyPaneField<any>[] {
+
+        const {
+            properties,
+            webPartStrings,
+            commonStrings,
+            propertyFieldToogleWithCallout,
+            propertyFieldCalloutTriggers,
+            hasCustomQueryModifiers
+        } = this.options;
+
+        let searchQueryTextFields: IPropertyPaneField<any>[] = [
+            propertyFieldToogleWithCallout('useInputQueryText', {
+                label: webPartStrings.PropertyPane.ConnectionsPage.UseInputQueryText,
+                calloutTrigger: propertyFieldCalloutTriggers.Hover,
+                key: 'useInputQueryText',
+                calloutContent: React.createElement(
+                    'p',
+                    { style: { maxWidth: 250, wordBreak: 'break-word' } },
+                    webPartStrings.PropertyPane.ConnectionsPage.UseInputQueryTextHoverMessage
+                ),
+                onText: commonStrings.General.OnTextLabel,
+                offText: commonStrings.General.OffTextLabel,
+                checked: properties.useInputQueryText
+            })
+        ];
+
+        if (properties.useInputQueryText) {
+
+            searchQueryTextFields.push(
+                PropertyPaneChoiceGroup('queryTextSource', {
+                    options: [
+                        {
+                            key: QueryTextSource.StaticValue,
+                            text: webPartStrings.PropertyPane.ConnectionsPage.InputQueryTextStaticValue
+                        },
+                        {
+                            key: QueryTextSource.DynamicValue,
+                            text: webPartStrings.PropertyPane.ConnectionsPage.InputQueryTextDynamicValue
+                        }
+                    ]
+                })
+            );
+
+            switch (properties.queryTextSource) {
+
+                case QueryTextSource.StaticValue:
+                    searchQueryTextFields.push(
+                        PropertyPaneTextField('queryText', {
+                            label: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextFieldLabel,
+                            description: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextFieldDescription,
+                            multiline: true,
+                            resizable: true,
+                            placeholder: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryPlaceHolderText,
+                            onGetErrorMessage: this.validateEmptyField,
+                            deferredValidationTime: 500
+                        })
+                    );
+                    break;
+
+                case QueryTextSource.DynamicValue:
+                    searchQueryTextFields.push(
+                        PropertyPaneDynamicField('queryText', {
+                            label: ''
+                        }),
+                        PropertyPaneCheckbox('useDefaultQueryText', {
+                            text: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextUseDefaultQuery,
+                            disabled: properties.queryText.reference === undefined
+                        })
+                    );
+
+                    if (properties.useDefaultQueryText && properties.queryText.reference !== undefined) {
+                        searchQueryTextFields.push(
+                            PropertyPaneTextField('defaultQueryText', {
+                                label: webPartStrings.PropertyPane.ConnectionsPage.SearchQueryTextDefaultValue,
+                                multiline: true
+                            })
+                        );
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (hasCustomQueryModifiers) {
+                searchQueryTextFields = searchQueryTextFields.concat(this.buildQueryModifierFields());
+            }
+        }
+
+        return searchQueryTextFields;
+    }
+
+    private async buildDataResultsConnectionFields(): Promise<IPropertyPaneField<any>[]> {
+
+        const {
+            properties,
+            webPartStrings,
+            propertyPaneWebPartInformation,
+            getSelectedProperties,
+            onCustomPropertyUpdate
+        } = this.options;
+
+        let dataResultsConnectionFields: IPropertyPaneField<any>[] = [
+            PropertyPaneToggle('useDynamicFiltering', {
+                label: webPartStrings.PropertyPane.ConnectionsPage.UseDynamicFilteringsWebPartLabel,
+                checked: properties.useDynamicFiltering
+            })
+        ];
+
+        if (properties.useDynamicFiltering) {
+
+            let isSourceFieldConfigured: boolean = false;
+
+            // Make sure a property is selected in the source according to the reference format.
+            // Ex: PageContext:UrlData:queryParameters.q = Page environment
+            // Ex: WebPart.544c1372-42df-47c3-94d6-017428cd2baf.1272b161-3435-4815-99a1-996590334cff:AvailableFieldValuesFromResults:FileType = Search Results
+            if (properties.selectedItemFieldValue.reference) {
+                isSourceFieldConfigured = /^.+:.+:(.+)$/.test(properties.selectedItemFieldValue.reference);
+            }
+
+            dataResultsConnectionFields.push(
+
+                // Allow both 'Search Results' Web Parts and OOTB SharePoint List Web Parts
+                PropertyPaneDynamicFieldSet({
+                    label: webPartStrings.PropertyPane.ConnectionsPage.UseDataResultsFromComponentsLabel,
+                    fields: [
+                        PropertyPaneDynamicField('selectedItemFieldValue', {
+                            label: webPartStrings.PropertyPane.ConnectionsPage.UseDataResultsFromComponentsLabel,
+                        })
+                    ],
+                    sharedConfiguration: {
+                        depth: DynamicDataSharedDepth.Property,
+                        property: {
+                            filters: {
+                                propertyId: DynamicDataProperties.AvailableFieldValuesFromResults
+                            }
+                        }
+                    }
+                })
+            );
+
+            if (isSourceFieldConfigured) {
+
+                const availableOptions: IComboBoxOption[] = getSelectedProperties().map((field: string) => {
+                    return {
+                        key: field,
+                        text: field
+                    };
+                });
+
+                dataResultsConnectionFields.splice(4, 0,
+                    new PropertyPaneAsyncCombo('itemSelectionProps.destinationFieldName', {
+                        label: webPartStrings.PropertyPane.ConnectionsPage.SourceDestinationFieldLabel,
+                        availableOptions: availableOptions,
+                        description: webPartStrings.PropertyPane.ConnectionsPage.SourceDestinationFieldDescription,
+                        allowMultiSelect: false,
+                        allowFreeform: true,
+                        searchAsYouType: false,
+                        defaultSelectedKeys: properties.selectedVerticalKeys,
+                        textDisplayValue: properties.itemSelectionProps.destinationFieldName,
+                        onPropertyChange: onCustomPropertyUpdate,
+                    })
+                );
+            }
+
+            if (isSourceFieldConfigured && properties.itemSelectionProps.destinationFieldName) {
+
+                dataResultsConnectionFields.splice(4, 0,
+                    PropertyPaneChoiceGroup('itemSelectionProps.selectionMode', {
+                        options: [
+                            {
+                                key: ItemSelectionMode.AsDataFilter,
+                                text: webPartStrings.PropertyPane.LayoutPage.Handlebars.AsDataFiltersSelectionMode
+                            },
+                            {
+                                key: ItemSelectionMode.AsTokenValue,
+                                text: webPartStrings.PropertyPane.LayoutPage.Handlebars.AsTokensSelectionMode
+                            }
+                        ],
+                        label: webPartStrings.PropertyPane.LayoutPage.Handlebars.SelectionModeLabel,
+                    })
+                );
+
+                if (properties.itemSelectionProps.selectionMode === ItemSelectionMode.AsDataFilter) {
+                    dataResultsConnectionFields.splice(5, 0,
+                        propertyPaneWebPartInformation({
+                            description: `<em>${webPartStrings.PropertyPane.LayoutPage.Handlebars.AsDataFiltersDescription}</em>`,
+                            key: 'selectionModeText'
+                        }),
+                        PropertyPaneChoiceGroup('itemSelectionProps.valuesOperator', {
+                            options: [
+                                {
+                                    key: FilterConditionOperator.OR,
+                                    text: 'OR'
+                                },
+                                {
+                                    key: FilterConditionOperator.AND,
+                                    text: 'AND'
+                                },
+                            ],
+                            label: webPartStrings.PropertyPane.LayoutPage.Handlebars.FilterValuesOperator
+                        })
+                    );
+                } else {
+                    dataResultsConnectionFields.splice(4, 0,
+                        propertyPaneWebPartInformation({
+                            description: `<em>${webPartStrings.PropertyPane.LayoutPage.Handlebars.AsTokensDescription}</em>`,
+                            key: 'selectionModeText'
+                        })
+                    );
+                }
+            }
+        }
+
+        return dataResultsConnectionFields;
+    }
+
+    private async buildFiltersConnectionFields(): Promise<IPropertyPaneField<any>[]> {
+
+        const {
+            properties,
+            instanceId,
+            webPartStrings,
+            dynamicDataService,
+            filtersConnectionSourceData,
+            propertyPaneWebPartInformation
+        } = this.options;
+
+        let filtersConnectionFields: IPropertyPaneField<any>[] = [
+            PropertyPaneToggle('useFilters', {
+                label: webPartStrings.PropertyPane.ConnectionsPage.UseFiltersWebPartLabel,
+                checked: properties.useFilters
+            })
+        ];
+
+        if (properties.useFilters) {
+            filtersConnectionFields.splice(1, 0,
+                PropertyPaneDropdown('filtersDataSourceReference', {
+                    options: await dynamicDataService.getAvailableDataSourcesByType(ComponentType.SearchFilters),
+                    label: webPartStrings.PropertyPane.ConnectionsPage.UseFiltersFromComponentLabel
+                })
+            );
+
+            // Check bidirectional connection: does the filter web part also connect back to this results web part?
+            if (properties.filtersDataSourceReference && filtersConnectionSourceData) {
+                const filterData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(filtersConnectionSourceData);
+                if (filterData && filterData.connectedResultsSourceReferences) {
+                    // Extract sourceId from each reference (format: "sourceId:propertyId") and check if it ends with this web part's instanceId
+                    const isConnectedBack = filterData.connectedResultsSourceReferences.some(
+                        ref => {
+                            const sourceId = ref.split(':')[0];
+                            return sourceId.endsWith(instanceId);
+                        }
+                    );
+                    if (!isConnectedBack) {
+                        filtersConnectionFields.push(
+                            propertyPaneWebPartInformation({
+                                description: `<span style="color: #d83b01;">⚠ ${webPartStrings.PropertyPane.ConnectionsPage.BidirectionalConnectionWarning}</span>`,
+                                key: 'bidirectionalFilterWarning'
+                            })
+                        );
+                    }
+                }
+            }
+        }
+
+        return filtersConnectionFields;
+    }
+
+    private async buildVerticalsConnectionFields(): Promise<IPropertyPaneField<any>[]> {
+
+        const {
+            properties,
+            webPartStrings,
+            dynamicDataService,
+            verticalsConnectionSourceData,
+            onCustomPropertyUpdate
+        } = this.options;
+
+        let verticalsConnectionFields: IPropertyPaneField<any>[] = [
+            PropertyPaneToggle('useVerticals', {
+                label: webPartStrings.PropertyPane.ConnectionsPage.UseSearchVerticalsWebPartLabel,
+                checked: properties.useVerticals
+            })
+        ];
+
+        if (properties.useVerticals) {
+            verticalsConnectionFields.splice(1, 0,
+                PropertyPaneDropdown('verticalsDataSourceReference', {
+                    options: await dynamicDataService.getAvailableDataSourcesByType(ComponentType.SearchVerticals),
+                    label: webPartStrings.PropertyPane.ConnectionsPage.UseSearchVerticalsFromComponentLabel
+                })
+            );
+
+            if (properties.verticalsDataSourceReference && verticalsConnectionSourceData) {
+
+                const availableVerticals = DynamicPropertyHelper.tryGetValueSafe(verticalsConnectionSourceData);
+
+                if (availableVerticals) {
+
+                    // Get the corresponding text for selected keys
+                    const selectedKeysAsText: string[] = [];
+
+                    availableVerticals.verticalsConfiguration.forEach(verticalConfiguration => {
+                        if (properties.selectedVerticalKeys.indexOf(verticalConfiguration.key) !== -1) {
+                            selectedKeysAsText.push(verticalConfiguration.tabName);
+                        }
+                    });
+
+                    verticalsConnectionFields.push(
+                        new PropertyPaneAsyncCombo('selectedVerticalKeys', {
+                            availableOptions: availableVerticals.verticalsConfiguration.filter(v => !v.isLink).map(verticalConfiguration => {
+                                return {
+                                    key: verticalConfiguration.key,
+                                    text: verticalConfiguration.tabName
+                                };
+                            }),
+                            allowMultiSelect: true,
+                            allowFreeform: false,
+                            description: webPartStrings.PropertyPane.ConnectionsPage.LinkToVerticalLabelHoverMessage,
+                            label: webPartStrings.PropertyPane.ConnectionsPage.LinkToVerticalLabel,
+                            searchAsYouType: false,
+                            defaultSelectedKeys: properties.selectedVerticalKeys,
+                            textDisplayValue: selectedKeysAsText.join(','),
+                            onPropertyChange: onCustomPropertyUpdate,
+                        }),
+                    );
+                }
+            }
+        }
+
+        return verticalsConnectionFields;
+    }
+
+    private buildQueryModifierFields(): IPropertyPaneField<any>[] {
+
+        const {
+            properties,
+            webPartStrings,
+            commonStrings,
+            propertyFieldCollectionData,
+            customCollectionFieldType
+        } = this.options;
+
+        const queryTransformationFields: IPropertyPaneField<any>[] = [];
+
+        queryTransformationFields.push(
+            propertyFieldCollectionData('queryModifierConfiguration', {
+                manageBtnLabel: webPartStrings.PropertyPane.CustomQueryModifier.EditQueryModifiersLabel,
+                key: 'queryModifierConfiguration',
+                panelHeader: webPartStrings.PropertyPane.CustomQueryModifier.EditQueryModifiersLabel,
+                panelDescription: webPartStrings.PropertyPane.CustomQueryModifier.QueryModifiersDescription,
+                disableItemCreation: true,
+                disableItemDeletion: true,
+                enableSorting: true,
+                label: webPartStrings.PropertyPane.CustomQueryModifier.QueryModifiersLabel,
+                value: properties.queryModifierConfiguration,
+                tableClassName: commonStyles.slotTable,
+                fields: [
+                    {
+                        id: 'enabled',
+                        title: webPartStrings.PropertyPane.CustomQueryModifier.EnabledPropertyLabel,
+                        type: customCollectionFieldType.custom,
+                        onCustomRender: (field, value, onUpdate, item, itemId) => {
+                            return (
+                                React.createElement("div", null,
+                                    React.createElement(Toggle, {
+                                        key: itemId, checked: value, onChange: (evt, checked) => {
+                                            onUpdate(field.id, checked);
+                                        },
+                                        offText: commonStrings.General.OffTextLabel,
+                                        onText: commonStrings.General.OnTextLabel
+                                    })
+                                )
+                            );
+                        }
+                    },
+                    {
+                        id: 'endWhenSuccessfull',
+                        title: webPartStrings.PropertyPane.CustomQueryModifier.EndWhenSuccessfullPropertyLabel,
+                        type: customCollectionFieldType.custom,
+                        onCustomRender: (field, value, onUpdate, item, itemId) => {
+                            return (
+                                React.createElement("div", null,
+                                    React.createElement(Toggle, {
+                                        key: itemId, checked: value, onChange: (evt, checked) => {
+                                            onUpdate(field.id, checked);
+                                        },
+                                        offText: commonStrings.General.OffTextLabel,
+                                        onText: commonStrings.General.OnTextLabel
+                                    })
+                                )
+                            );
+                        }
+                    },
+                    {
+                        id: 'name',
+                        title: webPartStrings.PropertyPane.CustomQueryModifier.ModifierNamePropertyLabel,
+                        type: customCollectionFieldType.custom,
+                        onCustomRender: (field, value) => {
+                            return (
+                                React.createElement("div", { style: { 'fontWeight': 600 } }, value)
+                            );
+                        }
+                    },
+                    {
+                        id: 'description',
+                        title: webPartStrings.PropertyPane.CustomQueryModifier.ModifierDescriptionPropertyLabel,
+                        type: customCollectionFieldType.custom,
+                        onCustomRender: (field, value) => {
+                            return (
+                                React.createElement("div", null, value)
+                            );
+                        }
+                    }
+                ]
+            })
+        );
+
+        return queryTransformationFields;
+    }
+
+    private validateEmptyField = (value: string): string => {
+        if (!value) {
+            return this.options.commonStrings.General.EmptyFieldErrorMessage;
+        }
+        return '';
     }
 }

--- a/search-parts/src/webparts/searchResults/propertyPane/ConnectionsPropertyPaneBuilder.ts
+++ b/search-parts/src/webparts/searchResults/propertyPane/ConnectionsPropertyPaneBuilder.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Text } from '@microsoft/sp-core-library';
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import {
     IPropertyPaneGroup,
@@ -347,7 +346,7 @@ export class ConnectionsPropertyPaneBuilder {
             // Check bidirectional connection: does the filter web part also connect back to this results web part?
             if (properties.filtersDataSourceReference && filtersConnectionSourceData) {
                 const filterData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(filtersConnectionSourceData);
-                if (filterData && filterData.connectedResultsSourceReferences) {
+                if (filterData?.connectedResultsSourceReferences) {
                     // Extract sourceId from each reference (format: "sourceId:propertyId") and check if it ends with this web part's instanceId
                     const isConnectedBack = filterData.connectedResultsSourceReferences.some(
                         ref => {
@@ -405,7 +404,7 @@ export class ConnectionsPropertyPaneBuilder {
                     const selectedKeysAsText: string[] = [];
 
                     availableVerticals.verticalsConfiguration.forEach(verticalConfiguration => {
-                        if (properties.selectedVerticalKeys.indexOf(verticalConfiguration.key) !== -1) {
+                        if (properties.selectedVerticalKeys.includes(verticalConfiguration.key)) {
                             selectedKeysAsText.push(verticalConfiguration.tabName);
                         }
                     });
@@ -523,7 +522,7 @@ export class ConnectionsPropertyPaneBuilder {
         return queryTransformationFields;
     }
 
-    private validateEmptyField = (value: string): string => {
+    private readonly validateEmptyField = (value: string): string => {
         if (!value) {
             return this.options.commonStrings.General.EmptyFieldErrorMessage;
         }


### PR DESCRIPTION
## Summary

Adds an inline warning at the top of the Search Results Web Part (in edit mode) when it is not connected to anything on the page, recommending the lazy-loadable **PnP - Search Rollup** variant. Also expands the docs to explain when to use which variant and the performance implications.

## What changed

### Feature: rollup-version suggestion

When **all** of the following are true, render a yellow `MessageBar` with a link to the docs:

- `displayMode === DisplayMode.Edit`
- `allowWebPartConnections === true` (i.e. this is the standard variant, not the Rollup preset)
- No outgoing connection is **configured AND has a selected source**: `useInputQueryText`+queryText source, `useFilters`+`filtersDataSourceReference`, `useVerticals`+`verticalsDataSourceReference`, or `useDynamicFiltering`+`selectedItemFieldValue` source
- No `SearchFilters` Web Part on the page declares this instance in its published `IDataFilterSourceData.connectedResultsSourceReferences` (the one incoming-direction signal SPFx makes available)

The incoming check re-runs via `dynamicDataProvider.registerAvailableSourcesChanged` so the warning appears/disappears as other web parts are added or removed without needing a page refresh.

Localized strings added in en + 13 other locales for the message and the 'Learn more' link.

### Docs

- New **'Which version to choose: PnP - Search Results vs PnP - Search Rollup'** section in [search-results/index.md](docs/usage/search-results/index.md) with a behavior comparison table.
- New **'What the Rollup variant can and cannot consume'** subsection clarifying that the Rollup gives up SPFx dynamic data (Web Part connections + page-environment bindings) but still supports `{QueryString.<name>}` and other tokens, so URL-driven scenarios still work.
- Explains *why* the Rollup variant defers loading (SPFx only lazy-loads web parts that don't register as dynamic data sources/consumers).

### Refactor

- Extracted the Connections property pane fields (~530 lines) into `ConnectionsPropertyPaneBuilder` next to the existing `DataSourcePropertyPaneBuilder`, `AboutPropertyPaneBuilder`, and `StylingPageGroupsBuilder`. Behavior unchanged.
- The builder is **lazy-loaded** via a dynamic import into the existing `pnp-modern-search-property-pane` webpack chunk, so display-mode page loads don't download it.
- `SearchResultsWebPart.ts` is now 2606 lines (was 3006), comfortably under the 3000-line cap.

## Testing

- Unconnected Search Results on a page with a Search Box + Search Filters + a separate connected Search Results → warning appears on the unconnected one.
- After connecting it to the filters → warning disappears within the next render cycle.
- After toggling a connection on without selecting a source → warning still shown (correct: nothing is actually consumed).
- View mode → warning never shown.
- Rollup variant (`allowWebPartConnections: false`) → warning never shown.
- TypeScript: `npx tsc --noEmit` passes.