### PR TITLE
perf: reduce bundle size via async chunk splitting across all 4 web parts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# Copilot instructions
+
+This repository (**PnP Modern Search v4**) is a **SharePoint Framework (SPFx)** solution
+(TypeScript + React + webpack). The main package lives under `search-parts/`.
+
+These notes are **additional, project-specific** guidance for PR reviews — they supplement, not
+replace, the default review.
+
+## SPFx-specific things the reviewer should know
+
+- **Async-only code splitting**: each web part has a single injected entry script, so only
+  webpack `chunks: 'async'` splitting works. Initial/sync split chunks would never load — be
+  skeptical of changes that assume eager/sync vendor chunks.
+- **Bundle size is a first-class concern**. Flag new top-level/eager imports of heavy libraries
+  (Fluent UI, MGT, Adaptive Cards, Handlebars, Monaco/ACE, moment). Heavy or optional dependencies
+  should load on demand via dynamic `import()` with a `webpackChunkName` comment prefixed
+  `pnp-modern-search-*`. Webpack customization lives in
+  `search-parts/config/spfx-customize-webpack.js`.
+- **Microsoft Graph Toolkit (MGT)** must only load when the `useMicrosoftGraphToolkit` toggle is
+  enabled — never eagerly on every render.
+- **Property-pane controls**: shared controls should use the lazily-loaded references from
+  `BaseWebPart.loadCommonPropertyPaneResources()` rather than eager
+  `@pnp/spfx-property-controls` imports.
+- **Localization & translation**: all user-facing strings must be localized — never hard-coded.
+  Add the key to the per-web-part strings modules (e.g. `SearchResultsWebPartStrings`) or shared
+  `CommonStrings`, with its English value in `src/loc/en-us.js`. Any new or changed string must
+  also be added/updated in **every** language file under `search-parts/src/loc/` (e.g. `de-de.js`,
+  `fr-fr.js`, `es-es.js`, `nl-nl.js`, `sv-SE.js`, `nb-no.js`, `da-dk.js`, `fi-fi.js`, `it-it.js`,
+  `pl-pl.js`, `cs-cz.js`, `pt-br.js`) with a translation appropriate to that language — not left as
+  the English fallback. Flag PRs that add/modify a string in `en-us.js` without updating the other
+  locale files.
+- **Templates/layouts**: watch for unsanitized HTML rendered via `dangerouslySetInnerHTML` or
+  Handlebars (XSS risk from untrusted search data).
+
+## Build
+
+- Build with `npm run build` from `search-parts/`; output goes to `sharepoint/solution/`.

--- a/search-parts/config/spfx-customize-webpack.js
+++ b/search-parts/config/spfx-customize-webpack.js
@@ -71,6 +71,14 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
             include: [/spfx-controls-react[/\\]lib[/\\]controls[/\\]HoverReactionsBar/],
             loader: 'ignore-loader',
         },
+        // Ignore Dashboard & Toolbar controls from spfx-controls-react. We never import them,
+        // but they pull in @fluentui/react-northstar (+ react-icons-northstar) — ~600KB of
+        // Fluent UI v0 that is otherwise dead weight in the bundle.
+        {
+            test: /\.js$/,
+            include: [/spfx-controls-react[/\\]lib[/\\]controls[/\\](dashboard|toolbar)[/\\]/i],
+            loader: 'ignore-loader',
+        },
         // html-loader for .html files (handlebars templates) without minification
         {
             test: /\.html$/,
@@ -81,10 +89,39 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
         }
     );
 
-    // ─── optimization: disable vendor chunk splitting ──────────────────────────
+    // ─── optimization: shared async vendor chunks ─────────────────────────────
+    // SPFx injects only the single entry script per web part, so we must NOT create
+    // *initial* split chunks (they would never be loaded → runtime crash). Instead we
+    // split only *async* chunks (chunks: 'async'). Because each web part now loads its
+    // React container via dynamic import(), the heavy vendors (Fluent UI, PnP controls,
+    // handlebars, dompurify) live in the async graph and can be hoisted into shared
+    // chunks that webpack's own runtime loads on demand — emitted once instead of being
+    // duplicated across all four web part entries.
     webpackConfig.optimization = webpackConfig.optimization || {};
     webpackConfig.optimization.splitChunks = {
-        cacheGroups: { vendors: false },
+        chunks: 'async',
+        minSize: 20000,
+        cacheGroups: {
+            vendors: false,
+            fluentui: {
+                test: /[\\/]node_modules[\\/](@fluentui|@uifabric|office-ui-fabric-react)[\\/]/,
+                name: 'pnp-modern-search-fluentui',
+                priority: 40,
+                reuseExistingChunk: true,
+            },
+            pnpControls: {
+                test: /[\\/]node_modules[\\/]@pnp[\\/]spfx-(controls|property)-(react|controls)[\\/]/,
+                name: 'pnp-modern-search-pnp-controls',
+                priority: 30,
+                reuseExistingChunk: true,
+            },
+            handlebars: {
+                test: /[\\/]node_modules[\\/]handlebars[\\/]/,
+                name: 'pnp-modern-search-handlebars',
+                priority: 20,
+                reuseExistingChunk: true,
+            },
+        },
     };
 
     // ─── Plugins ───────────────────────────────────────────────────────────────

--- a/search-parts/config/spfx-customize-webpack.js
+++ b/search-parts/config/spfx-customize-webpack.js
@@ -118,9 +118,11 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
                 priority: 35,
                 reuseExistingChunk: true,
             },
-            // Monaco/ACE code editor stack used by the property pane code editor (on demand only).
-            // Not named: ace-builds does internal dynamic requires and diff-match-patch is also
-            // reachable from an entry's sync graph, so forcing a single named chunk conflicts.
+            // Handlebars templating engine (on demand only, used by the Handlebars layout).
+            // Note: the Monaco/ACE code editor stack (property pane code editor) is intentionally
+            // NOT given a named cacheGroup — ace-builds does internal dynamic requires and
+            // diff-match-patch is also reachable from an entry's sync graph, so forcing a single
+            // named chunk conflicts.
             handlebars: {
                 test: /[\\/]node_modules[\\/]handlebars[\\/]/,
                 name: 'pnp-modern-search-handlebars',

--- a/search-parts/config/spfx-customize-webpack.js
+++ b/search-parts/config/spfx-customize-webpack.js
@@ -109,6 +109,18 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
                 priority: 30,
                 reuseExistingChunk: true,
             },
+            // Adaptive Cards stack (adaptivecards, adaptivecards-templating, adaptive-expressions,
+            // antlr4ts, markdown-it). These always load together via AdaptiveCardsLoader and are
+            // only pulled in on demand by the Adaptive Card layout.
+            adaptiveCards: {
+                test: /[\\/]node_modules[\\/](adaptivecards|adaptivecards-templating|adaptive-expressions|antlr4ts|markdown-it)[\\/]/,
+                name: 'pnp-modern-search-adaptivecards',
+                priority: 35,
+                reuseExistingChunk: true,
+            },
+            // Monaco/ACE code editor stack used by the property pane code editor (on demand only).
+            // Not named: ace-builds does internal dynamic requires and diff-match-patch is also
+            // reachable from an entry's sync graph, so forcing a single named chunk conflicts.
             handlebars: {
                 test: /[\\/]node_modules[\\/]handlebars[\\/]/,
                 name: 'pnp-modern-search-handlebars',

--- a/search-parts/config/spfx-customize-webpack.js
+++ b/search-parts/config/spfx-customize-webpack.js
@@ -71,9 +71,7 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
             include: [/spfx-controls-react[/\\]lib[/\\]controls[/\\]HoverReactionsBar/],
             loader: 'ignore-loader',
         },
-        // Ignore Dashboard & Toolbar controls from spfx-controls-react. We never import them,
-        // but they pull in @fluentui/react-northstar (+ react-icons-northstar) — ~600KB of
-        // Fluent UI v0 that is otherwise dead weight in the bundle.
+        // Ignore Dashboard & Toolbar controls from spfx-controls-react (unused, pull in northstar)
         {
             test: /\.js$/,
             include: [/spfx-controls-react[/\\]lib[/\\]controls[/\\](dashboard|toolbar)[/\\]/i],
@@ -90,13 +88,9 @@ module.exports = function (webpackConfig, taskSession, heftConfiguration, webpac
     );
 
     // ─── optimization: shared async vendor chunks ─────────────────────────────
-    // SPFx injects only the single entry script per web part, so we must NOT create
-    // *initial* split chunks (they would never be loaded → runtime crash). Instead we
-    // split only *async* chunks (chunks: 'async'). Because each web part now loads its
-    // React container via dynamic import(), the heavy vendors (Fluent UI, PnP controls,
-    // handlebars, dompurify) live in the async graph and can be hoisted into shared
-    // chunks that webpack's own runtime loads on demand — emitted once instead of being
-    // duplicated across all four web part entries.
+    // SPFx injects only the single entry script per web part, so we split only *async* chunks
+    // (initial split chunks would never be loaded). Heavy vendors reachable via the web parts'
+    // dynamic import()s are hoisted into shared chunks emitted once instead of per entry.
     webpackConfig.optimization = webpackConfig.optimization || {};
     webpackConfig.optimization.splitChunks = {
         chunks: 'async',

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -28,8 +28,8 @@
                 "@microsoft/sp-webpart-base": "1.23.0",
                 "@pnp/common": "2.15.0",
                 "@pnp/modern-search-extensibility": "2.0.1",
-                "@pnp/spfx-controls-react": "3.23.0",
-                "@pnp/spfx-property-controls": "3.22.0",
+                "@pnp/spfx-controls-react": "3.24.0",
+                "@pnp/spfx-property-controls": "3.23.0",
                 "@pnp/telemetry-js": "2.0.0",
                 "adaptive-expressions": "4.23.3",
                 "adaptivecards": "2.11.2",
@@ -1323,6 +1323,8 @@
         },
         "node_modules/@fluentui/fluent2-theme": {
             "version": "8.107.153",
+            "resolved": "https://registry.npmjs.org/@fluentui/fluent2-theme/-/fluent2-theme-8.107.153.tgz",
+            "integrity": "sha512-JuODF0dsXCyCCQmJ6tsfCVWMWxrlpDA07ew46Fx057UujppzX9HcakE9GYVBRROSLJdXWxy5lLCg0xfGvfRz2w==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react": "^8.125.6",
@@ -1332,6 +1334,8 @@
         },
         "node_modules/@fluentui/fluent2-theme/node_modules/@fluentui/react": {
             "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
@@ -1405,6 +1409,8 @@
         },
         "node_modules/@fluentui/priority-overflow": {
             "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
+            "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -1437,19 +1443,21 @@
             }
         },
         "node_modules/@fluentui/react-accordion": {
-            "version": "9.11.0",
+            "version": "9.12.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.0.tgz",
+            "integrity": "sha512-Ay1Cet3qTdpcHQErelG/6tSAhaNCkCojZzNzhpET25ukiMNFeJVK/j/kQbrcjbdClYdz35+8/3hI8q6hSIPD/Q==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1461,16 +1469,18 @@
             }
         },
         "node_modules/@fluentui/react-alert": {
-            "version": "9.0.0-beta.139",
+            "version": "9.0.0-beta.140",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.140.tgz",
+            "integrity": "sha512-IYrS7qNyN6FFya+FBdyHZU3jA+6xcU7SD1FjFbthZMx2QTYN7wnZGUdIRQQc3BQRRwRNWtH2BEF4RZY20TvfWQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-avatar": "^9.11.1",
-                "@fluentui/react-button": "^9.9.1",
+                "@fluentui/react-avatar": "^9.11.2",
+                "@fluentui/react-button": "^9.9.2",
                 "@fluentui/react-icons": "^2.0.239",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1482,14 +1492,16 @@
             }
         },
         "node_modules/@fluentui/react-aria": {
-            "version": "9.17.11",
+            "version": "9.17.12",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.12.tgz",
+            "integrity": "sha512-Nrgj9ND3nqtr33w0ICXs3/VrtSBZNBoFl9FkeWz3SCUeUcC8A9eFIH2HpHjbgwENs9BV+aUPi2J2vZhX1+yqQg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-tabster": "^9.26.15",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -1500,19 +1512,21 @@
             }
         },
         "node_modules/@fluentui/react-avatar": {
-            "version": "9.11.1",
+            "version": "9.11.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.2.tgz",
+            "integrity": "sha512-OGGrpQBKbIfbX5ZDfZezCR2i1TErNopam0rUowuUl/etaiXv6Q8+1qdDPisJUR3OJJkSIXmiDhjdgJ+z/f7nFA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-badge": "^9.5.2",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-badge": "^9.5.3",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-popover": "^9.14.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-popover": "^9.14.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-tooltip": "^9.10.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-tooltip": "^9.10.2",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1524,14 +1538,16 @@
             }
         },
         "node_modules/@fluentui/react-badge": {
-            "version": "9.5.2",
+            "version": "9.5.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.3.tgz",
+            "integrity": "sha512-pMvzFTrMP/CvgDzne281pXyrBjSeiFwKRYuAa9Y1NkqK+H5wI0U/SsZu81mAuUA7vRxxqHkqtp5J2/huVK1yEQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1567,18 +1583,20 @@
             }
         },
         "node_modules/@fluentui/react-breadcrumb": {
-            "version": "9.4.1",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.2.tgz",
+            "integrity": "sha512-IpLlrQkvFnQ7kMzRaVn6lmfb6gDUwRtnMDfhLTfUiJkisvuqdZGeilGTH1Yx4JLqBzCQGnRHMjcYm1DcrwX4aQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-button": "^9.9.1",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-button": "^9.9.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-link": "^9.8.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-link": "^9.8.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1590,17 +1608,19 @@
             }
         },
         "node_modules/@fluentui/react-button": {
-            "version": "9.9.1",
+            "version": "9.9.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.2.tgz",
+            "integrity": "sha512-zQ6EuJCb3hQ7d62lrn+wI3C9ugbi3M1d98SjOmj4WW/xG9gOKIZ+xjg6AYtAm7L94I/6JZbe5al2NvtejQWsHw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
+                "@fluentui/react-aria": "^9.17.12",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1633,16 +1653,18 @@
             }
         },
         "node_modules/@fluentui/react-card": {
-            "version": "9.6.1",
+            "version": "9.7.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.0.tgz",
+            "integrity": "sha512-OWfkDlCNbxbap5W5TIc+fpSEWnArug2+47yYx2DnSiUkJ+/bSdqBvGAPlQjlONV/fuA/HPWBpsni4Ao9nZicqg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
-                "@fluentui/react-text": "^9.6.16",
+                "@fluentui/react-tabster": "^9.26.15",
+                "@fluentui/react-text": "^9.6.17",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1654,19 +1676,21 @@
             }
         },
         "node_modules/@fluentui/react-carousel": {
-            "version": "9.9.7",
+            "version": "9.9.8",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.8.tgz",
+            "integrity": "sha512-NaC7SVZF+dk1xV9FU9hsqQvoXrAzP6KMEcbzW7HLrQfM/qDyA2ERyYPZXeho24mvg4KXDalzEBwHxctASsA8iw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-tooltip": "^9.10.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-tooltip": "^9.10.2",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1",
                 "embla-carousel": "^8.5.1",
@@ -1681,17 +1705,19 @@
             }
         },
         "node_modules/@fluentui/react-checkbox": {
-            "version": "9.6.1",
+            "version": "9.6.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.2.tgz",
+            "integrity": "sha512-ONIvYhhIdwAuPD4V5CZYXXjeq0lAtpiwU0PSFP5JAabYrmPVnBALe8km1QFTSnz2pN70AfQsOm92n6PCUFbyrg==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1703,16 +1729,18 @@
             }
         },
         "node_modules/@fluentui/react-color-picker": {
-            "version": "9.2.16",
+            "version": "9.2.17",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.17.tgz",
+            "integrity": "sha512-cp9WdlrP2miMVNn5s1vjNqJCumezP/OWwGI0TV9tRMO0DvGQ8R1xwbVxxTH/C/wsMYrVIHiJaagQ5U6nzk6XLw==",
             "license": "MIT",
             "dependencies": {
                 "@ctrl/tinycolor": "^3.3.4",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1724,21 +1752,23 @@
             }
         },
         "node_modules/@fluentui/react-combobox": {
-            "version": "9.17.1",
+            "version": "9.17.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.2.tgz",
+            "integrity": "sha512-uYFelRhb+3BOwAIm4lvCfvrIBBi2Q5A66jzTXwZaH4rg5wrTWkpv+eSVkHF5gfcxzoEYRy1Ze2Tf1B2DtYYJyQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1785,69 +1815,71 @@
             }
         },
         "node_modules/@fluentui/react-components": {
-            "version": "9.73.8",
+            "version": "9.74.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.1.tgz",
+            "integrity": "sha512-N7BDd3g3A/ngxq8LKLD9ovd+3eHlOgo6R6QFPxA5pVYvznGSQlg00zQ2WxMz7jxQ8ADdPZYIsc7cfg80og3ckw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-accordion": "^9.11.0",
-                "@fluentui/react-alert": "9.0.0-beta.139",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-avatar": "^9.11.1",
-                "@fluentui/react-badge": "^9.5.2",
-                "@fluentui/react-breadcrumb": "^9.4.1",
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-card": "^9.6.1",
-                "@fluentui/react-carousel": "^9.9.7",
-                "@fluentui/react-checkbox": "^9.6.1",
-                "@fluentui/react-color-picker": "^9.2.16",
-                "@fluentui/react-combobox": "^9.17.1",
-                "@fluentui/react-dialog": "^9.18.0",
-                "@fluentui/react-divider": "^9.7.1",
-                "@fluentui/react-drawer": "^9.12.0",
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-image": "^9.4.1",
-                "@fluentui/react-infobutton": "9.0.0-beta.115",
-                "@fluentui/react-infolabel": "^9.4.20",
-                "@fluentui/react-input": "^9.8.2",
-                "@fluentui/react-label": "^9.4.1",
-                "@fluentui/react-link": "^9.8.1",
-                "@fluentui/react-list": "^9.6.14",
-                "@fluentui/react-menu": "^9.24.1",
-                "@fluentui/react-message-bar": "^9.7.0",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-nav": "^9.3.24",
-                "@fluentui/react-overflow": "^9.7.2",
-                "@fluentui/react-persona": "^9.7.3",
-                "@fluentui/react-popover": "^9.14.2",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
-                "@fluentui/react-progress": "^9.5.1",
-                "@fluentui/react-provider": "^9.22.16",
-                "@fluentui/react-radio": "^9.6.2",
-                "@fluentui/react-rating": "^9.4.1",
-                "@fluentui/react-search": "^9.4.2",
-                "@fluentui/react-select": "^9.5.1",
+                "@fluentui/react-accordion": "^9.12.0",
+                "@fluentui/react-alert": "9.0.0-beta.140",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-avatar": "^9.11.2",
+                "@fluentui/react-badge": "^9.5.3",
+                "@fluentui/react-breadcrumb": "^9.4.2",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-card": "^9.7.0",
+                "@fluentui/react-carousel": "^9.9.8",
+                "@fluentui/react-checkbox": "^9.6.2",
+                "@fluentui/react-color-picker": "^9.2.17",
+                "@fluentui/react-combobox": "^9.17.2",
+                "@fluentui/react-dialog": "^9.18.1",
+                "@fluentui/react-divider": "^9.7.2",
+                "@fluentui/react-drawer": "^9.13.0",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-image": "^9.4.2",
+                "@fluentui/react-infobutton": "9.0.0-beta.116",
+                "@fluentui/react-infolabel": "^9.4.21",
+                "@fluentui/react-input": "^9.8.3",
+                "@fluentui/react-label": "^9.4.2",
+                "@fluentui/react-link": "^9.8.2",
+                "@fluentui/react-list": "^9.6.15",
+                "@fluentui/react-menu": "^9.25.0",
+                "@fluentui/react-message-bar": "^9.7.1",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-nav": "^9.4.0",
+                "@fluentui/react-overflow": "^9.8.0",
+                "@fluentui/react-persona": "^9.7.4",
+                "@fluentui/react-popover": "^9.14.3",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
+                "@fluentui/react-progress": "^9.5.2",
+                "@fluentui/react-provider": "^9.22.17",
+                "@fluentui/react-radio": "^9.6.3",
+                "@fluentui/react-rating": "^9.4.2",
+                "@fluentui/react-search": "^9.4.3",
+                "@fluentui/react-select": "^9.5.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-skeleton": "^9.7.2",
-                "@fluentui/react-slider": "^9.6.2",
-                "@fluentui/react-spinbutton": "^9.6.2",
-                "@fluentui/react-spinner": "^9.8.2",
-                "@fluentui/react-swatch-picker": "^9.5.2",
-                "@fluentui/react-switch": "^9.7.2",
-                "@fluentui/react-table": "^9.19.15",
-                "@fluentui/react-tabs": "^9.12.1",
-                "@fluentui/react-tabster": "^9.26.14",
-                "@fluentui/react-tag-picker": "^9.8.6",
-                "@fluentui/react-tags": "^9.8.1",
-                "@fluentui/react-teaching-popover": "^9.6.21",
-                "@fluentui/react-text": "^9.6.16",
-                "@fluentui/react-textarea": "^9.7.2",
+                "@fluentui/react-skeleton": "^9.7.3",
+                "@fluentui/react-slider": "^9.6.3",
+                "@fluentui/react-spinbutton": "^9.6.3",
+                "@fluentui/react-spinner": "^9.8.3",
+                "@fluentui/react-swatch-picker": "^9.5.3",
+                "@fluentui/react-switch": "^9.7.3",
+                "@fluentui/react-table": "^9.19.16",
+                "@fluentui/react-tabs": "^9.12.2",
+                "@fluentui/react-tabster": "^9.26.15",
+                "@fluentui/react-tag-picker": "^9.8.8",
+                "@fluentui/react-tags": "^9.9.1",
+                "@fluentui/react-teaching-popover": "^9.7.0",
+                "@fluentui/react-text": "^9.6.17",
+                "@fluentui/react-textarea": "^9.7.3",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-toast": "^9.7.17",
-                "@fluentui/react-toolbar": "^9.8.0",
-                "@fluentui/react-tooltip": "^9.10.1",
-                "@fluentui/react-tree": "^9.16.0",
-                "@fluentui/react-utilities": "^9.26.3",
-                "@fluentui/react-virtualizer": "9.0.0-alpha.112",
+                "@fluentui/react-toast": "^9.8.0",
+                "@fluentui/react-toolbar": "^9.8.1",
+                "@fluentui/react-tooltip": "^9.10.2",
+                "@fluentui/react-tree": "^9.16.1",
+                "@fluentui/react-utilities": "^9.26.4",
+                "@fluentui/react-virtualizer": "9.0.0-alpha.113",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1878,10 +1910,12 @@
             "license": "0BSD"
         },
         "node_modules/@fluentui/react-context-selector": {
-            "version": "9.2.16",
+            "version": "9.2.17",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.17.tgz",
+            "integrity": "sha512-pZGIz8vjK9nxHKmztV7y5T8yHseoTjm3a43TdPN6fhup0tlrGE/JUmVFEwulI3j4fMWqa0P2OhJoe+HrDMs44Q==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -1920,21 +1954,23 @@
             }
         },
         "node_modules/@fluentui/react-dialog": {
-            "version": "9.18.0",
+            "version": "9.18.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.1.tgz",
+            "integrity": "sha512-tvi5MgUXY6yOySfKSEJobeBNwK3BOXVjRInxDz3ZM7g7FMMyzuf9HrXK/7caqMNRA9uQEQKFXKI9zD03L0kyPA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-portal": "^9.8.12",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-portal": "^9.8.13",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1946,13 +1982,15 @@
             }
         },
         "node_modules/@fluentui/react-divider": {
-            "version": "9.7.1",
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.2.tgz",
+            "integrity": "sha512-rfzGQoGKtLBF5vxiJH2KhRiJGosozdql3d6eS7j11oRczgc5W/h38iLhiXuQzZHpkGaAOd3sY6sq4uGHJheOjA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1964,18 +2002,20 @@
             }
         },
         "node_modules/@fluentui/react-drawer": {
-            "version": "9.12.0",
+            "version": "9.13.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.0.tgz",
+            "integrity": "sha512-Xeh9kW8SiNXobx+5AUb4UVYsaqpE9uqrqFwsb5Z47oupX3zRLw7UCh5rVbJoXowZRc7z6K1FViyORqpsOXnzJw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-dialog": "^9.18.0",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-portal": "^9.8.12",
+                "@fluentui/react-dialog": "^9.18.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-portal": "^9.8.13",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -1987,16 +2027,18 @@
             }
         },
         "node_modules/@fluentui/react-field": {
-            "version": "9.5.1",
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.2.tgz",
+            "integrity": "sha512-5pZXGtDVXCkoL3/sRMyhCcPd6+TDR9/wYG7/mK82BDuX4viuoSr5llcQ1PkdcXMixFFU+nXa39l7/BLP3f6W8g==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2077,13 +2119,15 @@
             }
         },
         "node_modules/@fluentui/react-image": {
-            "version": "9.4.1",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.2.tgz",
+            "integrity": "sha512-E7bOTFds8qoMiT/YDe2+ZL5h13u7M1bm8yoGFfeTw0fmE9Q0gtrx2WzJB/1ZV/4MTmjnaO9Dgx7ysTYxc3RWRw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2095,16 +2139,18 @@
             }
         },
         "node_modules/@fluentui/react-infobutton": {
-            "version": "9.0.0-beta.115",
+            "version": "9.0.0-beta.116",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.116.tgz",
+            "integrity": "sha512-bnL8hRs9K8xCKvJU49F0UxcRankGb2sr+KYezdrcrgfbePrh8kyJTFGmxKQSgka8P+SySE5DxFwb2RbfpTjmnw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.237",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
-                "@fluentui/react-popover": "^9.14.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
+                "@fluentui/react-popover": "^9.14.3",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2116,17 +2162,19 @@
             }
         },
         "node_modules/@fluentui/react-infolabel": {
-            "version": "9.4.20",
+            "version": "9.4.21",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.21.tgz",
+            "integrity": "sha512-FDpbxwdEztarJ63NmHCQP5n2XXKvyVgkdIVQIbkVslYqfooy2kql8Q0+5brRN2IsjQJRZ0MpSFRoJSNVT8rJEg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
-                "@fluentui/react-popover": "^9.14.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
+                "@fluentui/react-popover": "^9.14.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2138,14 +2186,16 @@
             }
         },
         "node_modules/@fluentui/react-input": {
-            "version": "9.8.2",
+            "version": "9.8.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.3.tgz",
+            "integrity": "sha512-nnApEcsPXVXCZZl9qRpS9hc2hy18btUtbG188TYM1FAynqjx5zZC9Ww5/6IOrGT8d12nDxxTu9dp/xqMZtUbbw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2157,10 +2207,12 @@
             }
         },
         "node_modules/@fluentui/react-jsx-runtime": {
-            "version": "9.4.2",
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.3.tgz",
+            "integrity": "sha512-1QwEgITME+X24lnS68pQlU/b4BBdeS7oPdApwwoYQuAGKvImDY2nLAJt8BoHYKs9VFeX5ySEKPRM0rKXGq3EWQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -2169,13 +2221,15 @@
             }
         },
         "node_modules/@fluentui/react-label": {
-            "version": "9.4.1",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.2.tgz",
+            "integrity": "sha512-FfbOQf5caDA3yc/wukbKY0p6Pv8wkzre7E480VxqTgKrMm12KUoT+0+2S7vi0eCQJCW3pL8XjzVTbGIn8KDE8A==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2187,15 +2241,17 @@
             }
         },
         "node_modules/@fluentui/react-link": {
-            "version": "9.8.1",
+            "version": "9.8.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.2.tgz",
+            "integrity": "sha512-PDziHdvp717LFc7BgxXDVldnq8UFtyqWM4ZWr0772XtuEc08jVU3MxKMUEsGOclqLRKGyjd0nG7IWKREuSETcg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2207,17 +2263,19 @@
             }
         },
         "node_modules/@fluentui/react-list": {
-            "version": "9.6.14",
+            "version": "9.6.15",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.15.tgz",
+            "integrity": "sha512-mb2yVQC2gfILLFOZAxsYwo70YgoyacR52Qy2EGuB4wZOQtZ9KMZIOUFlQIztJBSxNIfo869/bF8EUWsVDaTeYg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-checkbox": "^9.6.1",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-checkbox": "^9.6.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2229,22 +2287,24 @@
             }
         },
         "node_modules/@fluentui/react-menu": {
-            "version": "9.24.1",
+            "version": "9.25.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.0.tgz",
+            "integrity": "sha512-aoBlNLv8Ngr9wBiOEhvYVOSLfeen2vvdAdZM10OjJ+mo9uhdRxF4m0Uqd8mcp0bpGf5/Cnz9FIZjdgc5krdwyA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2256,18 +2316,20 @@
             }
         },
         "node_modules/@fluentui/react-message-bar": {
-            "version": "9.7.0",
+            "version": "9.7.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.1.tgz",
+            "integrity": "sha512-8ImzffgVF/DJacOCiP1x75GQHE0wdB+3QoRkGKsgOZcqn6JOXzCEYvM0JplietUsNczmXRtXx9ZE+Otl6HPOHQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-button": "^9.9.1",
+                "@fluentui/react-button": "^9.9.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-link": "^9.8.1",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-link": "^9.8.2",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2279,13 +2341,15 @@
             }
         },
         "node_modules/@fluentui/react-migration-v8-v9": {
-            "version": "9.10.9",
+            "version": "9.10.12",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-migration-v8-v9/-/react-migration-v8-v9-9.10.12.tgz",
+            "integrity": "sha512-VOBMr9j7VMYvTAczIeFq0U9/MhHD2Qwg+Y6Ap2TXFsIvHvSbq45ZBFm8o5pSIAj+XXA4Scwuqpr5IXrBnbQUZQ==",
             "license": "MIT",
             "dependencies": {
                 "@ctrl/tinycolor": "^3.3.4",
-                "@fluentui/fluent2-theme": "^8.107.152",
-                "@fluentui/react": "^8.125.5",
-                "@fluentui/react-components": "^9.73.7",
+                "@fluentui/fluent2-theme": "^8.107.153",
+                "@fluentui/react": "^8.125.6",
+                "@fluentui/react-components": "^9.74.1",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-icons": "^2.0.245",
                 "@griffel/react": "^1.5.32",
@@ -2300,6 +2364,8 @@
         },
         "node_modules/@fluentui/react-migration-v8-v9/node_modules/@fluentui/react": {
             "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
@@ -2325,11 +2391,13 @@
             }
         },
         "node_modules/@fluentui/react-motion": {
-            "version": "9.15.0",
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.0.tgz",
+            "integrity": "sha512-ZhbeRfir3V6+2kQjRqF2Bp8jwZd6TfmA9y1c6IlglsB8aNAbhnewYJsYXLrbZ+gwloiDdf46cVDqWYv5VFAgpg==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -2340,7 +2408,9 @@
             }
         },
         "node_modules/@fluentui/react-motion-components-preview": {
-            "version": "0.15.4",
+            "version": "0.15.5",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.5.tgz",
+            "integrity": "sha512-AhDw4/6fjIDWPwx8L1vNDYu3GBJYkyAazNHNrowoRsuxZHn0vK5TMUacT4UW6/QbByCk1x76TLv+CxmwU75FPA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-motion": "*",
@@ -2355,23 +2425,25 @@
             }
         },
         "node_modules/@fluentui/react-nav": {
-            "version": "9.3.24",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.0.tgz",
+            "integrity": "sha512-gyrXwT1NFfRT4WoVXrz7656tuFOmhFgCw1OBmb+0igftXmSxz6XMIj8MlwfUv2/VUymAU4Hs0p3rZwE4l81KKA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-divider": "^9.7.1",
-                "@fluentui/react-drawer": "^9.12.0",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-divider": "^9.7.2",
+                "@fluentui/react-drawer": "^9.13.0",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-tooltip": "^9.10.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-tooltip": "^9.10.2",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2463,13 +2535,16 @@
             }
         },
         "node_modules/@fluentui/react-overflow": {
-            "version": "9.7.2",
+            "version": "9.8.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.8.0.tgz",
+            "integrity": "sha512-6lHvfcRNFSnOIrKHUzWc/WCKvSp5ivH8QP/stzyCUyzJpDde8uAbRMfg2iDFgJ8wlySP29BoPiepaH9bHgVLdQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/priority-overflow": "^9.3.0",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2481,15 +2556,17 @@
             }
         },
         "node_modules/@fluentui/react-persona": {
-            "version": "9.7.3",
+            "version": "9.7.4",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.4.tgz",
+            "integrity": "sha512-CtYA3aElMwTrhZcvdtrSIHWOzZqFcpJlfjchNNFTtvvFvrLGw65/1UPzLf/IUVBD1JO0XLGyQFRLUg/g+rtBfg==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-avatar": "^9.11.1",
-                "@fluentui/react-badge": "^9.5.2",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-avatar": "^9.11.2",
+                "@fluentui/react-badge": "^9.5.3",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2501,21 +2578,23 @@
             }
         },
         "node_modules/@fluentui/react-popover": {
-            "version": "9.14.2",
+            "version": "9.14.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.3.tgz",
+            "integrity": "sha512-wR73yLdMm3/pJ92xJEeRnBAJ8tNvNv0LTSmaZvwbTgdcMT1zqfSyNO37qE7a8z+4bcp8kjyM8FR9NRqkr8OYdA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2527,12 +2606,14 @@
             }
         },
         "node_modules/@fluentui/react-portal": {
-            "version": "9.8.12",
+            "version": "9.8.13",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.13.tgz",
+            "integrity": "sha512-a4EEt3KMzvW6qMk97K/8TQegmO8Ba4C2TdR7ke7g1SsEDmJGwwOD34hCwVxGi8LtxLcpAEdOx++brXnPsk5+Zw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-tabster": "^9.26.15",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2555,14 +2636,16 @@
             }
         },
         "node_modules/@fluentui/react-positioning": {
-            "version": "9.22.1",
+            "version": "9.22.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.2.tgz",
+            "integrity": "sha512-Pmio9+lDN+rF4k0mHVXqX6W0+A0ym0dje92UVfXeuassuIuJpKfvQg1xLpgQPrGRbgERr8KgA04xQVoJKaZQmA==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/devtools": "^0.2.3",
                 "@floating-ui/dom": "^1.6.12",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1",
                 "use-sync-external-store": "^1.2.0"
@@ -2575,15 +2658,17 @@
             }
         },
         "node_modules/@fluentui/react-progress": {
-            "version": "9.5.1",
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.2.tgz",
+            "integrity": "sha512-H2t9Q9qYPm5gGb68RiIukFAZn/IxgoxcpKwZ+AjXKCly0C8x8EWCpyQSdfvswaGbcx7H6fe3SpKytBAAuvOOtA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2604,15 +2689,17 @@
             }
         },
         "node_modules/@fluentui/react-provider": {
-            "version": "9.22.16",
+            "version": "9.22.17",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.17.tgz",
+            "integrity": "sha512-VIguLw2Ez9qxYCzrwKe3ttIcIbRdi7qpafImLNdpIAWRacIHw1AXSiDKcL6VFfE1+NxfQEy655wqYABi+7pJfw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/core": "^1.16.0",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
@@ -2625,16 +2712,18 @@
             }
         },
         "node_modules/@fluentui/react-radio": {
-            "version": "9.6.2",
+            "version": "9.6.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.3.tgz",
+            "integrity": "sha512-U+funQQvlcOe3BQevUlkxsCoTQKFjw3Z/wnoAXNaNr1lTLIZnB+nesLA3ovZFWyOGTTJ2Mfa+vYpLbyyEpS8eA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2646,15 +2735,17 @@
             }
         },
         "node_modules/@fluentui/react-rating": {
-            "version": "9.4.1",
+            "version": "9.4.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.2.tgz",
+            "integrity": "sha512-jVHv9GFKKhzH1fai4/1ArG1xjFAU/PFsY8UkBikt3LQDL5Cuw2S2uIBanso0AllNwmwaImsd5xb1Uo8mfMayBw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2666,15 +2757,17 @@
             }
         },
         "node_modules/@fluentui/react-search": {
-            "version": "9.4.2",
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.3.tgz",
+            "integrity": "sha512-wKRakuodG76MTu2v/8PZiXA3SUFaMJhdJ5OjoVh5TpFtoYnzwJmiyW2TlgDuod2rk2fpJ3v34C6wkdx6tW8oZw==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-input": "^9.8.2",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-input": "^9.8.3",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2686,15 +2779,17 @@
             }
         },
         "node_modules/@fluentui/react-select": {
-            "version": "9.5.1",
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.2.tgz",
+            "integrity": "sha512-kbLbF8DAXsbb2UwJxVzV5tS9fpSX2RZdFPZYosvQly6+h5kTojVFeZRrSkyMPYRCkTMVENdAeyahdx4ESa5qHw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2718,14 +2813,16 @@
             }
         },
         "node_modules/@fluentui/react-skeleton": {
-            "version": "9.7.2",
+            "version": "9.7.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.3.tgz",
+            "integrity": "sha512-4YhAux0OaYs/91xz/K25pNQxFbdQ2FcDRnwTpgsCDFH4XGQtA+rxBsLA5il3chIf++bNWr/78c5PHp6tZQuCDw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2737,15 +2834,17 @@
             }
         },
         "node_modules/@fluentui/react-slider": {
-            "version": "9.6.2",
+            "version": "9.6.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.3.tgz",
+            "integrity": "sha512-r0AP/ZqyMpVEEniIMjQ6AH5DZeCZ/XypBw+21D6mtjiy9vCg0A9lU8U+ay2Y1RyQY4PCShsUVSOb3bNTSTVUxQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2757,16 +2856,18 @@
             }
         },
         "node_modules/@fluentui/react-spinbutton": {
-            "version": "9.6.2",
+            "version": "9.6.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.3.tgz",
+            "integrity": "sha512-wc3GjEB3vBz8uO+Jmdch9gk5effGz6ld2SrfmpHjfTGgww9qIj5S+WbSPZjAKgtqZw/f597DMpiplRE1kvqn/A==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2778,14 +2879,16 @@
             }
         },
         "node_modules/@fluentui/react-spinner": {
-            "version": "9.8.2",
+            "version": "9.8.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.3.tgz",
+            "integrity": "sha512-knnL3Yx/qC+YoYPLCQLE5iHeNMwj3bLBQrksk85lQK0AFy1rOs8rTQuxUtjg9icn5BOFExhSDOYVwp3diSt1ug==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2813,17 +2916,19 @@
             "license": "0BSD"
         },
         "node_modules/@fluentui/react-swatch-picker": {
-            "version": "9.5.2",
+            "version": "9.5.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.3.tgz",
+            "integrity": "sha512-AiybFcvA6in1piIsPn83Wm+w5bOnLlWmqrHiTDFnt6bYb8j2MJZ+dratJVZRtidqlEyfcMS3SByLooaVzwLRLQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2835,17 +2940,19 @@
             }
         },
         "node_modules/@fluentui/react-switch": {
-            "version": "9.7.2",
+            "version": "9.7.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.3.tgz",
+            "integrity": "sha512-/eCYAtaoyUF//6F/OdOGj+GhLtkeJMXJUxaRPiDa6d18DX2eyoGaQ10175ysOjv4CbzIg8xH15flgpB4qUUstQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-label": "^9.4.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-label": "^9.4.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2857,21 +2964,23 @@
             }
         },
         "node_modules/@fluentui/react-table": {
-            "version": "9.19.15",
+            "version": "9.19.16",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.16.tgz",
+            "integrity": "sha512-SdwpJIHwCGg+ALOhZRvixkQhWSakXDgpDGe/OWwv1PiLDPxnBh+gUd+MtveryFaX+WvJvLWzx3u9O1ogQXKx3g==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-avatar": "^9.11.1",
-                "@fluentui/react-checkbox": "^9.6.1",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-avatar": "^9.11.2",
+                "@fluentui/react-checkbox": "^9.6.2",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-radio": "^9.6.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-radio": "^9.6.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2883,15 +2992,17 @@
             }
         },
         "node_modules/@fluentui/react-tabs": {
-            "version": "9.12.1",
+            "version": "9.12.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.2.tgz",
+            "integrity": "sha512-k2WsKmNQvFtNSywAb/VxXXlFdLC9fjRaRV4Ha7qDXucXuTCI1eKJuaAteePZiMAByv+AbRqRHevv5k2KMabxrw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2903,16 +3014,18 @@
             }
         },
         "node_modules/@fluentui/react-tabster": {
-            "version": "9.26.14",
+            "version": "9.26.15",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.15.tgz",
+            "integrity": "sha512-SugQlqXsMueTojtvPU/RIoZg6WaV4bw++NhLjnF7dFvD61/w5pPsVSLCPsLJBD+oU5Kbgx2x3KFbI69kb+kNmQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1",
-                "keyborg": "^2.6.0",
-                "tabster": "^8.5.5"
+                "keyborg": "^2.14.1",
+                "tabster": "^8.8.0"
             },
             "peerDependencies": {
                 "@types/react": ">=16.14.0 <20.0.0",
@@ -2922,23 +3035,25 @@
             }
         },
         "node_modules/@fluentui/react-tag-picker": {
-            "version": "9.8.6",
+            "version": "9.8.8",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.8.tgz",
+            "integrity": "sha512-GkBqUMAxJtOGRNFmkoi6Js4jxvQEc3JScUok1/UKThPHZeMfk4vAKT8aGVx9Sa/Ab4Akr5LhcjOt4TXHPQ2IvQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-combobox": "^9.17.1",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-field": "^9.5.1",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-combobox": "^9.17.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-field": "^9.5.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
-                "@fluentui/react-tags": "^9.8.1",
+                "@fluentui/react-tabster": "^9.26.15",
+                "@fluentui/react-tags": "^9.9.1",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2950,18 +3065,20 @@
             }
         },
         "node_modules/@fluentui/react-tags": {
-            "version": "9.8.1",
+            "version": "9.9.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.1.tgz",
+            "integrity": "sha512-WY6Ye5TblwHnMIlRd0DgnPTCH+UyJBafr8bIOszi13KOkN3HFswY5syb4lbQUzP+EslAC5M5cPnJXe89TUXV+Q==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-avatar": "^9.11.1",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-avatar": "^9.11.2",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -2973,19 +3090,21 @@
             }
         },
         "node_modules/@fluentui/react-teaching-popover": {
-            "version": "9.6.21",
+            "version": "9.7.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.0.tgz",
+            "integrity": "sha512-8oKts1w33JbLAgVNt7Ad5vidXsIpXyVkrPwo5aZW6oqEASJGEooAOx1od+bKgwZb2wyjq5/RXxdV22r13nqajg==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-popover": "^9.14.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-popover": "^9.14.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1",
                 "use-sync-external-store": "^1.2.0"
@@ -2998,13 +3117,15 @@
             }
         },
         "node_modules/@fluentui/react-text": {
-            "version": "9.6.16",
+            "version": "9.6.17",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.17.tgz",
+            "integrity": "sha512-SqWXOKJNF6EgG4/vZeurl7MqO9OckRwK6tvk9JJVs7kbqOky+d+t1gITaqk9yIOw6LJtb76vm8cZUvKUb0WSqA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3016,14 +3137,16 @@
             }
         },
         "node_modules/@fluentui/react-textarea": {
-            "version": "9.7.2",
+            "version": "9.7.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.3.tgz",
+            "integrity": "sha512-BNStqBKO2fe3h5VAIPs33/7xj8EAr5msmb9krq02XAmvDndt3aLrQdz25vVEMvbcuUCNQoFsPtN/PrR6nXTIHw==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-field": "^9.5.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-field": "^9.5.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3097,20 +3220,22 @@
             "license": "0BSD"
         },
         "node_modules/@fluentui/react-toast": {
-            "version": "9.7.17",
+            "version": "9.8.0",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.8.0.tgz",
+            "integrity": "sha512-GsLeEjLCLZ+SM2yL4G/hsypecXPn4FK73sH3KXer7Q0MST+ldulcaW8nsppCwqBB6Zf5pwcRU4qnkWwFMQd66Q==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
+                "@fluentui/react-aria": "^9.17.12",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-portal": "^9.8.12",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-portal": "^9.8.13",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3122,18 +3247,20 @@
             }
         },
         "node_modules/@fluentui/react-toolbar": {
-            "version": "9.8.0",
+            "version": "9.8.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.1.tgz",
+            "integrity": "sha512-ZzjFwFElF3bCsHXgl6YfmHzfZn2gUDe7NoYl4qloHhGacrSStvOt0h94WRz0a5ur/VIG2PDROeBLkcI2MIZQJQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-context-selector": "^9.2.16",
-                "@fluentui/react-divider": "^9.7.1",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-radio": "^9.6.2",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-context-selector": "^9.2.17",
+                "@fluentui/react-divider": "^9.7.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-radio": "^9.6.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3145,17 +3272,19 @@
             }
         },
         "node_modules/@fluentui/react-tooltip": {
-            "version": "9.10.1",
+            "version": "9.10.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.2.tgz",
+            "integrity": "sha512-1qewqiTNKpbRuoINhytyaMoUsBLE4TRPXf9ilJnvN3UtN5TYtS/8Oe6zMocHEnCLETsFOyCn8sAlufWOo5efpQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-portal": "^9.8.12",
-                "@fluentui/react-positioning": "^9.22.1",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-portal": "^9.8.13",
+                "@fluentui/react-positioning": "^9.22.2",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3167,24 +3296,26 @@
             }
         },
         "node_modules/@fluentui/react-tree": {
-            "version": "9.16.0",
+            "version": "9.16.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.1.tgz",
+            "integrity": "sha512-e87Fa+8ttbYh0XY4qxJ9NcmIWSfYouw8Rc68c10UczK2TcsWSII84cV9fHrbL7FtX8DlyncZuSjukoJYm5LD7w==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-aria": "^9.17.11",
-                "@fluentui/react-avatar": "^9.11.1",
-                "@fluentui/react-button": "^9.9.1",
-                "@fluentui/react-checkbox": "^9.6.1",
-                "@fluentui/react-context-selector": "^9.2.16",
+                "@fluentui/react-aria": "^9.17.12",
+                "@fluentui/react-avatar": "^9.11.2",
+                "@fluentui/react-button": "^9.9.2",
+                "@fluentui/react-checkbox": "^9.6.2",
+                "@fluentui/react-context-selector": "^9.2.17",
                 "@fluentui/react-icons": "^2.0.245",
-                "@fluentui/react-jsx-runtime": "^9.4.2",
-                "@fluentui/react-motion": "^9.15.0",
-                "@fluentui/react-motion-components-preview": "^0.15.4",
-                "@fluentui/react-radio": "^9.6.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
+                "@fluentui/react-motion": "^9.16.0",
+                "@fluentui/react-motion-components-preview": "^0.15.5",
+                "@fluentui/react-radio": "^9.6.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-tabster": "^9.26.14",
+                "@fluentui/react-tabster": "^9.26.15",
                 "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -3196,7 +3327,9 @@
             }
         },
         "node_modules/@fluentui/react-utilities": {
-            "version": "9.26.3",
+            "version": "9.26.4",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.4.tgz",
+            "integrity": "sha512-Rg1kg0ZPFOBi6VtQNkgV+K3z3O7PY5QFJQ4Y+qkZv7a8fUSNkEK151coaGOLps4P77fY2DiHhqKqeOehN7vFOA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3209,12 +3342,14 @@
             }
         },
         "node_modules/@fluentui/react-virtualizer": {
-            "version": "9.0.0-alpha.112",
+            "version": "9.0.0-alpha.113",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.113.tgz",
+            "integrity": "sha512-MGmdlm+0HwwMypCpUCpddQjgKvZkL9oGvjXNcoIHYhMVy4WSc5ha8XqOxAo2cfWvKGN0jMiW3H3IebLdcFpd7Q==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-jsx-runtime": "^9.4.2",
+                "@fluentui/react-jsx-runtime": "^9.4.3",
                 "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-utilities": "^9.26.3",
+                "@fluentui/react-utilities": "^9.26.4",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1"
             },
@@ -5001,29 +5136,22 @@
             }
         },
         "node_modules/@microsoft/decorators": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.22.2.tgz",
+            "integrity": "sha512-UMj1l4IxQaVcWI5dGQAXvyPySBFk5SH/vfQUOP2F0OQ6wEyuzKRzcI1gtvoZnBQ9wx3Wf2GxjbrrtVy1Duf7eg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/decorators/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/decorators/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/decorators/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/eslint-config-spfx": {
@@ -5337,22 +5465,24 @@
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-application-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.22.2.tgz",
+            "integrity": "sha512-nHOHFImcYEGhDWq4dnFiivVk7Q26+cGsybyCwtP8X3bjfWmR964nwnJWB+NjIyqoFZolWzoDna2/w2Mpf5AsRA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-extension-base": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@microsoft/sp-search-extensibility": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-extension-base": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@microsoft/sp-search-extensibility": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5360,19 +5490,21 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-component-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.22.2.tgz",
+            "integrity": "sha512-M7V6VGTHvsyGH9pcsskMs4dFdrHmp1Eg/R1Akw1bmQCLaWwUTWIl19J0jPsC26DPnzITbkcLDrKmXcqcp6dwpw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5380,11 +5512,13 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5398,14 +5532,16 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5413,14 +5549,16 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-http": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.22.2.tgz",
+            "integrity": "sha512-749sgOG1QABJEEVgoDBoTXkeYR8W7Ythx18AHo3tvtwgCV3O1Shx9RjWbww7PwS3EglwKw5f50Ou7cAB7BWRFg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-http-msgraph": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-http-msgraph": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5428,15 +5566,17 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-http-msgraph": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.22.2.tgz",
+            "integrity": "sha512-sjM1ENHHkXrGSmpWxtbrGlz2MIh4RgHrMl1lkBzzWGHtK5GOxx7x5PxS8nfd0OLVqBOnc/xFu7PAryhBeyShUA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
                 "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "peerDependencies": {
@@ -5444,20 +5584,22 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-loader": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.22.2.tgz",
+            "integrity": "sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@rushstack/loader-raw-script": "1.4.92",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@rushstack/loader-raw-script": "1.5.2",
+                "@swc/helpers": "^0.5.12",
                 "@types/requirejs": "2.1.29",
                 "raw-loader": "~0.5.1",
                 "react": "17.0.1",
@@ -5474,10 +5616,12 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -5486,26 +5630,30 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5513,14 +5661,18 @@
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@rushstack/loader-raw-script": {
-            "version": "1.4.92",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.5.2.tgz",
+            "integrity": "sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
             }
         },
         "node_modules/@microsoft/sp-application-base/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -5541,19 +5693,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-application-base/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-application-base/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-application-base/node_modules/ajv": {
+        "node_modules/@microsoft/sp-application-base/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -5566,8 +5709,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-application-base/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-application-base/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -5580,6 +5725,8 @@
         },
         "node_modules/@microsoft/sp-application-base/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -5593,8 +5740,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-application-base/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-application-base/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-component-base": {
@@ -5692,16 +5857,18 @@
             }
         },
         "node_modules/@microsoft/sp-dialog": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dialog/-/sp-dialog-1.22.2.tgz",
+            "integrity": "sha512-onISHeL5n5FLomCbHQOf6RzZggjL7ex4x2xtF45yodtg0YHC4aofpu0Th8oDj6kl5PqFiED99oXYXCnu2XHouA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@fluentui/react-migration-v8-v9": "^9.6.49",
-                "@microsoft/sp-application-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@fluentui/react-migration-v8-v9": "^9.8.5",
+                "@microsoft/sp-application-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "react": "17.0.1",
                 "react-dom": "17.0.1",
                 "tslib": "2.3.1"
@@ -5715,11 +5882,13 @@
             }
         },
         "node_modules/@microsoft/sp-dialog/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5733,18 +5902,22 @@
             }
         },
         "node_modules/@microsoft/sp-dialog/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-dialog/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -5765,19 +5938,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-dialog/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-dialog/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-dialog/node_modules/ajv": {
+        "node_modules/@microsoft/sp-dialog/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -5790,8 +5954,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-dialog/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-dialog/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -5804,6 +5970,8 @@
         },
         "node_modules/@microsoft/sp-dialog/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -5817,8 +5985,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-dialog/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-dialog/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-dynamic-data": {
@@ -5843,15 +6029,17 @@
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-extension-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.22.2.tgz",
+            "integrity": "sha512-NiQtBMvnW+MCiGYCZW9wGeMtcs6uY0ArwXaHSvxK4DwH/lOZ3leVS258/PGr/9MkfwTx9JRbErk0pmwAAQ/J2g==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5859,19 +6047,21 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-component-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.22.2.tgz",
+            "integrity": "sha512-M7V6VGTHvsyGH9pcsskMs4dFdrHmp1Eg/R1Akw1bmQCLaWwUTWIl19J0jPsC26DPnzITbkcLDrKmXcqcp6dwpw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5879,11 +6069,13 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5897,14 +6089,16 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5912,14 +6106,16 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-http": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.22.2.tgz",
+            "integrity": "sha512-749sgOG1QABJEEVgoDBoTXkeYR8W7Ythx18AHo3tvtwgCV3O1Shx9RjWbww7PwS3EglwKw5f50Ou7cAB7BWRFg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-http-msgraph": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-http-msgraph": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -5927,15 +6123,17 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-http-msgraph": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.22.2.tgz",
+            "integrity": "sha512-sjM1ENHHkXrGSmpWxtbrGlz2MIh4RgHrMl1lkBzzWGHtK5GOxx7x5PxS8nfd0OLVqBOnc/xFu7PAryhBeyShUA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
                 "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "peerDependencies": {
@@ -5943,20 +6141,22 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-loader": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.22.2.tgz",
+            "integrity": "sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@rushstack/loader-raw-script": "1.4.92",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@rushstack/loader-raw-script": "1.5.2",
+                "@swc/helpers": "^0.5.12",
                 "@types/requirejs": "2.1.29",
                 "raw-loader": "~0.5.1",
                 "react": "17.0.1",
@@ -5973,10 +6173,12 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -5985,26 +6187,30 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6012,14 +6218,18 @@
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@rushstack/loader-raw-script": {
-            "version": "1.4.92",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.5.2.tgz",
+            "integrity": "sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
             }
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -6040,19 +6250,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-extension-base/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-extension-base/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-extension-base/node_modules/ajv": {
+        "node_modules/@microsoft/sp-extension-base/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -6065,8 +6266,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-extension-base/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-extension-base/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -6079,6 +6282,8 @@
         },
         "node_modules/@microsoft/sp-extension-base/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -6092,8 +6297,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-extension-base/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-extension-base/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-http": {
@@ -6114,24 +6337,28 @@
             }
         },
         "node_modules/@microsoft/sp-http-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http-base/-/sp-http-base-1.22.2.tgz",
+            "integrity": "sha512-yiDnIQY6XJCbzuQ9bIyvkgd2Ts+GP8AxnilvI3AwWffOtwfrpqkrJtdkgSGf567/KvkJJHnG2cvLwYWimrwf2w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
                 "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.32.0",
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "adal-angular": "1.0.16",
                 "tslib": "2.3.1"
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6145,14 +6372,16 @@
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6160,10 +6389,12 @@
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -6172,26 +6403,30 @@
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6199,7 +6434,9 @@
             }
         },
         "node_modules/@microsoft/sp-http-base/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -6220,19 +6457,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-http-base/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-http-base/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-http-base/node_modules/ajv": {
+        "node_modules/@microsoft/sp-http-base/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -6245,8 +6473,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-http-base/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-http-base/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -6259,6 +6489,8 @@
         },
         "node_modules/@microsoft/sp-http-base/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -6272,8 +6504,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-http-base/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-http-base/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-http-msgraph": {
@@ -6414,14 +6664,16 @@
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-listview-extensibility": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-listview-extensibility/-/sp-listview-extensibility-1.22.2.tgz",
+            "integrity": "sha512-5TF+QBgSrCUn03y4ViZGFSBMF4zcLVFHQjRy/q0s6RSheROsafj7rce+oyM9rSsepN2F1NBguiq0YG7NuS+Ucw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-extension-base": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-extension-base": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6429,11 +6681,13 @@
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6447,14 +6701,16 @@
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6462,10 +6718,12 @@
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -6474,26 +6732,30 @@
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6501,7 +6763,9 @@
             }
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -6522,19 +6786,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-listview-extensibility/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-listview-extensibility/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-listview-extensibility/node_modules/ajv": {
+        "node_modules/@microsoft/sp-listview-extensibility/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -6547,8 +6802,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-listview-extensibility/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-listview-extensibility/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -6561,6 +6818,8 @@
         },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -6574,8 +6833,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-listview-extensibility/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-listview-extensibility/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-loader": {
@@ -6703,36 +6980,31 @@
             }
         },
         "node_modules/@microsoft/sp-odata-types": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.22.2.tgz",
+            "integrity": "sha512-gtru9lV74B1/padXRaMf0dZNgnZpbABIc83idq4QYH9jHBdKmcdfnNbaSgUWALXHHeHBDA5Xani2YjYjxrF3EQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/sp-odata-types/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-odata-types/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-odata-types/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-office-ui-fabric-core": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.22.2.tgz",
+            "integrity": "sha512-vf3bzrGw1FYAorzfbUiAJTe0tG7CZ1mVSdoNiUGOjMR8kqCyn1DO7L4zr94P/AyLoqyJWavucraOVLgS/xtpOg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "office-ui-fabric-core": "11.0.1",
                 "tslib": "2.3.1"
             },
@@ -6740,23 +7012,16 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@microsoft/sp-office-ui-fabric-core/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-office-ui-fabric-core/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@microsoft/sp-office-ui-fabric-core/node_modules/office-ui-fabric-core": {
             "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-11.0.1.tgz",
+            "integrity": "sha512-jcfycbVOm2aUoI+AGtHW24HvM7nUVFr44hR5NIE56EobK67bVwbNAQL15CJj3vNz5PBrnitsV9ROOB+KOEWn8g==",
             "license": "MIT"
         },
         "node_modules/@microsoft/sp-office-ui-fabric-core/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-page-context": {
@@ -6845,14 +7110,16 @@
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-search-extensibility": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-search-extensibility/-/sp-search-extensibility-1.22.2.tgz",
+            "integrity": "sha512-mxJ5NseQz0zBKf6OdVR7FDJFr3tNbWDxanoNQTitLWb6suEteCWK5Fx/sNvzGJBuv5McijGXaaIj8atlsX2vIg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-extension-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-extension-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6860,11 +7127,13 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6878,14 +7147,16 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6893,20 +7164,22 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-loader": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.22.2.tgz",
+            "integrity": "sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@rushstack/loader-raw-script": "1.4.92",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@rushstack/loader-raw-script": "1.5.2",
+                "@swc/helpers": "^0.5.12",
                 "@types/requirejs": "2.1.29",
                 "raw-loader": "~0.5.1",
                 "react": "17.0.1",
@@ -6923,10 +7196,12 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -6935,26 +7210,30 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -6962,14 +7241,18 @@
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@rushstack/loader-raw-script": {
-            "version": "1.4.92",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.5.2.tgz",
+            "integrity": "sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
             }
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -6990,19 +7273,10 @@
                 }
             }
         },
-        "node_modules/@microsoft/sp-search-extensibility/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@microsoft/sp-search-extensibility/node_modules/@swc/helpers/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@microsoft/sp-search-extensibility/node_modules/ajv": {
+        "node_modules/@microsoft/sp-search-extensibility/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -7015,8 +7289,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@microsoft/sp-search-extensibility/node_modules/ajv-draft-04": {
+        "node_modules/@microsoft/sp-search-extensibility/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -7029,6 +7305,8 @@
         },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -7042,8 +7320,26 @@
                 }
             }
         },
+        "node_modules/@microsoft/sp-search-extensibility/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@microsoft/sp-search-extensibility/node_modules/tslib": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "license": "0BSD"
         },
         "node_modules/@microsoft/sp-top-actions": {
@@ -7414,6 +7710,9 @@
         "node_modules/@microsoft/teams-js-v2": {
             "name": "@microsoft/teams-js",
             "version": "2.32.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-2.32.0.tgz",
+            "integrity": "sha512-ZKfQtbGRZisvdUdxt8iiX7uRlrB14fIQiB3+zV76CJoLDSMD1WqB4qlP8pgrKHyG2HjCI1TC3/wuKXGLjrOT2g==",
+            "deprecated": "Package no longer supported. Use at your own risk",
             "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.3.1",
@@ -7612,17 +7911,6 @@
             "version": "2.3.0",
             "license": "0BSD"
         },
-        "node_modules/@pnp/logging": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "1.10.0"
-            }
-        },
-        "node_modules/@pnp/logging/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
         "node_modules/@pnp/modern-search-extensibility": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@pnp/modern-search-extensibility/-/modern-search-extensibility-2.0.1.tgz",
@@ -7725,7 +8013,9 @@
             "license": "0BSD"
         },
         "node_modules/@pnp/spfx-controls-react": {
-            "version": "3.23.0",
+            "version": "3.24.0",
+            "resolved": "https://registry.npmjs.org/@pnp/spfx-controls-react/-/spfx-controls-react-3.24.0.tgz",
+            "integrity": "sha512-rVZXGBFTbijeIU5WiUHD/wPj7oHQntQRZe2OyPydIu2EA40waAvFJPcNtDyLRcOVytT24K3XO81zSWq3ztL6pw==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -7745,23 +8035,23 @@
                 "@fluentui/theme": "^2.6.6",
                 "@iconify/react": "^4.1.1",
                 "@juggle/resize-observer": "3.4.0",
-                "@microsoft/decorators": "1.21.1",
+                "@microsoft/decorators": "1.22.2",
                 "@microsoft/mgt-react": "3.1.3",
                 "@microsoft/mgt-spfx": "3.1.3",
-                "@microsoft/sp-adaptive-card-extension-base": "1.21.1",
-                "@microsoft/sp-application-base": "1.21.1",
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-dialog": "1.21.1",
-                "@microsoft/sp-extension-base": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-listview-extensibility": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-office-ui-fabric-core": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
-                "@microsoft/sp-webpart-base": "1.21.1",
+                "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
+                "@microsoft/sp-application-base": "1.22.2",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-dialog": "1.22.2",
+                "@microsoft/sp-extension-base": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-listview-extensibility": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
+                "@microsoft/sp-webpart-base": "1.22.2",
                 "@monaco-editor/loader": "^1.3.1",
                 "@nuvemerudita/react-controls": "1.0.0",
                 "@pnp/common": "2.5.0",
@@ -7781,9 +8071,9 @@
                 "date-fns": "^2.22.1",
                 "he": "^1.2.0",
                 "jotai": "^2.4.2",
-                "lodash": "4.17.21",
+                "lodash": "4.17.23",
                 "maplibre-gl": "^5.6.1",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^14.1.1",
                 "monaco-editor": "^0.29.1",
                 "nano-css": "^5.3.4",
                 "pmtiles": "^4.3.0",
@@ -7834,6 +8124,19 @@
                 "@types/react-dom": ">=16.8.0 <19.0.0",
                 "react": ">=16.8.0 <19.0.0",
                 "react-dom": ">=16.8.0 <19.0.0"
+            }
+        },
+        "node_modules/@pnp/spfx-controls-react/node_modules/@fluentui/react-icons": {
+            "version": "2.0.306",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.306.tgz",
+            "integrity": "sha512-zS66O59F8gvwjaaIchguMVTwmI3qplwJrm5F8c17rfdrqtFhJKMM2Udef6DWHA7XtnQA8OfvYz2GGrE+GBy/KA==",
+            "license": "MIT",
+            "dependencies": {
+                "@griffel/react": "^1.0.0",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 <19.0.0"
             }
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@iconify/react": {
@@ -7896,20 +8199,22 @@
             "version": "0.29.0-preview"
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-adaptive-card-extension-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-adaptive-card-extension-base/-/sp-adaptive-card-extension-base-1.22.2.tgz",
+            "integrity": "sha512-bCsV0HaerAMFdpyB75+68rsCtL4ZNRvIdlGK26GY6ze9rewXCT2NmMnKH60UrTh7KXdqbZZE4yy6r2JJTHt3xA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
                 "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.32.0",
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "adaptivecards": "2.11.2",
                 "tslib": "2.3.1"
             },
@@ -7917,24 +8222,22 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-adaptive-card-extension-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.22.2.tgz",
+            "integrity": "sha512-M7V6VGTHvsyGH9pcsskMs4dFdrHmp1Eg/R1Akw1bmQCLaWwUTWIl19J0jPsC26DPnzITbkcLDrKmXcqcp6dwpw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -7943,30 +8246,30 @@
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/merge-styles": {
             "version": "8.6.14",
+            "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
+            "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/set-version": "^8.2.24",
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/merge-styles/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -7979,20 +8282,14 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-component-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8005,38 +8302,34 @@
                 "react-dom": ">=16.13.1 <18.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-core-library/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-dynamic-data/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-http": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.22.2.tgz",
+            "integrity": "sha512-749sgOG1QABJEEVgoDBoTXkeYR8W7Ythx18AHo3tvtwgCV3O1Shx9RjWbww7PwS3EglwKw5f50Ou7cAB7BWRFg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-http-msgraph": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-http-msgraph": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8044,40 +8337,36 @@
             }
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-http-msgraph": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.22.2.tgz",
+            "integrity": "sha512-sjM1ENHHkXrGSmpWxtbrGlz2MIh4RgHrMl1lkBzzWGHtK5GOxx7x5PxS8nfd0OLVqBOnc/xFu7PAryhBeyShUA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
                 "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "peerDependencies": {
                 "@microsoft/microsoft-graph-client": "3.0.2"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-http-msgraph/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-http/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-image-helper": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.22.2.tgz",
+            "integrity": "sha512-gB59OtaAkSv4TuBA/CZxEGGhBeD/yAIvDCfs3EkOHM+4cV7pPsW4zVV9+ei7e/kzH79rril+1KCPFIUJKM44CQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8090,25 +8379,23 @@
                 "react-dom": ">=16.13.1 <18.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-image-helper/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.22.2.tgz",
+            "integrity": "sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@rushstack/loader-raw-script": "1.4.92",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@rushstack/loader-raw-script": "1.5.2",
+                "@swc/helpers": "^0.5.12",
                 "@types/requirejs": "2.1.29",
                 "raw-loader": "~0.5.1",
                 "react": "17.0.1",
@@ -8126,30 +8413,30 @@
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader/node_modules/@fluentui/merge-styles": {
             "version": "8.6.14",
+            "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
+            "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/set-version": "^8.2.24",
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader/node_modules/@fluentui/merge-styles/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8162,19 +8449,13 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-loader/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -8182,58 +8463,56 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-lodash-subset/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-page-context/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.22.2.tgz",
+            "integrity": "sha512-xHargjpw98gFaJ8kwDffTp0RrimKPfyXbdI3PmPCEfWPBqr3cOl88gENH5j6jcGo3lTbphy+NXv/wUTgWz22Vw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@fluentui/react-icons": "~2.0.258",
-                "@fluentui/react-tabster": "^9.23.3",
-                "@fluentui/utilities": "^8.15.19",
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-image-helper": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@fluentui/react-icons": "2.0.306",
+                "@fluentui/react-tabster": "^9.25.3",
+                "@fluentui/utilities": "^8.15.22",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-image-helper": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "react": "17.0.1",
                 "react-dom": "17.0.1",
                 "tslib": "2.3.1"
@@ -8248,30 +8527,30 @@
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/merge-styles": {
             "version": "8.6.14",
+            "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
+            "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/set-version": "^8.2.24",
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/merge-styles/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8284,36 +8563,35 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-property-pane/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-top-actions": {
-            "version": "1.21.1",
-            "license": "https://aka.ms/spfx/license"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-top-actions/-/sp-top-actions-1.22.2.tgz",
+            "integrity": "sha512-8Gl+lZbAgRZ5vTjIiCpG2GMyjNPgAoDwKm2ZHaxowfYFg6GTOnb9EnfoSRJpfl8oNQuXWIT1q+ujE9doc4t/nQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
-                "@microsoft/sp-top-actions": "1.21.1",
+                "@swc/helpers": "^0.5.12"
+            }
+        },
+        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base": {
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.22.2.tgz",
+            "integrity": "sha512-HjaVBbjePR3etkdy8VCXiytHzwOXK8gIefZSQJAPXpfYGNJHgjbVDoNfoV+QFA5FxKFFB8ASLH96HE93y1YBsQ==",
+            "license": "https://aka.ms/spfx/license",
+            "dependencies": {
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
+                "@microsoft/sp-top-actions": "1.22.2",
                 "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.32.0",
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/office-js": "1.0.36",
                 "react": "17.0.1",
                 "react-dom": "17.0.1",
@@ -8329,30 +8607,30 @@
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/merge-styles": {
             "version": "8.6.14",
+            "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
+            "integrity": "sha512-vghuHFAfQgS9WLIIs4kgDOCh/DHd5vGIddP4/bzposhlAVLZR6wUBqldm9AuCdY88r5LyCRMavVJLV+Up3xdvA==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/set-version": "^8.2.24",
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/merge-styles/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8364,14 +8642,6 @@
                 "react": ">=16.8.0 <20.0.0",
                 "react-dom": ">=16.8.0 <20.0.0"
             }
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@microsoft/sp-webpart-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@pnp/common": {
             "version": "2.5.0",
@@ -8389,14 +8659,18 @@
             "license": "0BSD"
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@rushstack/loader-raw-script": {
-            "version": "1.4.92",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.5.2.tgz",
+            "integrity": "sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
             }
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -8417,15 +8691,10 @@
                 }
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@pnp/spfx-controls-react/node_modules/ajv": {
+        "node_modules/@pnp/spfx-controls-react/node_modules/@rushstack/node-core-library/node_modules/ajv": {
             "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -8438,8 +8707,10 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@pnp/spfx-controls-react/node_modules/ajv-draft-04": {
+        "node_modules/@pnp/spfx-controls-react/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^8.5.0"
@@ -8452,6 +8723,8 @@
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/ajv-formats": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -8463,6 +8736,22 @@
                 "ajv": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@pnp/spfx-controls-react/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/@pnp/spfx-controls-react/node_modules/idb": {
@@ -8509,26 +8798,28 @@
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
+        "node_modules/@pnp/spfx-controls-react/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "license": "0BSD"
+        },
         "node_modules/@pnp/spfx-property-controls": {
-            "version": "3.22.0",
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.23.0.tgz",
+            "integrity": "sha512-iq3Nyv+/lQeNLbDuRUtq7zZ8XEWQA+HcOg8zCypSg+iVFiL4q47PfH9LU6DQypNL7NxhmX8gBWG125EX39/bUw==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react": "8.106.4",
                 "@fluentui/react-components": "^9.48.0",
-                "@microsoft/sp-adaptive-card-extension-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-office-ui-fabric-core": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
-                "@microsoft/sp-webpart-base": "1.21.1",
+                "@microsoft/sp-adaptive-card-extension-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-office-ui-fabric-core": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
+                "@microsoft/sp-webpart-base": "1.22.2",
                 "@monaco-editor/loader": "^1.2.0",
-                "@pnp/common": "1.3.11",
-                "@pnp/logging": "1.3.11",
-                "@pnp/odata": "1.3.11",
-                "@pnp/sp": "1.3.11",
-                "@pnp/sp-clientsvc": "1.3.11",
-                "@pnp/sp-taxonomy": "1.3.11",
                 "@pnp/telemetry-js": "2.0.0",
                 "@uifabric/icons": "7.5.17",
                 "brace": "0.11.1",
@@ -8569,6 +8860,19 @@
                 "react-dom": ">=16.8.0 <19.0.0"
             }
         },
+        "node_modules/@pnp/spfx-property-controls/node_modules/@fluentui/react-icons": {
+            "version": "2.0.306",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.306.tgz",
+            "integrity": "sha512-zS66O59F8gvwjaaIchguMVTwmI3qplwJrm5F8c17rfdrqtFhJKMM2Udef6DWHA7XtnQA8OfvYz2GGrE+GBy/KA==",
+            "license": "MIT",
+            "dependencies": {
+                "@griffel/react": "^1.0.0",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 <19.0.0"
+            }
+        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@fluentui/react/node_modules/@fluentui/merge-styles": {
             "version": "8.5.12",
             "license": "MIT",
@@ -8578,20 +8882,22 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-adaptive-card-extension-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-adaptive-card-extension-base/-/sp-adaptive-card-extension-base-1.22.2.tgz",
+            "integrity": "sha512-bCsV0HaerAMFdpyB75+68rsCtL4ZNRvIdlGK26GY6ze9rewXCT2NmMnKH60UrTh7KXdqbZZE4yy6r2JJTHt3xA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
                 "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.32.0",
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "adaptivecards": "2.11.2",
                 "tslib": "2.3.1"
             },
@@ -8599,24 +8905,22 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-adaptive-card-extension-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-component-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.22.2.tgz",
+            "integrity": "sha512-M7V6VGTHvsyGH9pcsskMs4dFdrHmp1Eg/R1Akw1bmQCLaWwUTWIl19J0jPsC26DPnzITbkcLDrKmXcqcp6dwpw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8624,19 +8928,21 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8649,20 +8955,14 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-component-base/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-component-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-core-library": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.22.2.tgz",
+            "integrity": "sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8675,38 +8975,34 @@
                 "react-dom": ">=16.13.1 <18.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-core-library/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-dynamic-data": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.22.2.tgz",
+            "integrity": "sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-dynamic-data/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-http": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.22.2.tgz",
+            "integrity": "sha512-749sgOG1QABJEEVgoDBoTXkeYR8W7Ythx18AHo3tvtwgCV3O1Shx9RjWbww7PwS3EglwKw5f50Ou7cAB7BWRFg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-http-msgraph": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-http-msgraph": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8714,40 +9010,36 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-http-msgraph": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.22.2.tgz",
+            "integrity": "sha512-sjM1ENHHkXrGSmpWxtbrGlz2MIh4RgHrMl1lkBzzWGHtK5GOxx7x5PxS8nfd0OLVqBOnc/xFu7PAryhBeyShUA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
                 "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "peerDependencies": {
                 "@microsoft/microsoft-graph-client": "3.0.2"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-http-msgraph/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-http/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-image-helper": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.22.2.tgz",
+            "integrity": "sha512-gB59OtaAkSv4TuBA/CZxEGGhBeD/yAIvDCfs3EkOHM+4cV7pPsW4zVV9+ei7e/kzH79rril+1KCPFIUJKM44CQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
@@ -8760,25 +9052,23 @@
                 "react-dom": ">=16.13.1 <18.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-image-helper/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-loader": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.22.2.tgz",
+            "integrity": "sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@rushstack/loader-raw-script": "1.4.92",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@rushstack/loader-raw-script": "1.5.2",
+                "@swc/helpers": "^0.5.12",
                 "@types/requirejs": "2.1.29",
                 "raw-loader": "~0.5.1",
                 "react": "17.0.1",
@@ -8795,19 +9085,21 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-loader/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8820,19 +9112,13 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-loader/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-loader/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-lodash-subset": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.22.2.tgz",
+            "integrity": "sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/lodash": "4.14.117",
                 "tslib": "2.3.1"
             },
@@ -8840,58 +9126,56 @@
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-lodash-subset/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-module-interfaces": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.22.2.tgz",
+            "integrity": "sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
-                "z-schema": "6.0.2"
+                "@rushstack/node-core-library": "5.17.1",
+                "ajv": "^6.12.5"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-page-context": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.22.2.tgz",
+            "integrity": "sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-odata-types": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-odata-types": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "tslib": "2.3.1"
             },
             "engines": {
                 "node": ">=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-page-context/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-property-pane": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.22.2.tgz",
+            "integrity": "sha512-xHargjpw98gFaJ8kwDffTp0RrimKPfyXbdI3PmPCEfWPBqr3cOl88gENH5j6jcGo3lTbphy+NXv/wUTgWz22Vw==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@fluentui/react-components": "^9.58.3",
-                "@fluentui/react-icons": "~2.0.258",
-                "@fluentui/react-tabster": "^9.23.3",
-                "@fluentui/utilities": "^8.15.19",
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-dynamic-data": "1.21.1",
-                "@microsoft/sp-image-helper": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@swc/helpers": "0.5.12",
+                "@fluentui/react": "^8.123.1",
+                "@fluentui/react-components": "^9.66.5",
+                "@fluentui/react-icons": "2.0.306",
+                "@fluentui/react-tabster": "^9.25.3",
+                "@fluentui/utilities": "^8.15.22",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-dynamic-data": "1.22.2",
+                "@microsoft/sp-image-helper": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@swc/helpers": "^0.5.12",
                 "react": "17.0.1",
                 "react-dom": "17.0.1",
                 "tslib": "2.3.1"
@@ -8905,19 +9189,21 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8930,36 +9216,35 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-property-pane/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-property-pane/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-top-actions": {
-            "version": "1.21.1",
-            "license": "https://aka.ms/spfx/license"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-webpart-base": {
-            "version": "1.21.1",
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-top-actions/-/sp-top-actions-1.22.2.tgz",
+            "integrity": "sha512-8Gl+lZbAgRZ5vTjIiCpG2GMyjNPgAoDwKm2ZHaxowfYFg6GTOnb9EnfoSRJpfl8oNQuXWIT1q+ujE9doc4t/nQ==",
             "license": "https://aka.ms/spfx/license",
             "dependencies": {
-                "@fluentui/react": "^8.122.9",
-                "@microsoft/sp-component-base": "1.21.1",
-                "@microsoft/sp-core-library": "1.21.1",
-                "@microsoft/sp-diagnostics": "1.21.1",
-                "@microsoft/sp-http": "1.21.1",
-                "@microsoft/sp-http-base": "1.21.1",
-                "@microsoft/sp-loader": "1.21.1",
-                "@microsoft/sp-lodash-subset": "1.21.1",
-                "@microsoft/sp-module-interfaces": "1.21.1",
-                "@microsoft/sp-page-context": "1.21.1",
-                "@microsoft/sp-property-pane": "1.21.1",
-                "@microsoft/sp-top-actions": "1.21.1",
+                "@swc/helpers": "^0.5.12"
+            }
+        },
+        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-webpart-base": {
+            "version": "1.22.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.22.2.tgz",
+            "integrity": "sha512-HjaVBbjePR3etkdy8VCXiytHzwOXK8gIefZSQJAPXpfYGNJHgjbVDoNfoV+QFA5FxKFFB8ASLH96HE93y1YBsQ==",
+            "license": "https://aka.ms/spfx/license",
+            "dependencies": {
+                "@fluentui/react": "^8.123.1",
+                "@microsoft/sp-component-base": "1.22.2",
+                "@microsoft/sp-core-library": "1.22.2",
+                "@microsoft/sp-diagnostics": "1.22.2",
+                "@microsoft/sp-http": "1.22.2",
+                "@microsoft/sp-http-base": "1.22.2",
+                "@microsoft/sp-loader": "1.22.2",
+                "@microsoft/sp-lodash-subset": "1.22.2",
+                "@microsoft/sp-module-interfaces": "1.22.2",
+                "@microsoft/sp-page-context": "1.22.2",
+                "@microsoft/sp-property-pane": "1.22.2",
+                "@microsoft/sp-top-actions": "1.22.2",
                 "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.32.0",
-                "@swc/helpers": "0.5.12",
+                "@swc/helpers": "^0.5.12",
                 "@types/office-js": "1.0.36",
                 "react": "17.0.1",
                 "react-dom": "17.0.1",
@@ -8974,19 +9259,21 @@
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/react": {
-            "version": "8.125.4",
+            "version": "8.125.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.125.6.tgz",
+            "integrity": "sha512-uvq0PdAL+Tznikek54zbS31JefTqcPaCkwjHjJz0t8NAC2ZFHozKnkApaQo2+sf0390K3k1ErGWr/+3Tvc6+JQ==",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.11",
-                "@fluentui/font-icons-mdl2": "^8.5.71",
-                "@fluentui/foundation-legacy": "^8.6.4",
+                "@fluentui/font-icons-mdl2": "^8.5.73",
+                "@fluentui/foundation-legacy": "^8.6.6",
                 "@fluentui/merge-styles": "^8.6.14",
-                "@fluentui/react-focus": "^8.10.4",
+                "@fluentui/react-focus": "^8.10.6",
                 "@fluentui/react-hooks": "^8.10.2",
                 "@fluentui/react-portal-compat-context": "^9.0.15",
                 "@fluentui/react-window-provider": "^2.3.2",
                 "@fluentui/set-version": "^8.2.24",
-                "@fluentui/style-utilities": "^8.14.0",
+                "@fluentui/style-utilities": "^8.15.1",
                 "@fluentui/theme": "^2.7.2",
                 "@fluentui/utilities": "^8.17.2",
                 "@microsoft/load-themed-styles": "^1.10.26",
@@ -8999,101 +9286,19 @@
                 "react-dom": ">=16.8.0 <20.0.0"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-webpart-base/node_modules/@fluentui/react/node_modules/tslib": {
-            "version": "2.8.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@microsoft/sp-webpart-base/node_modules/tslib": {
-            "version": "2.3.1",
-            "license": "0BSD"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/common": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "adal-angular": "1.0.17",
-                "tslib": "1.10.0"
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/common/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/odata": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "1.10.0"
-            },
-            "peerDependencies": {
-                "@pnp/common": "1.3.11",
-                "@pnp/logging": "1.3.11"
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/odata/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "1.10.0"
-            },
-            "peerDependencies": {
-                "@pnp/common": "1.3.11",
-                "@pnp/logging": "1.3.11",
-                "@pnp/odata": "1.3.11"
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp-clientsvc": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "1.10.0"
-            },
-            "peerDependencies": {
-                "@pnp/common": "1.3.11",
-                "@pnp/logging": "1.3.11",
-                "@pnp/odata": "1.3.11",
-                "@pnp/sp": "1.3.11"
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp-clientsvc/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp-taxonomy": {
-            "version": "1.3.11",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "1.10.0"
-            },
-            "peerDependencies": {
-                "@pnp/common": "1.3.11",
-                "@pnp/logging": "1.3.11",
-                "@pnp/odata": "1.3.11",
-                "@pnp/sp": "1.3.11",
-                "@pnp/sp-clientsvc": "1.3.11"
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp-taxonomy/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@pnp/sp/node_modules/tslib": {
-            "version": "1.10.0",
-            "license": "Apache-2.0"
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/@rushstack/loader-raw-script": {
-            "version": "1.4.92",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.5.2.tgz",
+            "integrity": "sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==",
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.17.1.tgz",
+            "integrity": "sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "~8.13.0",
@@ -9114,11 +9319,34 @@
                 }
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/@swc/helpers": {
-            "version": "0.5.12",
-            "license": "Apache-2.0",
+        "node_modules/@pnp/spfx-property-controls/node_modules/@rushstack/node-core-library/node_modules/ajv": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "license": "MIT",
             "dependencies": {
-                "tslib": "^2.4.0"
+                "fast-deep-equal": "^3.1.3",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.4.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@pnp/spfx-property-controls/node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@pnp/spfx-property-controls/node_modules/@uifabric/icons": {
@@ -9134,57 +9362,48 @@
             "version": "1.14.1",
             "license": "0BSD"
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/adal-angular": {
-            "version": "1.0.17",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8.0"
+        "node_modules/@pnp/spfx-property-controls/node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/ajv": {
-            "version": "8.13.0",
+        "node_modules/@pnp/spfx-property-controls/node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.4.1"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@pnp/spfx-property-controls/node_modules/ajv-draft-04": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "peerDependencies": {
-                "ajv": "^8.5.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@pnp/spfx-property-controls/node_modules/ajv-formats": {
-            "version": "3.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@pnp/spfx-property-controls/node_modules/monaco-editor": {
             "version": "0.32.1",
             "license": "MIT"
+        },
+        "node_modules/@pnp/spfx-property-controls/node_modules/tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "license": "0BSD"
         },
         "node_modules/@pnp/telemetry-js": {
             "version": "2.0.0",
@@ -12338,7 +12557,6 @@
         },
         "node_modules/ajv": {
             "version": "6.15.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -12392,7 +12610,6 @@
         },
         "node_modules/ajv/node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/animate.css": {
@@ -14334,6 +14551,8 @@
         },
         "node_modules/embla-carousel-autoplay": {
             "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+            "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
             "license": "MIT",
             "peerDependencies": {
                 "embla-carousel": "8.6.0"
@@ -14341,6 +14560,8 @@
         },
         "node_modules/embla-carousel-fade": {
             "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+            "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
             "license": "MIT",
             "peerDependencies": {
                 "embla-carousel": "8.6.0"
@@ -15183,7 +15404,6 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -18340,7 +18560,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
@@ -23163,13 +23385,6 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/validator": {
-            "version": "13.15.22",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/varint": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
@@ -23968,32 +24183,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/z-schema": {
-            "version": "6.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "lodash.get": "^4.4.2",
-                "lodash.isequal": "^4.5.0",
-                "validator": "^13.7.0"
-            },
-            "bin": {
-                "z-schema": "bin/z-schema"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "optionalDependencies": {
-                "commander": "^11.0.0"
-            }
-        },
-        "node_modules/z-schema/node_modules/commander": {
-            "version": "11.1.0",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=16"
             }
         }
     }

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -32,8 +32,8 @@
         "@microsoft/sp-webpart-base": "1.23.0",
         "@pnp/common": "2.15.0",
         "@pnp/modern-search-extensibility": "2.0.1",
-        "@pnp/spfx-controls-react": "3.23.0",
-        "@pnp/spfx-property-controls": "3.22.0",
+        "@pnp/spfx-controls-react": "3.24.0",
+        "@pnp/spfx-property-controls": "3.23.0",
         "@pnp/telemetry-js": "2.0.0",
         "adaptive-expressions": "4.23.3",
         "adaptivecards": "2.11.2",
@@ -118,18 +118,6 @@
         "@rushstack/heft": "1.2.17",
         "chalk": {
             "ansi-styles": "^4.3.0"
-        },
-        "@pnp/spfx-property-controls@3.22.0": {
-            "@pnp/common": "1.3.11"
-        },
-        "@pnp/odata@1.3.11": {
-            "@pnp/common": "1.3.11"
-        },
-        "@pnp/sp@1.3.11": {
-            "@pnp/common": "1.3.11"
-        },
-        "@pnp/sp-clientsvc@1.3.11": {
-            "@pnp/common": "1.3.11"
         }
     },
     "pnpm": {
@@ -150,10 +138,6 @@
             "adaptive-expressions": "4.23.3",
             "adaptivecards": "2.11.2",
             "adaptivecards-templating": "2.3.1",
-            "@pnp/spfx-property-controls@3.22.0 > @pnp/common": "1.3.11",
-            "@pnp/odata@1.3.11 > @pnp/common": "1.3.11",
-            "@pnp/sp@1.3.11 > @pnp/common": "1.3.11",
-            "@pnp/sp-clientsvc@1.3.11 > @pnp/common": "1.3.11",
             "@lit/task": "1.0.1",
             "@microsoft/mgt-spfx": "3.1.3",
             "micromatch": "4.0.8",

--- a/search-parts/pnpm-lock.yaml
+++ b/search-parts/pnpm-lock.yaml
@@ -22,10 +22,6 @@ overrides:
   adaptive-expressions: 4.23.3
   adaptivecards: 2.11.2
   adaptivecards-templating: 2.3.1
-  '@pnp/spfx-property-controls@3.22.0 > @pnp/common': 1.3.11
-  '@pnp/odata@1.3.11 > @pnp/common': 1.3.11
-  '@pnp/sp@1.3.11 > @pnp/common': 1.3.11
-  '@pnp/sp-clientsvc@1.3.11 > @pnp/common': 1.3.11
   '@lit/task': 1.0.1
   '@microsoft/mgt-spfx': 3.1.3
   micromatch: 4.0.8
@@ -109,11 +105,11 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@pnp/spfx-controls-react':
-        specifier: 3.23.0
-        version: 3.23.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+        specifier: 3.24.0
+        version: 3.24.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
       '@pnp/spfx-property-controls':
-        specifier: 3.22.0
-        version: 3.22.0(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)(swiper@8.4.7)
+        specifier: 3.23.0
+        version: 3.23.0(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)(swiper@8.4.7)
       '@pnp/telemetry-js':
         specifier: 2.0.0
         version: 2.0.0
@@ -180,10 +176,10 @@ importers:
         version: 1.23.0(@types/node@25.9.1)
       '@microsoft/spfx-heft-plugins':
         specifier: 1.23.0
-        version: 1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(postcss@8.5.15)
+        version: 1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
       '@microsoft/spfx-web-build-rig':
         specifier: 1.23.0
-        version: 1.23.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(jest-environment-node@30.3.0)(postcss@8.5.15)(tslib@2.8.1)
+        version: 1.23.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(jest-environment-node@30.3.0)(tslib@2.8.1)
       '@rushstack/heft':
         specifier: 1.2.17
         version: 1.2.17(@types/node@25.9.1)
@@ -204,10 +200,10 @@ importers:
         version: 2.1.0
       babel-loader:
         specifier: 8.4.1
-        version: 8.4.1(@babel/core@7.29.0)(webpack@5.102.1(postcss@8.5.15))
+        version: 8.4.1(@babel/core@7.29.0)(webpack@5.102.1)
       css-loader:
         specifier: 7.1.3
-        version: 7.1.3(webpack@5.102.1(postcss@8.5.15))
+        version: 7.1.3(webpack@5.102.1)
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -216,7 +212,7 @@ importers:
         version: 5.2.0(eslint@9.37.0)
       html-loader:
         specifier: 4.2.0
-        version: 4.2.0(webpack@5.102.1(postcss@8.5.15))
+        version: 4.2.0(webpack@5.102.1)
       ignore-loader:
         specifier: 0.1.2
         version: 0.1.2
@@ -246,7 +242,7 @@ importers:
         version: 0.12.5
       webpack:
         specifier: 5.102.1
-        version: 5.102.1(postcss@8.5.15)
+        version: 5.102.1
       webpack-bundle-analyzer:
         specifier: 5.2.0
         version: 5.2.0
@@ -886,6 +882,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17
       react-dom: ^16.8.0 || ^17
+
+  '@fluentui/react-icons@2.0.306':
+    resolution: {integrity: sha512-zS66O59F8gvwjaaIchguMVTwmI3qplwJrm5F8c17rfdrqtFhJKMM2Udef6DWHA7XtnQA8OfvYz2GGrE+GBy/KA==}
+    peerDependencies:
+      react: '>=16.8.0 <19.0.0'
 
   '@fluentui/react-icons@2.0.314':
     resolution: {integrity: sha512-oIfhvtrcQatubmJeUTQ6ME/ghlU0X8FY5eA8YwhgqtrvnPst5FOAIAfsQfFA30U7uPgcxg9psWYfQbtAc9DZhA==}
@@ -1771,8 +1772,8 @@ packages:
     resolution: {integrity: sha512-kF3GFME4lN22O5zbnXk2RP4y/4PDQdps0xKiYTipMYprkwCmmpsWLZt/N2Fkbil540cSLfJX0BW7LkHzgMVUYg==}
     hasBin: true
 
-  '@microsoft/decorators@1.21.1':
-    resolution: {integrity: sha512-MQsrNsxFdeEP1xuRELciyH4kxyf42ogazsDpjIFhUHD6YMxtpwHHA5GSCL2ke4XIIeuiratDHP0LzbGBF9MJCg==}
+  '@microsoft/decorators@1.22.2':
+    resolution: {integrity: sha512-UMj1l4IxQaVcWI5dGQAXvyPySBFk5SH/vfQUOP2F0OQ6wEyuzKRzcI1gtvoZnBQ9wx3Wf2GxjbrrtVy1Duf7eg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/eslint-config-spfx@1.23.0':
@@ -1872,28 +1873,28 @@ packages:
     resolution: {integrity: sha512-jarJIFIJZBqeofy3hh0vdQo1yOmTM+jCjj6/zmo9JunsQ6LO750eZHCg9eLptQhsvq321XCt5xdRNLCwU8YeNA==}
     engines: {node: '>=10.3.0'}
 
-  '@microsoft/sp-adaptive-card-extension-base@1.21.1':
-    resolution: {integrity: sha512-/0M0maRB1gtZCAy6GvNZklv+9yl4ccrqj77yWTe0b+szGmvdkWIBd2AqS0bkpzZPTyl7lkiDBckEzxbKmRyB/Q==}
+  '@microsoft/sp-adaptive-card-extension-base@1.22.2':
+    resolution: {integrity: sha512-bCsV0HaerAMFdpyB75+68rsCtL4ZNRvIdlGK26GY6ze9rewXCT2NmMnKH60UrTh7KXdqbZZE4yy6r2JJTHt3xA==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-adaptive-card-extension-base@1.23.0':
     resolution: {integrity: sha512-YyG3c81GGJw9AuvnpfbstNWmkGvHN2DcYbiwcJpovLJR0XzkWzqChRuMNq+owwTSywsQRIW4Wgy1o/yIYIdZzg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-application-base@1.21.1':
-    resolution: {integrity: sha512-b3PJwSZBP/MTpangqAqAJaJqBm0fhBNayWNoAjR31iFSfr6+9RVokn4LMiI4I0GHa8cTYKokvXZK57YgvPR7tQ==}
+  '@microsoft/sp-application-base@1.22.2':
+    resolution: {integrity: sha512-nHOHFImcYEGhDWq4dnFiivVk7Q26+cGsybyCwtP8X3bjfWmR964nwnJWB+NjIyqoFZolWzoDna2/w2Mpf5AsRA==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-component-base@1.21.1':
-    resolution: {integrity: sha512-MpwpuvvT6LVZ91hfxOVp6WkUfuTfqiVOGriM1SCioVLkACvTVvFtqROhFlfSg7EzNiu9QgNbiH0Za43voQYlaA==}
+  '@microsoft/sp-component-base@1.22.2':
+    resolution: {integrity: sha512-M7V6VGTHvsyGH9pcsskMs4dFdrHmp1Eg/R1Akw1bmQCLaWwUTWIl19J0jPsC26DPnzITbkcLDrKmXcqcp6dwpw==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-component-base@1.23.0':
     resolution: {integrity: sha512-DHODafV2zK+VrhZNNI7SIrcI631eDWFyyCPkA6VRs9FRHnaMPN2jR8661VpKy4OkF7+moxViZ5S250TRHiX7Jg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-core-library@1.21.1':
-    resolution: {integrity: sha512-yFhv6fSqMqvnp9YgihtGfy9ISyEjvHlFpavDmWQKiNdctqY3admuzhXF4c9o7GY60ICPJYs9Wrspda+HBsnbSw==}
+  '@microsoft/sp-core-library@1.22.2':
+    resolution: {integrity: sha512-WoIN1R5zYPRela+3Ma+7HQQMBtYqsm/FzckwgUZlpwY/DU9prdZnVrQN/mZNGRmz9LxUNWqUd6TZvz2HYYQV3A==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
@@ -1919,49 +1920,49 @@ packages:
     resolution: {integrity: sha512-klRIdzQFNs630g35edqVtlbNFVAYLGybAzOE07lNaWleXyOd7JmzVW+PgyLMZ9+yf+huEe52XehLwCH5qviaKw==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-dialog@1.21.1':
-    resolution: {integrity: sha512-wTs4ARd8ED/nIIpqSkWCCTTr4Ec8OOJwm6I3yzHCUgyCJS/cNrvN8t2C5i0XbYSu0L8GG371QBEFpz8APGwVKA==}
+  '@microsoft/sp-dialog@1.22.2':
+    resolution: {integrity: sha512-onISHeL5n5FLomCbHQOf6RzZggjL7ex4x2xtF45yodtg0YHC4aofpu0Th8oDj6kl5PqFiED99oXYXCnu2XHouA==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
       '@types/react-dom': '>=16.9.8 <18.0.0'
 
-  '@microsoft/sp-dynamic-data@1.21.1':
-    resolution: {integrity: sha512-CG1qIF1jgDdK18a9+mjjPbRYK6MJJBnGe6xiZTkKzOPFtEnL/xHwNUCDqXVSnN0imsc3RHu1cfhPLZ5VzAuHPA==}
+  '@microsoft/sp-dynamic-data@1.22.2':
+    resolution: {integrity: sha512-m+TbsTdJluu7B3WR8U1fa4hPfrz/iHqhXESfdI/0KINhFb6xsGAs8m2kmZBIPjCYCJrl7SFZjmIkZHW5N5BnJQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-dynamic-data@1.23.0':
     resolution: {integrity: sha512-9QsPvM8LwNE3G20g2NNs23ROXkN1gdOMFjYnOUjLl5wNGawnuh9xZzH0mR10aa8ir70ENyKbO6wf4eExPc9OIA==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-extension-base@1.21.1':
-    resolution: {integrity: sha512-EExF1MAZgP6Uik4KjNw3D7mr6NWJ2oTEgfIvCINVA3p1dOn3WHXDOLnT0ybP8N7AvqkJGSk0w2qNdTkIC9KAqg==}
+  '@microsoft/sp-extension-base@1.22.2':
+    resolution: {integrity: sha512-NiQtBMvnW+MCiGYCZW9wGeMtcs6uY0ArwXaHSvxK4DwH/lOZ3leVS258/PGr/9MkfwTx9JRbErk0pmwAAQ/J2g==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-http-base@1.21.1':
-    resolution: {integrity: sha512-nJtttro64yc5UwPIJyz/H+w4tqzn/5nduzJvGIqQj3Q0kYTWaV7qjESYgOCfWmZvS1K+BtbAf3A0M8PwbcPLgg==}
+  '@microsoft/sp-http-base@1.22.2':
+    resolution: {integrity: sha512-yiDnIQY6XJCbzuQ9bIyvkgd2Ts+GP8AxnilvI3AwWffOtwfrpqkrJtdkgSGf567/KvkJJHnG2cvLwYWimrwf2w==}
 
   '@microsoft/sp-http-base@1.23.0':
     resolution: {integrity: sha512-5r/r9LYn7ZlzZ/8SpPxqVMwNNeeZOFYdon8bFt9eVdD93cVnOnUDcc3lOZ6UBGWyUjOqb74i3Jpt8zQT3M3oeQ==}
 
-  '@microsoft/sp-http-msgraph@1.21.1':
-    resolution: {integrity: sha512-xpzNtVJR9YtXkql6HokvsvDUIZd7cRxT9Id8o9Q2WbRzarL6FtQZisqb4/7qodrZkKMyUJJpEezXnbqyI/7smQ==}
+  '@microsoft/sp-http-msgraph@1.22.2':
+    resolution: {integrity: sha512-sjM1ENHHkXrGSmpWxtbrGlz2MIh4RgHrMl1lkBzzWGHtK5GOxx7x5PxS8nfd0OLVqBOnc/xFu7PAryhBeyShUA==}
     peerDependencies:
       '@microsoft/microsoft-graph-client': 3.0.2
 
   '@microsoft/sp-http-msgraph@1.23.0':
     resolution: {integrity: sha512-rzk9RW92sV+UStfufKP4gLaSScnYniSVPlGNbjvxJPA9L4bXNuGDW99gpi1w3T5va3ArlIt9a6Prl299ZvV91g==}
 
-  '@microsoft/sp-http@1.21.1':
-    resolution: {integrity: sha512-6Gvq0iqdWG19jfQhv2u6lgYUjSQKcduf36XaVLg3JAUT2fayQ+LTQAi15nt6kwN3RRnHWBwC4Lh07M0z9/AlLg==}
+  '@microsoft/sp-http@1.22.2':
+    resolution: {integrity: sha512-749sgOG1QABJEEVgoDBoTXkeYR8W7Ythx18AHo3tvtwgCV3O1Shx9RjWbww7PwS3EglwKw5f50Ou7cAB7BWRFg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-http@1.23.0':
     resolution: {integrity: sha512-VJtiipifxqH4zhqBc0RE57Gx8/P7VOivyHZNRnVLrfqzBVZLEt8h9VNwXlgJqO8HYr9YAoaf7tUevFqjBHYFuQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-image-helper@1.21.1':
-    resolution: {integrity: sha512-2XVLItq19XqzZgXWamBcFRtC+Hl7u9BwHovfQy6XJ0FcbUzEIZ1WGRN8Y54EDuSSyz/aE+49MpUHV70eqKoTJQ==}
+  '@microsoft/sp-image-helper@1.22.2':
+    resolution: {integrity: sha512-gB59OtaAkSv4TuBA/CZxEGGhBeD/yAIvDCfs3EkOHM+4cV7pPsW4zVV9+ei7e/kzH79rril+1KCPFIUJKM44CQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
@@ -1978,12 +1979,12 @@ packages:
       react: '>=16.13.1 <18.0.0'
       react-dom: '>=16.13.1 <18.0.0'
 
-  '@microsoft/sp-listview-extensibility@1.21.1':
-    resolution: {integrity: sha512-htxjNG7Rj471NT0mDd+31NQn+G9AQdJ9nb/nXnyFBB7dwa2IsOrWRvVwonMqjGVBjR1cDnGMXnvy+O7bJfw3Pg==}
+  '@microsoft/sp-listview-extensibility@1.22.2':
+    resolution: {integrity: sha512-5TF+QBgSrCUn03y4ViZGFSBMF4zcLVFHQjRy/q0s6RSheROsafj7rce+oyM9rSsepN2F1NBguiq0YG7NuS+Ucw==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-loader@1.21.1':
-    resolution: {integrity: sha512-AYvJ3I30ECiaSYk8twKZYHMNiSW/udE3JgaIXlltQBBCgjN/HhVuMCMN1YpOgVW8OZGCtvNCc9Thmrq6kbuTBw==}
+  '@microsoft/sp-loader@1.22.2':
+    resolution: {integrity: sha512-84dUlqT2m5UrppRBFhh5QD3fK6HqCedE+I+ldJq63fLZdCe9tgGPKfjbwa3LHHlGNEdpU+ouF/BiTM8bJvyryg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
@@ -1996,44 +1997,44 @@ packages:
       '@types/react': 17.0.45
       '@types/react-dom': '>=16.9.8 <18.0.0'
 
-  '@microsoft/sp-lodash-subset@1.21.1':
-    resolution: {integrity: sha512-5wOwxn96Um5gifI0EIq+sxeQaUppIYSHBn1msK/HY5m91MuntuRwjyA74aCjVkeqzu2gYeMNpMl/RY1mRVuPEw==}
+  '@microsoft/sp-lodash-subset@1.22.2':
+    resolution: {integrity: sha512-hKjhSRq8SEZRyL2nAgML0cEW0XL4ppWJAHpNSq7imJMWpnqaVZgqpgPc5oeKw/x8FxHQglt5W/MLUNO/rF/b6w==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-lodash-subset@1.23.0':
     resolution: {integrity: sha512-oKDBD+47caI1kYGCKhcVfckw+hhbulPNAc3cfkyn6qZuYnc4gIoNVMv9y8SW9yTa5iZMcpSqye6nwImBjqjAlQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-module-interfaces@1.21.1':
-    resolution: {integrity: sha512-ZIz8gKHtVerwrbi6il6qu69PtxOKzpFdL7YAts5BgGeupNjSwO7+rHPsupOz/zqwnXfpSnRMBUD3RFSCh1CnJQ==}
+  '@microsoft/sp-module-interfaces@1.22.2':
+    resolution: {integrity: sha512-s8tMPxgekZGDhr3tTcyi+Rk5KQZskGd/Xs1zqYyZ+ZwyJWXbfKg9ik2xmOTCq18xEIcc2x7XRI0PfiTP+drz3A==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-module-interfaces@1.23.0':
     resolution: {integrity: sha512-aI8auPwXp9SNLKGkU+bhfbu9CjdtVCLg8hMTZaLEw75UihJdON/gxjz1iSdHjFNBZhd02VNZ3ab8ft0sEySkVQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-odata-types@1.21.1':
-    resolution: {integrity: sha512-pI7Qbxm+IjIThdUFpO63LwR/oxSLM9qqTbJNng6cRBEYCcNXiLRQiaXWFWP1TrNVTvDVSVThvT6vZZ7YPrz0ig==}
+  '@microsoft/sp-odata-types@1.22.2':
+    resolution: {integrity: sha512-gtru9lV74B1/padXRaMf0dZNgnZpbABIc83idq4QYH9jHBdKmcdfnNbaSgUWALXHHeHBDA5Xani2YjYjxrF3EQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-odata-types@1.23.0':
     resolution: {integrity: sha512-s/mtug2hciANb6bN8pCGp2+lw4XegG1OXpOCpZhJl+Dg+19QieT5Af15gwLU++FQEP0wvXcXeFEYguOlYYxDmg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-office-ui-fabric-core@1.21.1':
-    resolution: {integrity: sha512-r4rfFvbVi6W02g+ikoyHMxDlcO0iHX0dtf5pK1YfZGnOzHzhkPLyhWWUxP+Jnmu7VoRecsZAw5RcQz09HP6VaQ==}
+  '@microsoft/sp-office-ui-fabric-core@1.22.2':
+    resolution: {integrity: sha512-vf3bzrGw1FYAorzfbUiAJTe0tG7CZ1mVSdoNiUGOjMR8kqCyn1DO7L4zr94P/AyLoqyJWavucraOVLgS/xtpOg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-page-context@1.21.1':
-    resolution: {integrity: sha512-hrLuhcmK2fxPYq/oWCk4qrzZrnYsjreyZ5rUUN1miYoFUpoPOuPPvZ61G9hONBzht+HAjw6n5G2LwKhCM97d4g==}
+  '@microsoft/sp-page-context@1.22.2':
+    resolution: {integrity: sha512-wqjIVPbkBTWEm1dhSdweYZNGvHfZdUBxyVYAyrwMAV/UzxI76c4ivcacjuODYin7MqxF/EJOAXYDPPf0/pikIA==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
   '@microsoft/sp-page-context@1.23.0':
     resolution: {integrity: sha512-niMSguzQoscT3ETMF46mgfn+b5JjVHlGaJM7h+bwO32tVS3BkjYEFWJwdtx/sLHzlZq04JPvIXojCoQCHfnnEQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-property-pane@1.21.1':
-    resolution: {integrity: sha512-6xdjKzM05zkiDU90gFvQsRGJNK2HI4PQbc3Hkyzc1AM7KHQzkugiS8nbds0p4HoZGIv1p+4L25FmpZBeQtnfmw==}
+  '@microsoft/sp-property-pane@1.22.2':
+    resolution: {integrity: sha512-xHargjpw98gFaJ8kwDffTp0RrimKPfyXbdI3PmPCEfWPBqr3cOl88gENH5j6jcGo3lTbphy+NXv/wUTgWz22Vw==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
@@ -2046,18 +2047,18 @@ packages:
       '@types/react': 17.0.45
       '@types/react-dom': '>=16.9.8 <18.0.0'
 
-  '@microsoft/sp-search-extensibility@1.21.1':
-    resolution: {integrity: sha512-V+877MjAsJ+zvPOzwwK/XBUkcafwLN34l4xTb1oXlLBXfgtGmAffxT1Gwu52RckCll3RYWK5yZ8onzopF0A1Wg==}
+  '@microsoft/sp-search-extensibility@1.22.2':
+    resolution: {integrity: sha512-mxJ5NseQz0zBKf6OdVR7FDJFr3tNbWDxanoNQTitLWb6suEteCWK5Fx/sNvzGJBuv5McijGXaaIj8atlsX2vIg==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
 
-  '@microsoft/sp-top-actions@1.21.1':
-    resolution: {integrity: sha512-ag2fDtYRRg/emS+qEGMr8AZib82QhlGgHZpAonq+pB07ofewlKJAOd/jDACWWZbNdDHNTWByHDPRjoWIu93law==}
+  '@microsoft/sp-top-actions@1.22.2':
+    resolution: {integrity: sha512-8Gl+lZbAgRZ5vTjIiCpG2GMyjNPgAoDwKm2ZHaxowfYFg6GTOnb9EnfoSRJpfl8oNQuXWIT1q+ujE9doc4t/nQ==}
 
   '@microsoft/sp-top-actions@1.23.0':
     resolution: {integrity: sha512-naR9+J58pkRCgYEAbj9ixJyjr4eOVZo1NtKNNgBLwIfArcpMMmqNRK7j48eMnyy7cjHpEUKVfzgQpBmcgRYVag==}
 
-  '@microsoft/sp-webpart-base@1.21.1':
-    resolution: {integrity: sha512-nzjT59nMfjM5b0Zr8J14lyshndJm28x2Tg+Jn3TAwA7PwcntlUosZj+lfTOvAyna8YdJpoc6vCrXSul9fQUSpA==}
+  '@microsoft/sp-webpart-base@1.22.2':
+    resolution: {integrity: sha512-HjaVBbjePR3etkdy8VCXiytHzwOXK8gIefZSQJAPXpfYGNJHgjbVDoNfoV+QFA5FxKFFB8ASLH96HE93y1YBsQ==}
     engines: {node: '>=18.17.1 <19.0.0 || >=22.14.0 < 23.0.0'}
     peerDependencies:
       '@types/react': 17.0.45
@@ -2127,17 +2128,11 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@pnp/common@1.3.11':
-    resolution: {integrity: sha512-RhYKcfMP+h0pAzORZRHSPPLOBB58djN/pfnorpWPjsx6ZxMqbiDqTzAtTF4m8z/mdNnxJr0Q3kwt4ImU3FjwnA==}
-
   '@pnp/common@2.15.0':
     resolution: {integrity: sha512-lyK5LIet6xh0wXPvnMpOKU7cK1aRuLAJK+TxWUsg44fmoda4w316pWycTyWelaJYXnqZT2OOoz996Zpkc6t76w==}
 
   '@pnp/common@2.5.0':
     resolution: {integrity: sha512-ea4zTNC3sjLolrHZXP+/2SrJM+yC8PygmPW/yRfgbErdvdwYMUSogT69dW+NUaqhkfYZfkkAoWn42irlLMSpdw==}
-
-  '@pnp/logging@1.3.11':
-    resolution: {integrity: sha512-hADlIXwvF/wjee7425nFJ6NhqaWpWTJ5yg02bpwBUsiSuFqEUf+LwuAcyHQre2lMs6KyNa65FWoRQok9BlZuxA==}
 
   '@pnp/logging@2.5.0':
     resolution: {integrity: sha512-SnmMCN6oADjiHKAIR23FfTqXeQZeXPBnWeVfyZAgzJfRn9uEQoUlkyET3jHjl9kkrFOVkiOD1CRI7TWMIxURbA==}
@@ -2149,48 +2144,18 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@pnp/odata@1.3.11':
-    resolution: {integrity: sha512-yMaRiuVZRei2pkryCOqsw3ZXD2Lw30IJv136WQmQPQPOxG4cvsS9+woXkfMqbWV2KQ1evFUqVXbitIz6eDVfNA==}
-    peerDependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-
   '@pnp/odata@2.5.0':
     resolution: {integrity: sha512-AeP01jDvnkiUVn7V+4FT07chz+G/yzrJDH0Gk+qzujJ393ZO6FwJpJEiOCRh9cxF48gqSj/f7r/IIyDHe0+IpQ==}
-
-  '@pnp/sp-clientsvc@1.3.11':
-    resolution: {integrity: sha512-eIUnmDWjizcWJzhWxAbfsxEyHF1dabkGlihnDnlcYGhtvh8BwuM67A57qc5fbxzCS59c0YU57szB1EucoNmV4A==}
-    peerDependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11
-      '@pnp/sp': 1.3.11
-
-  '@pnp/sp-taxonomy@1.3.11':
-    resolution: {integrity: sha512-shzCSjmOlr6mojCXJkfD8Xf9lJnhphq4Fj6mdUQGwpak+VIU+Fogf6AI0j6AReCKtKsKyqfud9X7C8tH07C3DA==}
-    peerDependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11
-      '@pnp/sp': 1.3.11
-      '@pnp/sp-clientsvc': 1.3.11
-
-  '@pnp/sp@1.3.11':
-    resolution: {integrity: sha512-NjdeGe81aukiSPelSPjgAFRC1+SrNPTXvTdEqTH+Q1ZvgNtk8bdZp6K6xf9emfeM2qZDOu9GpKZpg0W/emq++g==}
-    peerDependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11
 
   '@pnp/sp@2.5.0':
     resolution: {integrity: sha512-4s2p+X5qvkXR72NViKb8DIfC+pvj/a3psZ3Im5PRIan2ErMtu9ch3Lb9nkSaMCF3NTJxWOhkUQ/R6tx8ApaUkg==}
 
-  '@pnp/spfx-controls-react@3.23.0':
-    resolution: {integrity: sha512-YDuY6C7Nt0Cj5EL8Q8s83sfLCrVJ2pxK2G3lHHiHTPYlZ7Od+Hg9TPj8M0WdVobk2P4vSIxVk2oddqQ3hRprUg==}
+  '@pnp/spfx-controls-react@3.24.0':
+    resolution: {integrity: sha512-rVZXGBFTbijeIU5WiUHD/wPj7oHQntQRZe2OyPydIu2EA40waAvFJPcNtDyLRcOVytT24K3XO81zSWq3ztL6pw==}
     engines: {node: '>=22.14.0 < 23.0.0'}
 
-  '@pnp/spfx-property-controls@3.22.0':
-    resolution: {integrity: sha512-U1S3bfVJjNieJRxDpSv7a21LmeLp5vv4XGUkoj3HRSTvEsxNUuLXrnP0b/Z4vYgjrP+p0AybGOD5HPgADKDWCQ==}
+  '@pnp/spfx-property-controls@3.23.0':
+    resolution: {integrity: sha512-iq3Nyv+/lQeNLbDuRUtq7zZ8XEWQA+HcOg8zCypSg+iVFiL4q47PfH9LU6DQypNL7NxhmX8gBWG125EX39/bUw==}
     engines: {node: '>=22.14.0 < 23.0.0'}
 
   '@pnp/telemetry-js@2.0.0':
@@ -2291,8 +2256,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  '@rushstack/loader-raw-script@1.4.92':
-    resolution: {integrity: sha512-CkyiTM4IXwe0tKKQCfUhkzPkV4fCpDEh6Jglh6IkHKo+IDVKfV3XA/wMkf5P+ulTmO2H03NT6MogeptcXB3g/A==}
+  '@rushstack/loader-raw-script@1.5.2':
+    resolution: {integrity: sha512-nreoK5JjFdrQv72MH1zpEGbJg66DbicqmDPF4F8Jw/NotnmnH36qLd4pJcxjX22g0FmKRvsaRSCLMEtuDBjr8Q==}
 
   '@rushstack/loader-raw-script@1.6.7':
     resolution: {integrity: sha512-jlWGpMrFVxxp4inbAYf6ZTtOyiaAk33ewalX++6PulLDXfxZH3hzF69dG/z2HAGX88ElTHlWpsjGi71IbsqKaA==}
@@ -2308,8 +2273,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/node-core-library@5.12.0':
-    resolution: {integrity: sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==}
+  '@rushstack/node-core-library@5.17.1':
+    resolution: {integrity: sha512-Mtcsa0aRJgYJOpeTe4qElLTRBlijNohdliq/xOhqce5rlzMIfLr73j9wUuj6GYPZPbG0S+is/RL2l0m/vnL55A==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -2483,9 +2448,6 @@ packages:
 
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
-
-  '@swc/helpers@0.5.12':
-    resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
@@ -2991,11 +2953,6 @@ packages:
     engines: {node: '>=0.8.0'}
     deprecated: This package is no longer supported. Please migrate to @azure/msal-angular.
 
-  adal-angular@1.0.17:
-    resolution: {integrity: sha512-+Z9aq7L25OncsaVcnhSsi7AMR/dlg0gWVNptsdtkL9Ih7hA1oJ14mhWB60CB83JF6DlzamVKLMGbrAcgFQqhCg==}
-    engines: {node: '>=0.8.0'}
-    deprecated: This package is no longer supported. Please migrate to @azure/msal-angular.
-
   adaptive-expressions@4.23.3:
     resolution: {integrity: sha512-7i1Ka6SR0gVcyHgoaZDiZi3BW3m9jN+lqfiMF6IY7SjugfeauXoZRl5sIDwJkYZNnffrfUuK7Pc3I3JiKfPBMw==}
 
@@ -3415,10 +3372,6 @@ packages:
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
-
-  commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -5005,8 +4958,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -6631,9 +6584,6 @@ packages:
   ts-easing@0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
-  tslib@1.10.0:
-    resolution: {integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==}
-
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -6784,10 +6734,6 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
-
-  validator@13.15.22:
-    resolution: {integrity: sha512-uT/YQjiyLJP7HSrv/dPZqK9L28xf8hsNca01HSz1dfmI0DgMfjopp1rO/z13NeGF1tVystF0Ejx3y4rUKPw+bQ==}
-    engines: {node: '>= 0.10'}
 
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
@@ -7005,11 +6951,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  z-schema@6.0.2:
-    resolution: {integrity: sha512-9fQb2ZhpMD0ZQXYw0ll5ya6uLQm3Xtt4DXY2RV3QO1QVI4ihSzSWirlgkDsMgGg4qK0EV4tLOJgRSH2bn0cbIw==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
 
 snapshots:
 
@@ -8079,6 +8020,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
+  '@fluentui/react-icons@2.0.306(react@17.0.1)':
+    dependencies:
+      '@griffel/react': 1.7.4(react@17.0.1)
+      react: 17.0.1
+      tslib: 2.8.1
+
   '@fluentui/react-icons@2.0.314(react@17.0.1)':
     dependencies:
       '@griffel/react': 1.7.4(react@17.0.1)
@@ -8979,7 +8926,7 @@ snapshots:
       '@fluentui/date-time-utilities': 8.6.11
       '@fluentui/font-icons-mdl2': 8.5.73(@types/react@17.0.45)(react@17.0.1)
       '@fluentui/foundation-legacy': 8.6.6(@types/react@17.0.45)(react@17.0.1)
-      '@fluentui/merge-styles': 8.5.12
+      '@fluentui/merge-styles': 8.6.14
       '@fluentui/react-focus': 8.10.6(@types/react@17.0.45)(react@17.0.1)
       '@fluentui/react-hooks': 8.10.2(@types/react@17.0.45)(react@17.0.1)
       '@fluentui/react-portal-compat-context': 9.0.15(@types/react@17.0.45)(react@17.0.1)
@@ -9667,9 +9614,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/decorators@1.21.1':
+  '@microsoft/decorators@1.22.2':
     dependencies:
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
 
   '@microsoft/eslint-config-spfx@1.23.0(eslint@9.37.0)(typescript@5.8.3)':
@@ -9850,19 +9797,19 @@ snapshots:
 
   '@microsoft/recognizers-text-data-types-timex-expression@1.3.1': {}
 
-  '@microsoft/sp-adaptive-card-extension-base@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)':
+  '@microsoft/sp-adaptive-card-extension-base@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)':
     dependencies:
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-property-pane': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-http': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-property-pane': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
       '@microsoft/teams-js-v2': '@microsoft/teams-js@2.32.0'
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       adaptivecards: 2.11.2(swiper@8.4.7)
       tslib: 2.3.1
     transitivePeerDependencies:
@@ -9907,21 +9854,21 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/sp-application-base@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
+  '@microsoft/sp-application-base@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
     dependencies:
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-http': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-odata-types': 1.21.1
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-search-extensibility': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-http': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-odata-types': 1.22.2
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-search-extensibility': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -9934,18 +9881,18 @@ snapshots:
       - scheduler
       - supports-color
 
-  '@microsoft/sp-component-base@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
+  '@microsoft/sp-component-base@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react': 8.125.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@fluentui/react-components': 9.73.8(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-dynamic-data': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-dynamic-data': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -9985,10 +9932,10 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/sp-core-library@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-core-library@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@swc/helpers': 0.5.21
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       react: 17.0.1
@@ -10009,12 +9956,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/sp-css-loader@1.23.0(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))':
+  '@microsoft/sp-css-loader@1.23.0(@types/node@25.9.1)(webpack@5.105.4)':
     dependencies:
       '@microsoft/load-themed-styles': 1.10.292
       '@rushstack/node-core-library': 5.20.3(@types/node@25.9.1)
       autoprefixer: 10.5.0(postcss@8.5.15)
-      css-loader: 7.1.3(webpack@5.105.4(postcss@8.5.15))
+      css-loader: 7.1.3(webpack@5.105.4)
       cssnano: 5.1.15(postcss@8.5.15)
       loader-utils: 2.0.4
       postcss: 8.5.15
@@ -10022,7 +9969,7 @@ snapshots:
       postcss-modules-local-by-default: 4.2.0(postcss@8.5.15)
       postcss-modules-scope: 3.2.1(postcss@8.5.15)
       postcss-modules-values: 4.0.0(postcss@8.5.15)
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     transitivePeerDependencies:
       - '@rspack/core'
       - '@types/node'
@@ -10038,15 +9985,15 @@ snapshots:
       - react
       - react-dom
 
-  '@microsoft/sp-dialog@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
+  '@microsoft/sp-dialog@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react': 8.125.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@fluentui/react-components': 9.73.8(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
       '@fluentui/react-migration-v8-v9': 9.10.9(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-application-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-application-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       react: 17.0.1
@@ -10059,13 +10006,13 @@ snapshots:
       - scheduler
       - supports-color
 
-  '@microsoft/sp-dynamic-data@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-dynamic-data@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@types/node'
@@ -10089,14 +10036,14 @@ snapshots:
       - react
       - react-dom
 
-  '@microsoft/sp-extension-base@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
+  '@microsoft/sp-extension-base@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
     dependencies:
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -10109,13 +10056,13 @@ snapshots:
       - scheduler
       - supports-color
 
-  '@microsoft/sp-http-base@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-http-base@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/teams-js-v2': '@microsoft/teams-js@2.32.0'
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       adal-angular: 1.0.16
       tslib: 2.3.1
     transitivePeerDependencies:
@@ -10143,15 +10090,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@microsoft/sp-http-msgraph@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-http-msgraph@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
       '@microsoft/microsoft-graph-client': 3.0.2
       '@microsoft/microsoft-graph-clientv1': '@microsoft/microsoft-graph-client@1.7.2-spfx'
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@types/node'
@@ -10185,13 +10132,13 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/sp-http@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-http@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-msgraph': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http-msgraph': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -10224,15 +10171,15 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/sp-image-helper@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-image-helper@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@swc/helpers': 0.5.21
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       react: 17.0.1
@@ -10260,13 +10207,13 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@microsoft/sp-listview-extensibility@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
+  '@microsoft/sp-listview-extensibility@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -10279,19 +10226,19 @@ snapshots:
       - scheduler
       - supports-color
 
-  '@microsoft/sp-loader@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)':
+  '@microsoft/sp-loader@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)':
     dependencies:
       '@fluentui/react': 8.125.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-dynamic-data': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-odata-types': 1.21.1
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@rushstack/loader-raw-script': 1.4.92
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-dynamic-data': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-odata-types': 1.22.2
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@rushstack/loader-raw-script': 1.5.2
+      '@swc/helpers': 0.5.21
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       '@types/requirejs': 2.1.29
@@ -10329,9 +10276,9 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@microsoft/sp-lodash-subset@1.21.1':
+  '@microsoft/sp-lodash-subset@1.22.2':
     dependencies:
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       '@types/lodash': 4.14.117
       tslib: 2.3.1
 
@@ -10341,10 +10288,10 @@ snapshots:
       '@types/lodash': 4.14.117
       tslib: 2.3.1
 
-  '@microsoft/sp-module-interfaces@1.21.1(@types/node@25.9.1)':
+  '@microsoft/sp-module-interfaces@1.22.2(@types/node@25.9.1)':
     dependencies:
-      '@rushstack/node-core-library': 5.12.0(@types/node@25.9.1)
-      z-schema: 6.0.2
+      '@rushstack/node-core-library': 5.17.1(@types/node@25.9.1)
+      ajv: 6.15.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -10355,9 +10302,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/sp-odata-types@1.21.1':
+  '@microsoft/sp-odata-types@1.22.2':
     dependencies:
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
 
   '@microsoft/sp-odata-types@1.23.0':
@@ -10365,20 +10312,20 @@ snapshots:
       '@swc/helpers': 0.5.21
       tslib: 2.3.1
 
-  '@microsoft/sp-office-ui-fabric-core@1.21.1':
+  '@microsoft/sp-office-ui-fabric-core@1.22.2':
     dependencies:
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       office-ui-fabric-core: 11.0.1
       tslib: 2.3.1
 
-  '@microsoft/sp-page-context@1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@microsoft/sp-page-context@1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-dynamic-data': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-odata-types': 1.21.1
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-dynamic-data': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-odata-types': 1.22.2
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@types/node'
@@ -10403,21 +10350,21 @@ snapshots:
       - react
       - react-dom
 
-  '@microsoft/sp-property-pane@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
+  '@microsoft/sp-property-pane@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react': 8.125.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@fluentui/react-components': 9.73.8(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@fluentui/react-icons': 2.0.327(react@17.0.1)
+      '@fluentui/react-icons': 2.0.306(react@17.0.1)
       '@fluentui/react-tabster': 9.26.14(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@fluentui/utilities': 8.17.2(@types/react@17.0.45)(react@17.0.1)
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-dynamic-data': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-image-helper': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-dynamic-data': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-image-helper': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@swc/helpers': 0.5.21
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       react: 17.0.1
@@ -10460,13 +10407,13 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/sp-search-extensibility@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
+  '@microsoft/sp-search-extensibility@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)':
     dependencies:
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@swc/helpers': 0.5.12
+      '@microsoft/sp-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@swc/helpers': 0.5.21
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@microsoft/microsoft-graph-client'
@@ -10479,28 +10426,30 @@ snapshots:
       - scheduler
       - supports-color
 
-  '@microsoft/sp-top-actions@1.21.1': {}
+  '@microsoft/sp-top-actions@1.22.2':
+    dependencies:
+      '@swc/helpers': 0.5.21
 
   '@microsoft/sp-top-actions@1.23.0':
     dependencies:
       '@swc/helpers': 0.5.21
 
-  '@microsoft/sp-webpart-base@1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
+  '@microsoft/sp-webpart-base@1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react': 8.125.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/sp-diagnostics': 1.23.0(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-http-base': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-module-interfaces': 1.21.1(@types/node@25.9.1)
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-property-pane': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
-      '@microsoft/sp-top-actions': 1.21.1
+      '@microsoft/sp-http': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-http-base': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-module-interfaces': 1.22.2(@types/node@25.9.1)
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-property-pane': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-top-actions': 1.22.2
       '@microsoft/teams-js-v2': '@microsoft/teams-js@2.32.0'
-      '@swc/helpers': 0.5.12
+      '@swc/helpers': 0.5.21
       '@types/office-js': 1.0.36
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
@@ -10546,10 +10495,10 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@microsoft/spfx-heft-plugins@1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(postcss@8.5.15)':
+  '@microsoft/spfx-heft-plugins@1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)':
     dependencies:
       '@azure/storage-blob': 12.26.0
-      '@microsoft/sp-css-loader': 1.23.0(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))
+      '@microsoft/sp-css-loader': 1.23.0(@types/node@25.9.1)(webpack@5.105.4)
       '@microsoft/sp-module-interfaces': 1.23.0(@types/node@25.9.1)
       '@rushstack/heft': 1.2.17(@types/node@25.9.1)
       '@rushstack/heft-config-file': 0.20.3(@types/node@25.9.1)
@@ -10557,25 +10506,25 @@ snapshots:
       '@rushstack/module-minifier': 0.9.12(@types/node@25.9.1)
       '@rushstack/node-core-library': 5.20.3(@types/node@25.9.1)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/set-webpack-public-path-plugin': 5.3.8(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))
+      '@rushstack/set-webpack-public-path-plugin': 5.3.8(@types/node@25.9.1)(webpack@5.105.4)
       '@rushstack/terminal': 0.22.3(@types/node@25.9.1)
-      '@rushstack/webpack5-localization-plugin': 0.16.7(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))
-      '@rushstack/webpack5-module-minifier-plugin': 5.8.8(@rushstack/module-minifier@0.9.12(@types/node@25.9.1))(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))
+      '@rushstack/webpack5-localization-plugin': 0.16.7(@types/node@25.9.1)(webpack@5.105.4)
+      '@rushstack/webpack5-module-minifier-plugin': 5.8.8(@rushstack/module-minifier@0.9.12(@types/node@25.9.1))(@types/node@25.9.1)(webpack@5.105.4)
       '@types/tapable': 1.0.6
       cors: 2.8.5
       express: 4.21.2
       fast-glob: 3.2.12
       git-repo-info: 2.1.1
-      html-loader: 4.2.0(webpack@5.105.4(postcss@8.5.15))
+      html-loader: 4.2.0(webpack@5.105.4)
       jszip: 3.8.0
       lodash: 4.18.1
       mime: 2.5.2
       resolve: 1.17.0
       source-map: 0.6.1
-      source-map-loader: 4.0.2(webpack@5.105.4(postcss@8.5.15))
+      source-map-loader: 4.0.2(webpack@5.105.4)
       tapable: 1.1.3
       uuid: 9.0.1
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
       xml: 1.0.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10596,10 +10545,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@microsoft/spfx-web-build-rig@1.23.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(jest-environment-node@30.3.0)(postcss@8.5.15)(tslib@2.8.1)':
+  '@microsoft/spfx-web-build-rig@1.23.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(jest-environment-node@30.3.0)(tslib@2.8.1)':
     dependencies:
       '@microsoft/api-extractor': 7.58.1(@types/node@25.9.1)
-      '@microsoft/spfx-heft-plugins': 1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(postcss@8.5.15)
+      '@microsoft/spfx-heft-plugins': 1.23.0(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
       '@rushstack/heft': 1.2.17(@types/node@25.9.1)
       '@rushstack/heft-dev-cert-plugin': 1.1.13(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
       '@rushstack/heft-jest-plugin': 2.0.6(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/jest@30.0.0)(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(jest-environment-jsdom@30.4.1)(jest-environment-node@30.3.0)
@@ -10607,14 +10556,14 @@ snapshots:
       '@rushstack/heft-sass-plugin': 1.3.8(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
       '@rushstack/heft-static-asset-typings-plugin': 0.1.3(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
       '@rushstack/heft-typescript-plugin': 1.3.2(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)
-      '@rushstack/heft-webpack5-plugin': 1.3.10(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15))
+      '@rushstack/heft-webpack5-plugin': 1.3.10(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(tslib@2.8.1)(webpack@5.105.4)
       '@types/jest': 30.0.0
       '@types/webpack-env': 1.15.3
       eslint: 9.37.0
       jest-environment-jsdom: 30.4.1
       jest-junit: 12.3.0
       typescript: 5.3.3
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -10727,11 +10676,6 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@pnp/common@1.3.11':
-    dependencies:
-      adal-angular: 1.0.17
-      tslib: 1.10.0
-
   '@pnp/common@2.15.0':
     dependencies:
       tslib: 2.3.0
@@ -10739,10 +10683,6 @@ snapshots:
   '@pnp/common@2.5.0':
     dependencies:
       tslib: 2.2.0
-
-  '@pnp/logging@1.3.11':
-    dependencies:
-      tslib: 1.10.0
 
   '@pnp/logging@2.5.0':
     dependencies:
@@ -10756,41 +10696,11 @@ snapshots:
       react-dom: 17.0.1(react@17.0.1)
       tslib: 2.3.1
 
-  '@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)':
-    dependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      tslib: 1.10.0
-
   '@pnp/odata@2.5.0':
     dependencies:
       '@pnp/common': 2.5.0
       '@pnp/logging': 2.5.0
       tslib: 2.2.0
-
-  '@pnp/sp-clientsvc@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)))':
-    dependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)
-      '@pnp/sp': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))
-      tslib: 1.10.0
-
-  '@pnp/sp-taxonomy@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp-clientsvc@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)))':
-    dependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)
-      '@pnp/sp': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))
-      '@pnp/sp-clientsvc': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)))
-      tslib: 1.10.0
-
-  '@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))':
-    dependencies:
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)
-      tslib: 1.10.0
 
   '@pnp/sp@2.5.0':
     dependencies:
@@ -10799,7 +10709,7 @@ snapshots:
       '@pnp/odata': 2.5.0
       tslib: 2.2.0
 
-  '@pnp/spfx-controls-react@3.23.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
+  '@pnp/spfx-controls-react@3.24.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)':
     dependencies:
       '@emotion/css': 11.13.5
       '@fluentui/merge-styles': 8.5.12
@@ -10817,23 +10727,23 @@ snapshots:
       '@fluentui/theme': 2.7.2(@types/react@17.0.45)(react@17.0.1)
       '@iconify/react': 4.1.1(react@17.0.1)
       '@juggle/resize-observer': 3.4.0
-      '@microsoft/decorators': 1.21.1
+      '@microsoft/decorators': 1.22.2
       '@microsoft/mgt-react': 3.1.3(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@microsoft/mgt-spfx': 3.1.3
-      '@microsoft/sp-adaptive-card-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)
-      '@microsoft/sp-application-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-component-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-dialog': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
-      '@microsoft/sp-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-http': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-listview-extensibility': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-loader': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-office-ui-fabric-core': 1.21.1
-      '@microsoft/sp-page-context': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-property-pane': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
-      '@microsoft/sp-webpart-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-adaptive-card-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)
+      '@microsoft/sp-application-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-component-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-dialog': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-http': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-listview-extensibility': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
+      '@microsoft/sp-loader': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-office-ui-fabric-core': 1.22.2
+      '@microsoft/sp-page-context': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-property-pane': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-webpart-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
       '@monaco-editor/loader': 1.7.0
       '@nuvemerudita/react-controls': 1.0.0(@babel/core@7.29.0)(@babel/template@7.28.6)(scheduler@0.20.2)
       '@pnp/common': 2.5.0
@@ -10853,7 +10763,7 @@ snapshots:
       date-fns: 2.30.0
       he: 1.2.0
       jotai: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@17.0.45)(react@17.0.1)
-      lodash: 4.17.21
+      lodash: 4.17.23
       maplibre-gl: 5.24.0
       markdown-it: 14.1.1
       monaco-editor: 0.29.1
@@ -10885,23 +10795,17 @@ snapshots:
       - stream-browserify
       - supports-color
 
-  '@pnp/spfx-property-controls@3.22.0(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)(swiper@8.4.7)':
+  '@pnp/spfx-property-controls@3.23.0(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)(swiper@8.4.7)':
     dependencies:
       '@fluentui/react': 8.106.4(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@fluentui/react-components': 9.73.8(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)
-      '@microsoft/sp-adaptive-card-extension-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)
-      '@microsoft/sp-core-library': 1.21.1(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
-      '@microsoft/sp-lodash-subset': 1.21.1
-      '@microsoft/sp-office-ui-fabric-core': 1.21.1
-      '@microsoft/sp-property-pane': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
-      '@microsoft/sp-webpart-base': 1.21.1(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-adaptive-card-extension-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)(scheduler@0.20.2)(swiper@8.4.7)
+      '@microsoft/sp-core-library': 1.22.2(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+      '@microsoft/sp-lodash-subset': 1.22.2
+      '@microsoft/sp-office-ui-fabric-core': 1.22.2
+      '@microsoft/sp-property-pane': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
+      '@microsoft/sp-webpart-base': 1.22.2(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
       '@monaco-editor/loader': 1.7.0
-      '@pnp/common': 1.3.11
-      '@pnp/logging': 1.3.11
-      '@pnp/odata': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)
-      '@pnp/sp': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))
-      '@pnp/sp-clientsvc': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)))
-      '@pnp/sp-taxonomy': 1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp-clientsvc@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11))))(@pnp/sp@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)(@pnp/odata@1.3.11(@pnp/common@1.3.11)(@pnp/logging@1.3.11)))
       '@pnp/telemetry-js': 2.0.0
       '@uifabric/icons': 7.5.17(@types/react-dom@17.0.17)(@types/react@17.0.45)(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       brace: 0.11.1
@@ -11084,7 +10988,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-webpack5-plugin@1.3.10(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15))':
+  '@rushstack/heft-webpack5-plugin@1.3.10(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/node@25.9.1)(tslib@2.8.1)(webpack@5.105.4)':
     dependencies:
       '@rushstack/debug-certificate-manager': 1.7.10(@types/node@25.9.1)
       '@rushstack/heft': 1.2.17(@types/node@25.9.1)
@@ -11092,8 +10996,8 @@ snapshots:
       '@types/tapable': 1.0.6
       tapable: 1.1.3
       watchpack: 2.4.0
-      webpack: 5.105.4(postcss@8.5.15)
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15))
+      webpack: 5.105.4
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.4)
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -11120,7 +11024,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/loader-raw-script@1.4.92':
+  '@rushstack/loader-raw-script@1.5.2':
     dependencies:
       loader-utils: 2.0.4
 
@@ -11147,7 +11051,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@rushstack/node-core-library@5.12.0(@types/node@25.9.1)':
+  '@rushstack/node-core-library@5.17.1(@types/node@25.9.1)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -11233,11 +11137,11 @@ snapshots:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/set-webpack-public-path-plugin@5.3.8(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))':
+  '@rushstack/set-webpack-public-path-plugin@5.3.8(@types/node@25.9.1)(webpack@5.105.4)':
     dependencies:
       '@rushstack/node-core-library': 5.20.3(@types/node@25.9.1)
-      '@rushstack/webpack-plugin-utilities': 0.6.8(webpack@5.105.4(postcss@8.5.15))
-      webpack: 5.105.4(postcss@8.5.15)
+      '@rushstack/webpack-plugin-utilities': 0.6.8(webpack@5.105.4)
+      webpack: 5.105.4
     optionalDependencies:
       '@types/node': 25.9.1
     transitivePeerDependencies:
@@ -11304,30 +11208,30 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@rushstack/webpack-plugin-utilities@0.6.8(webpack@5.105.4(postcss@8.5.15))':
+  '@rushstack/webpack-plugin-utilities@0.6.8(webpack@5.105.4)':
     dependencies:
       memfs: 4.12.0
       webpack-merge: 5.8.0
     optionalDependencies:
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
 
-  '@rushstack/webpack5-localization-plugin@0.16.7(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))':
+  '@rushstack/webpack5-localization-plugin@0.16.7(@types/node@25.9.1)(webpack@5.105.4)':
     dependencies:
       '@rushstack/localization-utilities': 0.15.7(@types/node@25.9.1)
       '@rushstack/node-core-library': 5.20.3(@types/node@25.9.1)
       '@rushstack/terminal': 0.22.3(@types/node@25.9.1)
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@rushstack/webpack5-module-minifier-plugin@5.8.8(@rushstack/module-minifier@0.9.12(@types/node@25.9.1))(@types/node@25.9.1)(webpack@5.105.4(postcss@8.5.15))':
+  '@rushstack/webpack5-module-minifier-plugin@5.8.8(@rushstack/module-minifier@0.9.12(@types/node@25.9.1))(@types/node@25.9.1)(webpack@5.105.4)':
     dependencies:
       '@rushstack/module-minifier': 0.9.12(@types/node@25.9.1)
       '@rushstack/worker-pool': 0.7.7(@types/node@25.9.1)
       '@types/estree': 1.0.8
       '@types/tapable': 1.0.6
       tapable: 2.2.1
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     optionalDependencies:
       '@types/node': 25.9.1
 
@@ -11348,10 +11252,6 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@swc/helpers@0.5.12':
-    dependencies:
-      tslib: 2.8.1
 
   '@swc/helpers@0.5.21':
     dependencies:
@@ -11927,8 +11827,6 @@ snapshots:
 
   adal-angular@1.0.16: {}
 
-  adal-angular@1.0.17: {}
-
   adaptive-expressions@4.23.3:
     dependencies:
       '@microsoft/recognizers-text-data-types-timex-expression': 1.3.1
@@ -12164,14 +12062,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.102.1(postcss@8.5.15)):
+  babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.102.1):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.102.1(postcss@8.5.15)
+      webpack: 5.102.1
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
@@ -12434,9 +12332,6 @@ snapshots:
 
   commander@10.0.1: {}
 
-  commander@11.1.0:
-    optional: true
-
   commander@14.0.3: {}
 
   commander@2.20.3: {}
@@ -12514,7 +12409,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@7.1.3(webpack@5.102.1(postcss@8.5.15)):
+  css-loader@7.1.3(webpack@5.102.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -12525,9 +12420,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.102.1(postcss@8.5.15)
+      webpack: 5.102.1
 
-  css-loader@7.1.3(webpack@5.105.4(postcss@8.5.15)):
+  css-loader@7.1.3(webpack@5.105.4):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -12538,7 +12433,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
 
   css-select@4.3.0:
     dependencies:
@@ -13506,17 +13401,17 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-loader@4.2.0(webpack@5.102.1(postcss@8.5.15)):
+  html-loader@4.2.0(webpack@5.102.1):
     dependencies:
       html-minifier-terser: 7.2.0
       parse5: 7.3.0
-      webpack: 5.102.1(postcss@8.5.15)
+      webpack: 5.102.1
 
-  html-loader@4.2.0(webpack@5.105.4(postcss@8.5.15)):
+  html-loader@4.2.0(webpack@5.105.4):
     dependencies:
       html-minifier-terser: 7.2.0
       parse5: 7.3.0
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
 
   html-minifier-terser@7.2.0:
     dependencies:
@@ -14417,7 +14312,7 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 
@@ -15706,11 +15601,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@4.0.2(webpack@5.105.4(postcss@8.5.15)):
+  source-map-loader@4.0.2(webpack@5.105.4):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
 
   source-map-support@0.5.13:
     dependencies:
@@ -15967,25 +15862,21 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.6.0(postcss@8.5.15)(webpack@5.102.1(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(webpack@5.102.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.102.1(postcss@8.5.15)
-    optionalDependencies:
-      postcss: 8.5.15
+      webpack: 5.102.1
 
-  terser-webpack-plugin@5.6.0(postcss@8.5.15)(webpack@5.105.4(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.105.4(postcss@8.5.15)
-    optionalDependencies:
-      postcss: 8.5.15
+      webpack: 5.105.4
 
   terser@5.48.0:
     dependencies:
@@ -16054,8 +15945,6 @@ snapshots:
       typescript: 5.8.3
 
   ts-easing@0.2.0: {}
-
-  tslib@1.10.0: {}
 
   tslib@1.14.1: {}
 
@@ -16224,8 +16113,6 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  validator@13.15.22: {}
-
   varint@6.0.0: {}
 
   vary@1.1.2: {}
@@ -16275,7 +16162,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.4):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -16284,11 +16171,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15)):
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.4):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16316,10 +16203,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.4(postcss@8.5.15))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.4)
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.105.4(postcss@8.5.15)
+      webpack: 5.105.4
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16334,7 +16221,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.102.1(postcss@8.5.15):
+  webpack@5.102.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -16358,7 +16245,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(postcss@8.5.15)(webpack@5.102.1(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(webpack@5.102.1)
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -16375,7 +16262,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.105.4(postcss@8.5.15):
+  webpack@5.105.4:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -16399,7 +16286,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(postcss@8.5.15)(webpack@5.105.4(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -16541,11 +16428,3 @@ snapshots:
   yaml@1.10.3: {}
 
   yocto-queue@0.1.0: {}
-
-  z-schema@6.0.2:
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.15.22
-    optionalDependencies:
-      commander: 11.1.0

--- a/search-parts/src/common/BaseWebPart.ts
+++ b/search-parts/src/common/BaseWebPart.ts
@@ -15,13 +15,12 @@ import { IBaseWebPartProps } from "../models/common/IBaseWebPartProps";
 import * as commonStrings from 'CommonStrings';
 import { ThemeProvider, IReadonlyTheme, ThemeChangedEventArgs } from '@microsoft/sp-component-base';
 import { isEqual } from '@microsoft/sp-lodash-subset';
-import { PropertyPaneWebPartInformation } from '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation';
+// @pnp/spfx-property-controls fields are edit-mode only. They are loaded as a shared async chunk in
+// loadCommonPropertyPaneResources() (called from each web part's loadPropertyPaneResources) instead
+// of being imported synchronously here, so they stay out of every web part's entry bundle.
 import { Log } from '@microsoft/sp-core-library';
 import { DisplayMode } from '@microsoft/sp-core-library';
 import { AudienceTargetingService } from '../services/audienceTargetingService/AudienceTargetingService';
-import { PropertyFieldPeoplePicker, PrincipalType } from '@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker';
-import { PropertyFieldNumber } from '@pnp/spfx-property-controls/lib/PropertyFieldNumber';
-import { PropertyFieldColorPicker, PropertyFieldColorPickerStyle } from '@pnp/spfx-property-controls/lib/PropertyFieldColorPicker';
 
 /**
  * Generic abstract class for all Web Parts in the solution
@@ -56,6 +55,18 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
      */
     protected _isHiddenByAudience: boolean = false;
 
+    /**
+     * Lazily-loaded @pnp/spfx-property-controls references, shared by all web parts. Populated by
+     * loadCommonPropertyPaneResources() as part of the property-pane chunk so the heavy dependency
+     * graph is only downloaded when the property pane is opened (never on view-mode page loads).
+     */
+    protected _basePropertyPaneWebPartInformation: typeof import('@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation').PropertyPaneWebPartInformation = null;
+    protected _basePropertyFieldPeoplePicker: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker').PropertyFieldPeoplePicker = null;
+    protected _basePrincipalType: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker').PrincipalType = null;
+    protected _basePropertyFieldNumber: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldNumber').PropertyFieldNumber = null;
+    protected _basePropertyFieldColorPicker: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldColorPicker').PropertyFieldColorPicker = null;
+    protected _basePropertyFieldColorPickerStyle: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldColorPicker').PropertyFieldColorPickerStyle = null;
+
     constructor() {
         super();
     }
@@ -88,6 +99,39 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
     }
 
     /**
+     * Lazily loads the @pnp/spfx-property-controls used by the shared property-pane groups.
+     * Web parts must call this from their own loadPropertyPaneResources() before building the
+     * property pane configuration. All controls share the 'pnp-modern-search-property-pane' async
+     * chunk so they never end up in the synchronous web part entry bundle.
+     */
+    protected async loadCommonPropertyPaneResources(): Promise<void> {
+
+        // Already loaded
+        if (this._basePropertyFieldColorPicker) {
+            return;
+        }
+
+        const [
+            { PropertyPaneWebPartInformation },
+            { PropertyFieldPeoplePicker, PrincipalType },
+            { PropertyFieldNumber },
+            { PropertyFieldColorPicker, PropertyFieldColorPickerStyle }
+        ] = await Promise.all([
+            import(/* webpackChunkName: 'pnp-modern-search-property-pane' */ '@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation'),
+            import(/* webpackChunkName: 'pnp-modern-search-property-pane' */ '@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker'),
+            import(/* webpackChunkName: 'pnp-modern-search-property-pane' */ '@pnp/spfx-property-controls/lib/PropertyFieldNumber'),
+            import(/* webpackChunkName: 'pnp-modern-search-property-pane' */ '@pnp/spfx-property-controls/lib/PropertyFieldColorPicker')
+        ]);
+
+        this._basePropertyPaneWebPartInformation = PropertyPaneWebPartInformation;
+        this._basePropertyFieldPeoplePicker = PropertyFieldPeoplePicker;
+        this._basePrincipalType = PrincipalType;
+        this._basePropertyFieldNumber = PropertyFieldNumber;
+        this._basePropertyFieldColorPicker = PropertyFieldColorPicker;
+        this._basePropertyFieldColorPickerStyle = PropertyFieldColorPickerStyle;
+    }
+
+    /**
      * Returns common information groups for the property pane
      */
     protected getPropertyPaneWebPartInfoGroups(): IPropertyPaneGroup[] {
@@ -96,7 +140,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
             {
                 groupName: commonStrings.General.About,
                 groupFields: [
-                    PropertyPaneWebPartInformation({
+                    this._basePropertyPaneWebPartInformation({
                         description: `<span>${commonStrings.General.Authors}: <ul style="list-style-type: none;padding: 0;"><li>Franck Cornu <a href="https://www.linkedin.com/in/franckcornu/" target="_blank"><img width="16px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAABmJLR0QA/wD/AP+gvaeTAAAPDElEQVR4nO2deXBcR53Hv93vzamR5ZE0si7Llizb8ZEsieMYlxUCCS6SJQ4kwakCqqjaOBuDOYorkKJI4draXTCEImQXQg6OYhMIdhEqhBBDCLYr2OAshODYia/IliPLkkbXaM53de8fsrSSZkbz5r2epxn7fVyucb2j++f5zq/717/u1w9wcXFxcXFxmQ+IiEKav/TsSpmQf+IgrX7Zs9gnYykHpyLKvlzQGc6mFOMcOO8llB89t+u2YyLKtSxwyxef21jtlz7PQW6ur/Z6OupD0uK6oFQX9JAFfg8oEfLbuSzg4IhldIwkVd47kjK6hxJGNKbokOlLCUX7Tu83tuy3WnbRKrTe9+sbagLex6v90pI71rV5blwZIVU+2Wr9LnlIqQb2nxzAr149rw4llL6EZvyLFaFNC9y887lgjSH/T8Ar3frpG5d7r10SLrYuF4u8dm4MD+87pSYz+r4xSb+jb+eWlNl7TQnc/oXnl/iC9M9dy+oW3fOuDuqR3O7VaRjj+NHBHvbHEwN9cVXf1Ldryzkz9xUUuO3+33T4JPLax2/oDHV11rsd6zxz6K0h/uiB7mRc1Taf/+Ztfyl0/ZyCLfviMw2SP/Dmx29YFr5uadgVt0x4sz+Ob+09nlQU/cqeB287M9e1+UXbuZNeYWx47QNXt6y9eXWjK26Zcah7CD891BPVNHl5967NsXzX5Q1/l6nXfrItUnXFTSsbiGaw0ljpYpn1S2rx9nC6bv/JwacA3Jrvupye2fHlF2skWe372pa1wXDQUzIjXexhMI6v/vqoMjyuvuf8g1v+nOuanB5Mqfal9e21vpBPguu95c1H17f5fnjwzC+wdXc79txlzD6fLfDW3RII//R7VjRIusEdMdLFOssiITQt8EcyHcY/nwOem30+S+DWZYHrIwt8cpVPhup6b0WwqTPi7x9P3wczAgc88u1XtSz060y89wa9ErwyhUQIdMah6AwZLatVcSmS5Y0hMI71S+97vvHst97fP/1clsCU883NNX6i6WK8N+iVsLq5Bu31QVT7swO2aFxBdzSB4/1xGCX4UV0urGpcIL16buxWAE9MP54lsM54a03QA43ZF/iatjCubgtDpvmH0ZFqHyLVPqxtqcGBU1G8PWI6zeoyjfZIyHN8IH47CglsMO6TCIWmW/cmSghuXtuIjkiV6XuqfDJuWdOEAyejOHo+77jdJQ+RkA/g/JrZx2cKvHW3RAlsD43evbKhKHEnIQR414p6DCUU15OLxO+h0AyEAU4AMuWdMwVeEyFQUtxO89waDuDqtoWW76eE4L2rFuGJP3WDcbdPLgZCAOzcL2En9MljORMddprndW21lu+dZGHQg476EN68MG67rMud3AJb9GCfTNHZELJl0CRXNFXjyPkxIWVdzmQJzDmH1SHS4nAQ0hwRczEsqQ1atuNyhefo0nJ6sNUkh8i1WVU+GYQQNxduk5yKWE1RzjXetYJECZKqK7AdcnuwxUmG8Yxmy5jpcACxtOZmt2ySLTAh3Gqz2B/L2LVnitGk6uapi4WQLG/IDrJgPdHRPZRAPKOj2m+/Lz7aF3P73yLJ1dZlK8HtZbJeOTOMm1Ytsnz/JIdOD7kCF0sOhXO4GodmY6L/mb+fR9fyCHyy9bXTR8/H8I9eNx9dPCaHSXY8Z2A8g+/vO43PbV5h6f7RlIqHXjrpeq8ghEbRkxw4GcWiBX58eENbUQ8/jaZUfOOF4xiKq7bqd/l/cgZZIpbqPHm4BycH4rjn+g60hgNzXss5cOBUFD/8UzeGE664VjEXZAHQBTWPh94awuEzw9jYUYeu5RGsaV6AcNALr0wxltIQjWdw+MwI9p8YxDl3erAk5ImixSUXNINj34ko9p2ICivTJQ/momj7E/4u5UOOPphbzmS5zC8c2dNJeTzYzf9eKrhN9CVOziDLfWSlQjETZIkaB1+KeCSKK1tqcFVrDepCPtSHvAj5ZOiMYzyt4UIsg7dHUjjSG8Pbo84P+8yPg22squxsCOG6pfYW3jEOPP2/hbegcKIuSghuWtWAj21cig3tdaZz7H2xNF54vR+/fLUXx/rmL6+eU2A7q1U3tNfhP2+/0noBmOgifv5KYYHXL6nF1++4yl5dLH9dN17RgK9tWYP2+uLXeDfXBLCtqx3butpx4GQUD/7uBP7R6/wiwore4KpUiz2qvDL+/YNrcee6ViHl3bAigq7Oevzk0Fns2nvc0YUMFb0fUikWxreGg3j2U5uEiTuJRAm2dbXj2U9uQms4KLTsuahogQ3BAjfW+LF7+zuxYlG10HKns6ppAfZs34jFtc6IXNECc4FtdLVfxpPbNjjiXS3hAHZv34hIta/kdVW0wCL74G9vfUdJPXc2LQsDePxj16LUuwZWtMCimugPvqMFN69tFFJWMVzTFsbdm9pLWkdFCywiyKIEeODW1QKsscZnNy9HU42/ZOVXtMAiHJgS4khfmI8qr4zPb14ppCyupoewf+axWQIfgDbcq7F0HJzpKHculeeH77ymFS0L517WlBfOwDIJ6LFB6PGhCN59YMbpHB7MvSw9DmNsAMZ4FExJinGVEiBgG5GyQJYIPlTUuJuDq2kY8SHooxfAUjHAyP3Y0JxNNNdVsOQY9LF+GKkYuO4uiCsVH1q3GIXegsB1FSw9Dn1sAEZiBFxTCpZrLlXJGXgmASOTACgF8fhBPX4Qjx8FrXIxxZK6IFY31cyamODgmgKmpsG1jKUmq/hcNGPgSgqGkpomdgDE47ukxO6PZfDk4R68+MYAzg4lkdYMRKp9aKsN4n1rGnH71S1YtEBs9Hv98noc6xsD15QpYcHs5a3tTTZMFxsAkb1Ij9cglUohEAiAVKDgBuN4+I+n8L19p6HO2mEgGlcQjSv4W88ovvuHU3hgy2p85Lo2W/VxzpFOp5FKpdAZzEAf6bNV3myEziZxXUU6EUNvby8opQgGgwgEAggEAvD5fGUvuG5w7PjZ37D3aH/Ba5Oqjvt/eQRp1cC2ruKSFYqiIJPJTAmr6xMjlvaw15Ldc1Gy6ULGGBKJBBKJBACAEAK/3w+/349AIAC/3w9ZLq/ZygeePWpK3On8x/NvXNzRL/fWUYwxZDKZKUHT6TRYnr60JuBBXciH4UTh4Mksjn3Dk01ROp3G6OjoROWyDK/XC5/PN+PT7Nt+RDYIv3+jH08d7in6Pp1x7Np7HE/f+05omgZFUaAoClRVnfoshvb6qsoUOBe6rkPXdaRSM9cvUSrDSAwDVAahFITKAJVAqARQSbwdjOPfnnuj8IWcgzMDYPrFTwPc0PHy36P47UEfOi3s7jebesFZtfJqIy+iaRq4OrEdRFaKhZAJsQlFclTChQsXIEnS1F9KKQghIISA0olh/uTndCabSc459r7eh57+YXDOAM4mgsfJf3MOzhjAjTmHKS+fjIoROCS2H84tsJ227+KXawdCCtjADHAY0NXMVB9vh9/99QSM5KhJw3Lz155R3F1ksJWLcNDGcNPss0l2Xko6oY0AgU3YIKIuADh2YdxUfXNxdjgpxBa/V7Jty3SEezChNGeTWAycc1M2iKgLAIYSqu2ILakyjKV11FbZa2L9Hllo9Ci+iYYDTbTAugAgrTEhX+pISkNdyF6Q5JWpAwLbaaJF9cFmmmhqvy6DcUwkrOx/qYpmCPi/UyG2TJLHg22USAT0i8ScDUL6YJN1mSGjcwECE5H65trpDpyUgQebssHJukzAISDAvPjHUv0kO46u6D5YWHcgrM8TYQ9xog+2jrg+2NSVDtZlpiwBQZ/gCZk8Hmx96EGI/aEL5dyUDdOzVZbrgrm6TJUlYNhGKRVmD1CKVKWAIMvs7c62FuYKExL0CUR8osPBfpFczDs7UZe5sgT83+FIH1wGQZapVKVzdZkrS1CQVdapSicjW1HdgSgPFpFZcyKKtlW8sLGpmeucq8tsYSI8WGQ3LN6DHRwHU3IJ9sHOjINtVCAsinYmF112fbDI3ClK0geLGgeb8WBR42BBAlP79hDqxGxSua/omI+6zJTlpirNlmHuOmF9sCDEpCrF2DJJCSYbnBu6lNtkQ8UEWZUyXUgEBXTCBiaCgiyRA6USRNHORbbUwbrMlVURmSx7TYSTUbSQugRG0SJmk+xF0dn3VXaqsswmG8Tk4cs8inZ0ulBYokMMQqJowWF0ZacqUWaTDZUSRVdKkCVsPlhYkCXiB+dIqtJ6geL64MLXCYuihXXBghIdAltp4eNgMYGGWRvKa9msqCa69OPgComiqagg67LLRdsU2LnZpPIaB4t4GI6QMn82ydkgy81kFWLmz+3Yai609BJTMYY6B7mo4RQzBd5zl0HKc1tKlwJwzgAQBXvumrFzWvaLsSjS4MxvdXX9X7qHcf8zR6xZOWmDyR/ZK2dHHKvLDD8+eAZ7j12wVYbl9ygbOgghp2cfzhKYgHZzQ19HZGtPqp8eTOD0oP19M8qtLjPsOzE4b3UzPaODGS/MPp7lpgZjLzFdLf/Nol1mwNPJBGHsV7OPZwlMCV6Akow7Y5aLCLiugoMN9/34U6/OPpclcH+s7mVm6NzuLqcuzmFkkgkw46Fc57IjqT13GQB52EjH0yW3zMU23NDA1aSmZoyf5jqfM1RWKB5iakLjhuvF5Y4RH4lzgh0jT31mPNf5nAKPPrY9Rjn/ipEYTpbWPBc7sEyCgRuvDzz+iafzXZN3sNvXOvgI19UjLB3L/bYHl3mFaxlupMaGNEPdOtd1c2b7mu99tJ4z9poUqm0i3mBFv2PpUoLrGvTxwTgD6xp8YsecmZ45Ret7bPsQ19GlJ0ZGDCXljo3LAK5luD4+GGPAnYXEBUzm65u2/fcSTqSXqK+qWapaGHDT/PODkYpljHR8hBN+ixlxgSKUar730aDB+KME5ANSqDZEvX5XZYdgWgYsOTrODeOg18s/eu6RHSb2Pp6gaJEa//V76wHpByB0mRSorqbeIBW57Y/LRTgHU1KcZ+LjjOl9YPwL/T/akZVrLoRlL2y4+wcbCcEOSvgtkGRKJI8E6qkilEpuC24BDnDGDBhaCoamM6YDIC8C/JH+Jz6x32qxQqRYdM9/tYPTtRToNIjUJBGIfz/MJQ7hXOeM9xGCbl2SXh98bPtb822Ti4uLi4uLi3X+D+tOrAMpv7yYAAAAAElFTkSuQmCC"/></a> <a href="https://github.com/sponsors/FranckyC"><img width="16px" src="https://github.githubassets.com/images/modules/site/sponsors/pixel-mona-heart.gif"/></a></li><li>Mikael Svenson <a href="https://www.linkedin.com/in/mikaels/" target="_blank"><img width="16px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAABmJLR0QA/wD/AP+gvaeTAAAPDElEQVR4nO2deXBcR53Hv93vzamR5ZE0si7Llizb8ZEsieMYlxUCCS6SJQ4kwakCqqjaOBuDOYorkKJI4draXTCEImQXQg6OYhMIdhEqhBBDCLYr2OAshODYia/IliPLkkbXaM53de8fsrSSZkbz5r2epxn7fVyucb2j++f5zq/717/u1w9wcXFxcXFxmQ+IiEKav/TsSpmQf+IgrX7Zs9gnYykHpyLKvlzQGc6mFOMcOO8llB89t+u2YyLKtSxwyxef21jtlz7PQW6ur/Z6OupD0uK6oFQX9JAFfg8oEfLbuSzg4IhldIwkVd47kjK6hxJGNKbokOlLCUX7Tu83tuy3WnbRKrTe9+sbagLex6v90pI71rV5blwZIVU+2Wr9LnlIqQb2nxzAr149rw4llL6EZvyLFaFNC9y887lgjSH/T8Ar3frpG5d7r10SLrYuF4u8dm4MD+87pSYz+r4xSb+jb+eWlNl7TQnc/oXnl/iC9M9dy+oW3fOuDuqR3O7VaRjj+NHBHvbHEwN9cVXf1Ldryzkz9xUUuO3+33T4JPLax2/oDHV11rsd6zxz6K0h/uiB7mRc1Taf/+Ztfyl0/ZyCLfviMw2SP/Dmx29YFr5uadgVt0x4sz+Ob+09nlQU/cqeB287M9e1+UXbuZNeYWx47QNXt6y9eXWjK26Zcah7CD891BPVNHl5967NsXzX5Q1/l6nXfrItUnXFTSsbiGaw0ljpYpn1S2rx9nC6bv/JwacA3Jrvupye2fHlF2skWe372pa1wXDQUzIjXexhMI6v/vqoMjyuvuf8g1v+nOuanB5Mqfal9e21vpBPguu95c1H17f5fnjwzC+wdXc79txlzD6fLfDW3RII//R7VjRIusEdMdLFOssiITQt8EcyHcY/nwOem30+S+DWZYHrIwt8cpVPhup6b0WwqTPi7x9P3wczAgc88u1XtSz060y89wa9ErwyhUQIdMah6AwZLatVcSmS5Y0hMI71S+97vvHst97fP/1clsCU883NNX6i6WK8N+iVsLq5Bu31QVT7swO2aFxBdzSB4/1xGCX4UV0urGpcIL16buxWAE9MP54lsM54a03QA43ZF/iatjCubgtDpvmH0ZFqHyLVPqxtqcGBU1G8PWI6zeoyjfZIyHN8IH47CglsMO6TCIWmW/cmSghuXtuIjkiV6XuqfDJuWdOEAyejOHo+77jdJQ+RkA/g/JrZx2cKvHW3RAlsD43evbKhKHEnIQR414p6DCUU15OLxO+h0AyEAU4AMuWdMwVeEyFQUtxO89waDuDqtoWW76eE4L2rFuGJP3WDcbdPLgZCAOzcL2En9MljORMddprndW21lu+dZGHQg476EN68MG67rMud3AJb9GCfTNHZELJl0CRXNFXjyPkxIWVdzmQJzDmH1SHS4nAQ0hwRczEsqQ1atuNyhefo0nJ6sNUkh8i1WVU+GYQQNxduk5yKWE1RzjXetYJECZKqK7AdcnuwxUmG8Yxmy5jpcACxtOZmt2ySLTAh3Gqz2B/L2LVnitGk6uapi4WQLG/IDrJgPdHRPZRAPKOj2m+/Lz7aF3P73yLJ1dZlK8HtZbJeOTOMm1Ytsnz/JIdOD7kCF0sOhXO4GodmY6L/mb+fR9fyCHyy9bXTR8/H8I9eNx9dPCaHSXY8Z2A8g+/vO43PbV5h6f7RlIqHXjrpeq8ghEbRkxw4GcWiBX58eENbUQ8/jaZUfOOF4xiKq7bqd/l/cgZZIpbqPHm4BycH4rjn+g60hgNzXss5cOBUFD/8UzeGE664VjEXZAHQBTWPh94awuEzw9jYUYeu5RGsaV6AcNALr0wxltIQjWdw+MwI9p8YxDl3erAk5ImixSUXNINj34ko9p2ICivTJQ/momj7E/4u5UOOPphbzmS5zC8c2dNJeTzYzf9eKrhN9CVOziDLfWSlQjETZIkaB1+KeCSKK1tqcFVrDepCPtSHvAj5ZOiMYzyt4UIsg7dHUjjSG8Pbo84P+8yPg22squxsCOG6pfYW3jEOPP2/hbegcKIuSghuWtWAj21cig3tdaZz7H2xNF54vR+/fLUXx/rmL6+eU2A7q1U3tNfhP2+/0noBmOgifv5KYYHXL6nF1++4yl5dLH9dN17RgK9tWYP2+uLXeDfXBLCtqx3butpx4GQUD/7uBP7R6/wiwore4KpUiz2qvDL+/YNrcee6ViHl3bAigq7Oevzk0Fns2nvc0YUMFb0fUikWxreGg3j2U5uEiTuJRAm2dbXj2U9uQms4KLTsuahogQ3BAjfW+LF7+zuxYlG10HKns6ppAfZs34jFtc6IXNECc4FtdLVfxpPbNjjiXS3hAHZv34hIta/kdVW0wCL74G9vfUdJPXc2LQsDePxj16LUuwZWtMCimugPvqMFN69tFFJWMVzTFsbdm9pLWkdFCywiyKIEeODW1QKsscZnNy9HU42/ZOVXtMAiHJgS4khfmI8qr4zPb14ppCyupoewf+axWQIfgDbcq7F0HJzpKHculeeH77ymFS0L517WlBfOwDIJ6LFB6PGhCN59YMbpHB7MvSw9DmNsAMZ4FExJinGVEiBgG5GyQJYIPlTUuJuDq2kY8SHooxfAUjHAyP3Y0JxNNNdVsOQY9LF+GKkYuO4uiCsVH1q3GIXegsB1FSw9Dn1sAEZiBFxTCpZrLlXJGXgmASOTACgF8fhBPX4Qjx8FrXIxxZK6IFY31cyamODgmgKmpsG1jKUmq/hcNGPgSgqGkpomdgDE47ukxO6PZfDk4R68+MYAzg4lkdYMRKp9aKsN4n1rGnH71S1YtEBs9Hv98noc6xsD15QpYcHs5a3tTTZMFxsAkb1Ij9cglUohEAiAVKDgBuN4+I+n8L19p6HO2mEgGlcQjSv4W88ovvuHU3hgy2p85Lo2W/VxzpFOp5FKpdAZzEAf6bNV3myEziZxXUU6EUNvby8opQgGgwgEAggEAvD5fGUvuG5w7PjZ37D3aH/Ba5Oqjvt/eQRp1cC2ruKSFYqiIJPJTAmr6xMjlvaw15Ldc1Gy6ULGGBKJBBKJBACAEAK/3w+/349AIAC/3w9ZLq/ZygeePWpK3On8x/NvXNzRL/fWUYwxZDKZKUHT6TRYnr60JuBBXciH4UTh4Mksjn3Dk01ROp3G6OjoROWyDK/XC5/PN+PT7Nt+RDYIv3+jH08d7in6Pp1x7Np7HE/f+05omgZFUaAoClRVnfoshvb6qsoUOBe6rkPXdaRSM9cvUSrDSAwDVAahFITKAJVAqARQSbwdjOPfnnuj8IWcgzMDYPrFTwPc0PHy36P47UEfOi3s7jebesFZtfJqIy+iaRq4OrEdRFaKhZAJsQlFclTChQsXIEnS1F9KKQghIISA0olh/uTndCabSc459r7eh57+YXDOAM4mgsfJf3MOzhjAjTmHKS+fjIoROCS2H84tsJ227+KXawdCCtjADHAY0NXMVB9vh9/99QSM5KhJw3Lz155R3F1ksJWLcNDGcNPss0l2Xko6oY0AgU3YIKIuADh2YdxUfXNxdjgpxBa/V7Jty3SEezChNGeTWAycc1M2iKgLAIYSqu2ILakyjKV11FbZa2L9Hllo9Ci+iYYDTbTAugAgrTEhX+pISkNdyF6Q5JWpAwLbaaJF9cFmmmhqvy6DcUwkrOx/qYpmCPi/UyG2TJLHg22USAT0i8ScDUL6YJN1mSGjcwECE5H65trpDpyUgQebssHJukzAISDAvPjHUv0kO46u6D5YWHcgrM8TYQ9xog+2jrg+2NSVDtZlpiwBQZ/gCZk8Hmx96EGI/aEL5dyUDdOzVZbrgrm6TJUlYNhGKRVmD1CKVKWAIMvs7c62FuYKExL0CUR8osPBfpFczDs7UZe5sgT83+FIH1wGQZapVKVzdZkrS1CQVdapSicjW1HdgSgPFpFZcyKKtlW8sLGpmeucq8tsYSI8WGQ3LN6DHRwHU3IJ9sHOjINtVCAsinYmF112fbDI3ClK0geLGgeb8WBR42BBAlP79hDqxGxSua/omI+6zJTlpirNlmHuOmF9sCDEpCrF2DJJCSYbnBu6lNtkQ8UEWZUyXUgEBXTCBiaCgiyRA6USRNHORbbUwbrMlVURmSx7TYSTUbSQugRG0SJmk+xF0dn3VXaqsswmG8Tk4cs8inZ0ulBYokMMQqJowWF0ZacqUWaTDZUSRVdKkCVsPlhYkCXiB+dIqtJ6geL64MLXCYuihXXBghIdAltp4eNgMYGGWRvKa9msqCa69OPgComiqagg67LLRdsU2LnZpPIaB4t4GI6QMn82ydkgy81kFWLmz+3Yai609BJTMYY6B7mo4RQzBd5zl0HKc1tKlwJwzgAQBXvumrFzWvaLsSjS4MxvdXX9X7qHcf8zR6xZOWmDyR/ZK2dHHKvLDD8+eAZ7j12wVYbl9ygbOgghp2cfzhKYgHZzQ19HZGtPqp8eTOD0oP19M8qtLjPsOzE4b3UzPaODGS/MPp7lpgZjLzFdLf/Nol1mwNPJBGHsV7OPZwlMCV6Akow7Y5aLCLiugoMN9/34U6/OPpclcH+s7mVm6NzuLqcuzmFkkgkw46Fc57IjqT13GQB52EjH0yW3zMU23NDA1aSmZoyf5jqfM1RWKB5iakLjhuvF5Y4RH4lzgh0jT31mPNf5nAKPPrY9Rjn/ipEYTpbWPBc7sEyCgRuvDzz+iafzXZN3sNvXOvgI19UjLB3L/bYHl3mFaxlupMaGNEPdOtd1c2b7mu99tJ4z9poUqm0i3mBFv2PpUoLrGvTxwTgD6xp8YsecmZ45Ret7bPsQ19GlJ0ZGDCXljo3LAK5luD4+GGPAnYXEBUzm65u2/fcSTqSXqK+qWapaGHDT/PODkYpljHR8hBN+ixlxgSKUar730aDB+KME5ANSqDZEvX5XZYdgWgYsOTrODeOg18s/eu6RHSb2Pp6gaJEa//V76wHpByB0mRSorqbeIBW57Y/LRTgHU1KcZ+LjjOl9YPwL/T/akZVrLoRlL2y4+wcbCcEOSvgtkGRKJI8E6qkilEpuC24BDnDGDBhaCoamM6YDIC8C/JH+Jz6x32qxQqRYdM9/tYPTtRToNIjUJBGIfz/MJQ7hXOeM9xGCbl2SXh98bPtb822Ti4uLi4uLi3X+D+tOrAMpv7yYAAAAAElFTkSuQmCC"/></a> <a href="https://twitter.com/mikaelsvenson"><img width="16px" src="https://upload.wikimedia.org/wikipedia/commons/f/f2/Logo_Twitter.png"/></a></ul></span>`,
                         key: 'authors'
                     }),
@@ -191,11 +235,11 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
         return {
             groupName: commonStrings.PropertyPane.AudienceTargeting.GroupName,
             groupFields: [
-                PropertyFieldPeoplePicker('audiences', {
+                this._basePropertyFieldPeoplePicker('audiences', {
                     label: commonStrings.PropertyPane.AudienceTargeting.TargetAudienceLabel,
                     initialData: this.properties.audiences,
                     allowDuplicate: false,
-                    principalType: [PrincipalType.SharePoint, PrincipalType.Users, PrincipalType.Security],
+                    principalType: [this._basePrincipalType.SharePoint, this._basePrincipalType.Users, this._basePrincipalType.Security],
                     onPropertyChange: this.onPropertyPaneFieldChanged.bind(this),
                     context: this.context as any,
                     properties: this.properties,
@@ -203,7 +247,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
                     deferredValidationTime: 0,
                     key: 'audienceTargeting'
                 }),
-                PropertyFieldNumber('audienceCacheDuration', {
+                this._basePropertyFieldNumber('audienceCacheDuration', {
                     key: 'audienceCacheDuration',
                     label: commonStrings.PropertyPane.AudienceTargeting.CacheDurationLabel,
                     description: commonStrings.PropertyPane.AudienceTargeting.CacheDurationDescription,
@@ -245,7 +289,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
                     showValue: true,
                     value: this.properties.titleFontSize || 20
                 }),
-                PropertyFieldColorPicker('titleFontColor', {
+                this._basePropertyFieldColorPicker('titleFontColor', {
                     label: commonStrings.PropertyPane.TitleFontColor,
                     selectedColor: this.properties.titleFontColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -254,7 +298,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'titleFontColorFieldId'
                 }),
                 PropertyPaneButton('resetTitleStyling', {

--- a/search-parts/src/common/BaseWebPart.ts
+++ b/search-parts/src/common/BaseWebPart.ts
@@ -15,9 +15,6 @@ import { IBaseWebPartProps } from "../models/common/IBaseWebPartProps";
 import * as commonStrings from 'CommonStrings';
 import { ThemeProvider, IReadonlyTheme, ThemeChangedEventArgs } from '@microsoft/sp-component-base';
 import { isEqual } from '@microsoft/sp-lodash-subset';
-// @pnp/spfx-property-controls fields are edit-mode only. They are loaded as a shared async chunk in
-// loadCommonPropertyPaneResources() (called from each web part's loadPropertyPaneResources) instead
-// of being imported synchronously here, so they stay out of every web part's entry bundle.
 import { Log } from '@microsoft/sp-core-library';
 import { DisplayMode } from '@microsoft/sp-core-library';
 import { AudienceTargetingService } from '../services/audienceTargetingService/AudienceTargetingService';
@@ -55,11 +52,6 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
      */
     protected _isHiddenByAudience: boolean = false;
 
-    /**
-     * Lazily-loaded @pnp/spfx-property-controls references, shared by all web parts. Populated by
-     * loadCommonPropertyPaneResources() as part of the property-pane chunk so the heavy dependency
-     * graph is only downloaded when the property pane is opened (never on view-mode page loads).
-     */
     protected _basePropertyPaneWebPartInformation: typeof import('@pnp/spfx-property-controls/lib/PropertyPaneWebPartInformation').PropertyPaneWebPartInformation = null;
     protected _basePropertyFieldPeoplePicker: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker').PropertyFieldPeoplePicker = null;
     protected _basePrincipalType: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldPeoplePicker').PrincipalType = null;
@@ -101,12 +93,10 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
     /**
      * Lazily loads the @pnp/spfx-property-controls used by the shared property-pane groups.
      * Web parts must call this from their own loadPropertyPaneResources() before building the
-     * property pane configuration. All controls share the 'pnp-modern-search-property-pane' async
-     * chunk so they never end up in the synchronous web part entry bundle.
+     * property pane configuration.
      */
     protected async loadCommonPropertyPaneResources(): Promise<void> {
 
-        // Already loaded
         if (this._basePropertyFieldColorPicker) {
             return;
         }

--- a/search-parts/src/common/BaseWebPart.ts
+++ b/search-parts/src/common/BaseWebPart.ts
@@ -235,6 +235,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
                     properties: this.properties,
                     onGetErrorMessage: null,
                     deferredValidationTime: 0,
+                    searchTextLimit: 3,
                     key: 'audienceTargeting'
                 }),
                 this._basePropertyFieldNumber('audienceCacheDuration', {

--- a/search-parts/src/helpers/GraphToolKitHelper.ts
+++ b/search-parts/src/helpers/GraphToolKitHelper.ts
@@ -6,7 +6,7 @@ const DISAMBIGUATION = "pnp-modern-search";
 export const loadMsGraphToolkit = async (context: WebPartContext) => {
     // Load Microsoft Graph Toolkit dynamically
     const { customElementHelper } = await import(
-      /* webpackChunkName: 'pnp-modern-search-microsoft-graph-toolkit' */
+      /* webpackChunkName: 'pnp-modern-search-mgt-element' */
       '@microsoft/mgt-element/dist/es6/components/customElementHelper'
     );
 

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -257,9 +257,6 @@ export class TemplateService implements ITemplateService {
                 initializeFileTypeIcons();
                 GlobalSettings.setValue("fileTypeIconsInitialized", true);
             }
-
-            // Load Microsoft Graph Toolkit dynamically
-            this._customElementHelperPromise = this._initMgtCustomElementHelper();
         });
     }
 
@@ -287,8 +284,11 @@ export class TemplateService implements ITemplateService {
 
     private async _initMgtCustomElementHelper(): Promise<void> {
         if (!this._customElementHelper) {
+            // Only the lightweight mgt-element customElementHelper (element-name prefix
+            // plumbing) is loaded here. The heavy mgt-components / fast-foundation bundle
+            // is loaded separately via loadMsGraphToolkit, gated by useMicrosoftGraphToolkit.
             const { customElementHelper } = await import(
-                /* webpackChunkName: 'pnp-modern-search-microsoft-graph-toolkit' */
+                /* webpackChunkName: 'pnp-modern-search-mgt-element' */
                 "@microsoft/mgt-element/dist/es6/components/customElementHelper"
             );
             this._customElementHelper = customElementHelper;
@@ -296,9 +296,12 @@ export class TemplateService implements ITemplateService {
     }
 
     private async _ensureMgtCustomElementHelper(): Promise<void> {
-        if (this._customElementHelperPromise) {
-            await this._customElementHelperPromise;
+        // Lazily load the helper on first actual need (disambiguation / adaptive cards)
+        // instead of eagerly on every render, so pages that don't use MGT never load it.
+        if (!this._customElementHelperPromise) {
+            this._customElementHelperPromise = this._initMgtCustomElementHelper();
         }
+        await this._customElementHelperPromise;
     }
 
     public legacyStyleParser(

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -21,8 +21,6 @@ import {
     IPropertyPanePage,
     IPropertyPaneGroup
 } from "@microsoft/sp-property-pane";
-// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
-// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
 const SearchBoxContainer = React.lazy(() => import(/* webpackChunkName: 'pnp-modern-search-box-container' */ './components/SearchBoxContainer'));
 import { ISearchBoxContainerProps } from './components/ISearchBoxContainerProps';
 import { DynamicDataService } from '../../services/dynamicDataService/DynamicDataService';
@@ -367,7 +365,6 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
 
     protected async loadPropertyPaneResources(): Promise<void> {
 
-        // Load shared property-controls used by the base web part property-pane groups
         await this.loadCommonPropertyPaneResources();
 
         const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -22,7 +22,6 @@ import {
     IPropertyPaneGroup
 } from "@microsoft/sp-property-pane";
 const SearchBoxContainer = React.lazy(() => import(/* webpackChunkName: 'pnp-modern-search-box-container' */ './components/SearchBoxContainer'));
-import { ISearchBoxContainerProps } from './components/ISearchBoxContainerProps';
 import { DynamicDataService } from '../../services/dynamicDataService/DynamicDataService';
 import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsoft/sp-dynamic-data';
 import IDynamicDataService from '../../services/dynamicDataService/IDynamicDataService';
@@ -244,7 +243,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 themeVariant: this._themeVariant,
                 className: commonStyles.wpTitle
             }
-        } as ISearchBoxContainerProps);
+        });
 
         renderRootElement = React.createElement(React.Suspense, { fallback: null }, searchBoxElement);
 

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -21,8 +21,9 @@ import {
     IPropertyPanePage,
     IPropertyPaneGroup
 } from "@microsoft/sp-property-pane";
-import { PropertyFieldColorPicker, PropertyFieldColorPickerStyle } from '@pnp/spfx-property-controls/lib/PropertyFieldColorPicker';
-import SearchBoxContainer from './components/SearchBoxContainer';
+// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
+// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
+const SearchBoxContainer = React.lazy(() => import(/* webpackChunkName: 'pnp-modern-search-box-container' */ './components/SearchBoxContainer'));
 import { ISearchBoxContainerProps } from './components/ISearchBoxContainerProps';
 import { DynamicDataService } from '../../services/dynamicDataService/DynamicDataService';
 import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsoft/sp-dynamic-data';
@@ -207,7 +208,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
             }
         }
 
-        renderRootElement = React.createElement(SearchBoxContainer, {
+        const searchBoxElement = React.createElement(SearchBoxContainer, {
             domElement: this.domElement,
             enableQuerySuggestions: this.properties.enableQuerySuggestions,
             inputValue: this._searchQueryText,
@@ -246,6 +247,8 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 className: commonStyles.wpTitle
             }
         } as ISearchBoxContainerProps);
+
+        renderRootElement = React.createElement(React.Suspense, { fallback: null }, searchBoxElement);
 
         // Error message
         if (this.errorMessage) {
@@ -363,6 +366,9 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
     }
 
     protected async loadPropertyPaneResources(): Promise<void> {
+
+        // Load shared property-controls used by the base web part property-pane groups
+        await this.loadCommonPropertyPaneResources();
 
         const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
             /* webpackChunkName: 'pnp-modern-search-property-pane' */
@@ -642,7 +648,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
             }),
 
             // Colors
-            PropertyFieldColorPicker('searchBoxBorderColor', {
+            this._basePropertyFieldColorPicker('searchBoxBorderColor', {
                 label: webPartStrings.PropertyPane.SearchBoxStylingGroup.BorderColorLabel,
                 selectedColor: this.properties.searchBoxBorderColor,
                 onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -651,10 +657,10 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 debounce: 500,
                 isHidden: false,
                 alphaSliderHidden: false,
-                style: PropertyFieldColorPickerStyle.Inline,
+                style: this._basePropertyFieldColorPickerStyle.Inline,
                 key: 'searchBoxBorderColorFieldId'
             }),
-            PropertyFieldColorPicker('searchBoxTextColor', {
+            this._basePropertyFieldColorPicker('searchBoxTextColor', {
                 label: webPartStrings.PropertyPane.SearchBoxStylingGroup.TextColorLabel,
                 selectedColor: this.properties.searchBoxTextColor,
                 onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -663,10 +669,10 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 debounce: 500,
                 isHidden: false,
                 alphaSliderHidden: false,
-                style: PropertyFieldColorPickerStyle.Inline,
+                style: this._basePropertyFieldColorPickerStyle.Inline,
                 key: 'searchBoxTextColorFieldId'
             }),
-            PropertyFieldColorPicker('placeholderTextColor', {
+            this._basePropertyFieldColorPicker('placeholderTextColor', {
                 label: webPartStrings.PropertyPane.SearchBoxStylingGroup.PlaceholderTextColorLabel,
                 selectedColor: this.properties.placeholderTextColor,
                 onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -675,10 +681,10 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 debounce: 500,
                 isHidden: false,
                 alphaSliderHidden: false,
-                style: PropertyFieldColorPickerStyle.Inline,
+                style: this._basePropertyFieldColorPickerStyle.Inline,
                 key: 'placeholderTextColorFieldId'
             }),
-            PropertyFieldColorPicker('searchButtonColor', {
+            this._basePropertyFieldColorPicker('searchButtonColor', {
                 label: webPartStrings.PropertyPane.SearchBoxStylingGroup.ButtonColorLabel,
                 selectedColor: this.properties.searchButtonColor,
                 onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -687,7 +693,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
                 debounce: 500,
                 isHidden: false,
                 alphaSliderHidden: false,
-                style: PropertyFieldColorPickerStyle.Inline,
+                style: this._basePropertyFieldColorPickerStyle.Inline,
                 key: 'searchButtonColorFieldId'
             }),
 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -326,7 +326,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
                             this._selectedFilters = updatedFilters;
 
-                            // Notfify dynamic data consumers data have changed
+                            // Notify dynamic data consumers data have changed
                             this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchFilters);
                         },
                         templateService: this.templateService,

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -14,8 +14,6 @@ import {
     PropertyPaneButton,
     PropertyPaneButtonType
 } from '@microsoft/sp-property-pane';
-// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
-// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import { IPropertyPanePage } from '@microsoft/sp-property-pane';
 import * as webPartStrings from 'SearchFiltersWebPartStrings';
@@ -39,8 +37,6 @@ import { FileFormat, ITemplateService } from '../../services/templateService/ITe
 import { isEmpty, isEqual, uniqBy, cloneDeep, uniq, sortBy } from '@microsoft/sp-lodash-subset';
 import { BuiltinFilterTemplates, BuiltinFilterTypes } from '../../layouts/AvailableTemplates';
 import { ServiceScope } from '@microsoft/sp-core-library';
-// AvailableComponents pulls in the Fluent UI web component registry. It is loaded on demand inside
-// onInit() (see availableWebComponentDefinitions seeding) so it stays out of the entry bundle.
 import { PropertyPaneAsyncCombo } from '../../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo';
 import { BaseWebPart } from '../../common/BaseWebPart';
 import commonStyles from '../../styles/Common.module.scss';
@@ -315,39 +311,39 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 React.Suspense,
                 { fallback: null },
                 React.createElement(
-                SearchFilters,
-                {
-                    templateContent: this.templateContentToDisplay,
-                    availableFilters: filterResults,
-                    filtersConfiguration: this.properties.filtersConfiguration,
-                    domElement: this.domElement,
-                    instanceId: this.instanceId,
-                    selectedLayoutKey: this.properties.selectedLayoutKey,
-                    properties: JSON.parse(JSON.stringify(this.properties)),
-                    themeVariant: this._themeVariant,
-                    context: this.context,
-                    onUpdateFilters: (updatedFilters: IDataFilter[]) => {
+                    SearchFilters,
+                    {
+                        templateContent: this.templateContentToDisplay,
+                        availableFilters: filterResults,
+                        filtersConfiguration: this.properties.filtersConfiguration,
+                        domElement: this.domElement,
+                        instanceId: this.instanceId,
+                        selectedLayoutKey: this.properties.selectedLayoutKey,
+                        properties: JSON.parse(JSON.stringify(this.properties)),
+                        themeVariant: this._themeVariant,
+                        context: this.context,
+                        onUpdateFilters: (updatedFilters: IDataFilter[]) => {
 
-                        this._selectedFilters = updatedFilters;
+                            this._selectedFilters = updatedFilters;
 
-                        // Notfify dynamic data consumers data have changed
-                        this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchFilters);
-                    },
-                    templateService: this.templateService,
-                    taxonomyService: this.taxonomyService,
-                    webPartTitleProps: {
-                        displayMode: this.displayMode,
-                        title: this.properties.title,
-                        updateProperty: this._updateTitleProperty,
-                        className: commonStyles.wpTitle
-                    },
-                    filterBackgroundColor: this.properties.filterBackgroundColor,
-                    filterBorderColor: this.properties.filterBorderColor,
-                    filterBorderThickness: this.properties.filterBorderThickness,
-                    titleFont: this.properties.titleFont,
-                    titleFontSize: this.properties.titleFontSize,
-                    titleFontColor: this.properties.titleFontColor
-                } as ISearchFiltersContainerProps
+                            // Notfify dynamic data consumers data have changed
+                            this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchFilters);
+                        },
+                        templateService: this.templateService,
+                        taxonomyService: this.taxonomyService,
+                        webPartTitleProps: {
+                            displayMode: this.displayMode,
+                            title: this.properties.title,
+                            updateProperty: this._updateTitleProperty,
+                            className: commonStyles.wpTitle
+                        },
+                        filterBackgroundColor: this.properties.filterBackgroundColor,
+                        filterBorderColor: this.properties.filterBorderColor,
+                        filterBorderThickness: this.properties.filterBorderThickness,
+                        titleFont: this.properties.titleFont,
+                        titleFontSize: this.properties.titleFontSize,
+                        titleFontColor: this.properties.titleFontColor
+                    } as ISearchFiltersContainerProps
                 )
             );
 
@@ -1711,7 +1707,6 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
     public async loadPropertyPaneResources(): Promise<void> {
 
-        // Load shared property-controls used by the base web part property-pane groups
         await this.loadCommonPropertyPaneResources();
 
         const { PropertyFieldCodeEditor, PropertyFieldCodeEditorLanguages } = await import(

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -14,12 +14,13 @@ import {
     PropertyPaneButton,
     PropertyPaneButtonType
 } from '@microsoft/sp-property-pane';
-import { PropertyFieldColorPicker, PropertyFieldColorPickerStyle } from '@pnp/spfx-property-controls/lib/PropertyFieldColorPicker';
+// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
+// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import { IPropertyPanePage } from '@microsoft/sp-property-pane';
 import * as webPartStrings from 'SearchFiltersWebPartStrings';
 import * as commonStrings from 'CommonStrings';
-import SearchFilters from './components/SearchFiltersContainer';
+const SearchFilters = React.lazy(() => import(/* webpackChunkName: 'pnp-modern-search-filters-container' */ './components/SearchFiltersContainer'));
 import { ISearchFiltersContainerProps } from './components/ISearchFiltersContainerProps';
 import ISearchFiltersWebPartProps from './ISearchFiltersWebPartProps';
 import IDynamicDataService from '../../services/dynamicDataService/IDynamicDataService';
@@ -38,7 +39,8 @@ import { FileFormat, ITemplateService } from '../../services/templateService/ITe
 import { isEmpty, isEqual, uniqBy, cloneDeep, uniq, sortBy } from '@microsoft/sp-lodash-subset';
 import { BuiltinFilterTemplates, BuiltinFilterTypes } from '../../layouts/AvailableTemplates';
 import { ServiceScope } from '@microsoft/sp-core-library';
-import { AvailableComponents } from '../../components/AvailableComponents';
+// AvailableComponents pulls in the Fluent UI web component registry. It is loaded on demand inside
+// onInit() (see availableWebComponentDefinitions seeding) so it stays out of the entry bundle.
 import { PropertyPaneAsyncCombo } from '../../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo';
 import { BaseWebPart } from '../../common/BaseWebPart';
 import commonStyles from '../../styles/Common.module.scss';
@@ -143,7 +145,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     /**
      * The available web component definitions (not registered yet)
      */
-    private availableWebComponentDefinitions: IComponentDefinition<any>[] = AvailableComponents.BuiltinComponents;
+    private availableWebComponentDefinitions: IComponentDefinition<any>[] = [];
 
     /**
      * The available connections as property pane fields
@@ -242,6 +244,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         // Register Web Components in the global page context. We need to do this BEFORE the template processing to avoid race condition.
         // Web components are only defined once.
         // We need to register components here in the case where the Search Results WP is not present on the page
+        const { AvailableComponents } = await import(/* webpackChunkName: 'pnp-modern-search-web-components' */ '../../components/AvailableComponents');
+        this.availableWebComponentDefinitions = AvailableComponents.BuiltinComponents;
         await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
 
         return super.onInit();
@@ -308,6 +312,9 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             filterResults = this._initStaticFilters(filterResults, this.properties.filtersConfiguration);
 
             renderRootElement = React.createElement(
+                React.Suspense,
+                { fallback: null },
+                React.createElement(
                 SearchFilters,
                 {
                     templateContent: this.templateContentToDisplay,
@@ -341,6 +348,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     titleFontSize: this.properties.titleFontSize,
                     titleFontColor: this.properties.titleFontColor
                 } as ISearchFiltersContainerProps
+                )
             );
 
         } else {
@@ -739,7 +747,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             groupName: webPartStrings.Styling.StylingOptionsGroupName,
             isCollapsed: true,
             groupFields: [
-                PropertyFieldColorPicker('filterBackgroundColor', {
+                this._basePropertyFieldColorPicker('filterBackgroundColor', {
                     label: webPartStrings.Styling.FilterBackgroundColorLabel,
                     selectedColor: this.properties.filterBackgroundColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -748,10 +756,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'filterBackgroundColorFieldId'
                 }),
-                PropertyFieldColorPicker('filterBorderColor', {
+                this._basePropertyFieldColorPicker('filterBorderColor', {
                     label: webPartStrings.Styling.FilterBorderColorLabel,
                     selectedColor: this.properties.filterBorderColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -760,7 +768,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'filterBorderColorFieldId'
                 }),
                 PropertyPaneSlider('filterBorderThickness', {
@@ -1702,6 +1710,9 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     }
 
     public async loadPropertyPaneResources(): Promise<void> {
+
+        // Load shared property-controls used by the base web part property-pane groups
+        await this.loadCommonPropertyPaneResources();
 
         const { PropertyFieldCodeEditor, PropertyFieldCodeEditorLanguages } = await import(
             /* webpackChunkName: 'pnp-modern-search-code-editor', webpackMode: 'lazy' */

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -20,13 +20,20 @@ import {
 import ISearchResultsWebPartProps, { QueryTextSource } from './ISearchResultsWebPartProps';
 import { AvailableDataSources, BuiltinDataSourceProviderKeys } from '../../dataSources/AvailableDataSources';
 import { ServiceKey } from "@microsoft/sp-core-library";
-import SearchResultsContainer from './components/SearchResultsContainer';
+// Lazy-loaded so the container (and its @fluentui/react dependency graph) is emitted as a shared
+// async chunk instead of being bundled synchronously into every web part entry.
+const SearchResultsContainer = React.lazy(() => import(
+    /* webpackChunkName: 'pnp-modern-search-results-container' */
+    './components/SearchResultsContainer'
+));
 import { AvailableLayouts, BuiltinLayoutsKeys } from '../../layouts/AvailableLayouts';
 import { ITemplateService, FileFormat } from '../../services/templateService/ITemplateService';
 import { TemplateService } from '../../services/templateService/TemplateService';
 import { ServiceScopeHelper } from '../../helpers/ServiceScopeHelper';
 import { cloneDeep, isEmpty, isEqual, uniq, uniqBy } from "@microsoft/sp-lodash-subset";
-import { AvailableComponents } from '../../components/AvailableComponents';
+// AvailableComponents pulls in every Fluent UI-based web component. It is loaded as a shared async
+// chunk in loadExtensions() instead of being imported synchronously, so its heavy dependency graph
+// stays out of the web part entry bundle (it is still loaded at view time before rendering).
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import { ITemplateSlot, IDataContext, ITokenService, SortFieldDirection, IExtensibilityLibrary } from '@pnp/modern-search-extensibility';
 import { TokenService, BuiltinTokenNames } from '../../services/tokenService/TokenService';
@@ -40,7 +47,9 @@ import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsof
 import { IDataResultSourceData } from '../../models/dynamicData/IDataResultSourceData';
 import { LayoutHelper } from '../../helpers/LayoutHelper';
 import { IAsyncComboProps } from '../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps';
-import { AsyncCombo } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
+// Type-only import: the actual AsyncCombo control is loaded as part of the property-pane chunk
+// in loadPropertyPaneResources() so its @fluentui/react dependency stays out of the entry bundle.
+import type { AsyncCombo as AsyncComboType } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
 import { Constants } from '../../common/Constants';
 import PnPTelemetry from "@pnp/telemetry-js";
 import { IPageEventInfo } from '../../components/PaginationComponent';
@@ -54,11 +63,14 @@ import { ItemSelectionMode } from '../../models/common/IItemSelectionProps';
 import { DynamicPropertyHelper } from '../../helpers/DynamicPropertyHelper';
 import { IQueryModifierConfiguration } from '../../queryModifier/IQueryModifierConfiguration';
 import { loadMsGraphToolkit } from '../../helpers/GraphToolKitHelper';
-import { DataSourcePropertyPaneBuilder } from './propertyPane/DataSourcePropertyPaneBuilder';
-import { AboutPropertyPaneBuilder } from './propertyPane/AboutPropertyPaneBuilder';
+// Property-pane builders are loaded lazily (type-only here) so their @fluentui/react and
+// @pnp/spfx-property-controls dependency graphs are emitted in the property-pane chunk instead
+// of the synchronous web part entry bundle. They are downloaded only when the pane is opened.
+import type { DataSourcePropertyPaneBuilder as DataSourcePropertyPaneBuilderType } from './propertyPane/DataSourcePropertyPaneBuilder';
+import type { AboutPropertyPaneBuilder as AboutPropertyPaneBuilderType } from './propertyPane/AboutPropertyPaneBuilder';
 import type { ConnectionsPropertyPaneBuilder as ConnectionsPropertyPaneBuilderType } from './propertyPane/ConnectionsPropertyPaneBuilder';
 import { TokenSetter } from './services/TokenSetter';
-import { StylingPageGroupsBuilder } from './propertyPane/StylingPageGroupsBuilder';
+import type { StylingPageGroupsBuilder as StylingPageGroupsBuilderType } from './propertyPane/StylingPageGroupsBuilder';
 
 // Import statements for templates
 import defaultSimpleListTemplate from '../../layouts/resultTypes/default_simple_list.html';
@@ -69,7 +81,7 @@ import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
 import { Link } from '@fluentui/react/lib/Link';
 import { IComboBoxOption } from '@fluentui/react/lib/ComboBox';
 import { IToggleProps, Toggle } from '@fluentui/react/lib/Toggle';
-import { PropertyFieldMessage } from '@pnp/spfx-property-controls/lib/PropertyFieldMessage';
+// PropertyFieldMessage is loaded with the property-pane chunk (see loadPropertyPaneResources).
 
 const LogSource = "SearchResultsWebPart";
 
@@ -123,6 +135,18 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * downloaded when the property pane is opened. View-mode page loads do not pull it.
      */
     private _connectionsPropertyPaneBuilderClass: typeof ConnectionsPropertyPaneBuilderType = null;
+
+    /**
+     * Lazily-loaded property-pane builder/control references. Like the connections builder above,
+     * these are loaded as part of the `'pnp-modern-search-property-pane'` chunk in
+     * `loadPropertyPaneResources()`, so their heavy dependencies (Fluent UI, property controls)
+     * are only downloaded when the property pane is opened. View-mode page loads do not pull them.
+     */
+    private _dataSourcePropertyPaneBuilderClass: typeof DataSourcePropertyPaneBuilderType = null;
+    private _aboutPropertyPaneBuilderClass: typeof AboutPropertyPaneBuilderType = null;
+    private _stylingPageGroupsBuilderClass: typeof StylingPageGroupsBuilderType = null;
+    private _asyncComboComponent: typeof AsyncComboType = null;
+    private _propertyFieldMessage: typeof import('@pnp/spfx-property-controls/lib/PropertyFieldMessage').PropertyFieldMessage = null;
 
     /**
      * The selected data source for the WebPart
@@ -179,7 +203,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     /**
      * The available web component definitions (not registered yet)
      */
-    private availableWebComponentDefinitions: IComponentDefinition<any>[] = AvailableComponents.BuiltinComponents;
+    private availableWebComponentDefinitions: IComponentDefinition<any>[] = [];
 
     /**
      * The available custom QueryModifier definitions (not registered yet)
@@ -493,7 +517,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 titleFontColor: this.properties.titleFontColor
             } as ISearchResultsContainerProps);
 
-            renderRootElement = renderDataContainer;
+            renderRootElement = React.createElement(React.Suspense, { fallback: null }, renderDataContainer);
 
         } else {
 
@@ -737,7 +761,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         let dataSourceProperties: IPropertyPaneGroup[] = [];
 
         // Initialize property pane builders
-        const dataSourceBuilder = new DataSourcePropertyPaneBuilder(
+        const dataSourceBuilder = new this._dataSourcePropertyPaneBuilderClass(
             this.properties,
             this.dataSource,
             this.availableDataSourceDefinitions,
@@ -747,7 +771,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             webPartStrings
         );
 
-        const aboutBuilder = new AboutPropertyPaneBuilder(
+        const aboutBuilder = new this._aboutPropertyPaneBuilderClass(
             this.getPropertyPaneWebPartInfoGroups.bind(this),
             this.getExtensibilityFields.bind(this),
             this.getAudienceTargetingPropertyPaneGroup.bind(this),
@@ -959,7 +983,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // Reset existing definitions to default
             this.availableDataSourceDefinitions = AvailableDataSources.BuiltinDataSources;
             this.availableLayoutDefinitions = AvailableLayouts.BuiltinLayouts.filter(layout => { return layout.type === LayoutType.Results; });
-            this.availableWebComponentDefinitions = AvailableComponents.BuiltinComponents;
+            // Builtin web components are re-seeded at the top of loadExtensions() (loaded async).
+            this.availableWebComponentDefinitions = [];
             this.availableCustomQueryModifierDefinitions = [];
             this._selectedCustomQueryModifier = [];
             this.properties.queryModifierProperties = {};
@@ -1115,6 +1140,13 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      */
     private async loadExtensions(librariesConfiguration: IExtensibilityConfiguration[]) {
 
+        // Seed builtin web components from a shared async chunk (keeps Fluent UI out of the entry).
+        const { AvailableComponents } = await import(
+            /* webpackChunkName: 'pnp-modern-search-web-components' */
+            '../../components/AvailableComponents'
+        );
+        this.availableWebComponentDefinitions = AvailableComponents.BuiltinComponents;
+
         // Load extensibility library if present
         const extensibilityLibraries = await this.extensibilityService.loadExtensibilityLibraries(librariesConfiguration);
         const customQueryModifierConfiguration: IQueryModifierConfiguration[] = [];
@@ -1179,6 +1211,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
     public async loadPropertyPaneResources(): Promise<void> {
 
+        // Load shared property-controls used by the base web part property-pane groups
+        await this.loadCommonPropertyPaneResources();
+
         const { PropertyFieldCodeEditor, PropertyFieldCodeEditorLanguages } = await import(
             /* webpackChunkName: 'pnp-modern-search-code-editor', webpackMode: 'lazy' */
             '@pnp/spfx-property-controls/lib/propertyFields/codeEditor'
@@ -1239,6 +1274,36 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             './propertyPane/ConnectionsPropertyPaneBuilder'
         );
         this._connectionsPropertyPaneBuilderClass = ConnectionsPropertyPaneBuilder;
+
+        const { DataSourcePropertyPaneBuilder } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            './propertyPane/DataSourcePropertyPaneBuilder'
+        );
+        this._dataSourcePropertyPaneBuilderClass = DataSourcePropertyPaneBuilder;
+
+        const { AboutPropertyPaneBuilder } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            './propertyPane/AboutPropertyPaneBuilder'
+        );
+        this._aboutPropertyPaneBuilderClass = AboutPropertyPaneBuilder;
+
+        const { StylingPageGroupsBuilder } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            './propertyPane/StylingPageGroupsBuilder'
+        );
+        this._stylingPageGroupsBuilderClass = StylingPageGroupsBuilder;
+
+        const { AsyncCombo } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo'
+        );
+        this._asyncComboComponent = AsyncCombo;
+
+        const { PropertyFieldMessage } = await import(
+            /* webpackChunkName: 'pnp-modern-search-property-pane' */
+            '@pnp/spfx-property-controls/lib/PropertyFieldMessage'
+        );
+        this._propertyFieldMessage = PropertyFieldMessage;
 
         this.propertyPaneConnectionsGroup = await this.getConnectionOptionsGroup();
     }
@@ -1402,7 +1467,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * Returns property pane 'Styling' page groups
      */
     private getStylingPageGroups(): IPropertyPaneGroup[] {
-        const builder = new StylingPageGroupsBuilder(
+        const builder = new this._stylingPageGroupsBuilderClass(
             this.properties,
             this.availableLayoutDefinitions,
             this.templateContentToDisplay,
@@ -1690,7 +1755,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                             onCustomRender: (field, value, onUpdate, item) => {
                                 return (
                                     React.createElement("div", null,
-                                        React.createElement(AsyncCombo, {
+                                        React.createElement(this._asyncComboComponent, {
                                             allowFreeform: true,
                                             availableOptions: availableOptions,
                                             placeholder: webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.SlotFieldPlaceholderName,
@@ -1720,7 +1785,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 const undefinedTemplateSlots = layoutSlots.concat(resultTypesSlots).filter(slot => !templateSlotNames.includes(slot));
 
                 templateSlotFields.push(
-                    PropertyFieldMessage('messageMissingSlots', {
+                    this._propertyFieldMessage('messageMissingSlots', {
                         key: 'messageMissingSlotsKey',
                         multiline: true,
                         text: Text.format(webPartStrings.PropertyPane.DataSourcePage.TemplateSlots.MissingSlotsMessage, undefinedTemplateSlots.join(", ")),

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -20,8 +20,6 @@ import {
 import ISearchResultsWebPartProps, { QueryTextSource } from './ISearchResultsWebPartProps';
 import { AvailableDataSources, BuiltinDataSourceProviderKeys } from '../../dataSources/AvailableDataSources';
 import { ServiceKey } from "@microsoft/sp-core-library";
-// Lazy-loaded so the container (and its @fluentui/react dependency graph) is emitted as a shared
-// async chunk instead of being bundled synchronously into every web part entry.
 const SearchResultsContainer = React.lazy(() => import(
     /* webpackChunkName: 'pnp-modern-search-results-container' */
     './components/SearchResultsContainer'
@@ -31,9 +29,6 @@ import { ITemplateService, FileFormat } from '../../services/templateService/ITe
 import { TemplateService } from '../../services/templateService/TemplateService';
 import { ServiceScopeHelper } from '../../helpers/ServiceScopeHelper';
 import { cloneDeep, isEmpty, isEqual, uniq, uniqBy } from "@microsoft/sp-lodash-subset";
-// AvailableComponents pulls in every Fluent UI-based web component. It is loaded as a shared async
-// chunk in loadExtensions() instead of being imported synchronously, so its heavy dependency graph
-// stays out of the web part entry bundle (it is still loaded at view time before rendering).
 import { DynamicProperty } from '@microsoft/sp-component-base';
 import { ITemplateSlot, IDataContext, ITokenService, SortFieldDirection, IExtensibilityLibrary } from '@pnp/modern-search-extensibility';
 import { TokenService, BuiltinTokenNames } from '../../services/tokenService/TokenService';
@@ -47,8 +42,6 @@ import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsof
 import { IDataResultSourceData } from '../../models/dynamicData/IDataResultSourceData';
 import { LayoutHelper } from '../../helpers/LayoutHelper';
 import { IAsyncComboProps } from '../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps';
-// Type-only import: the actual AsyncCombo control is loaded as part of the property-pane chunk
-// in loadPropertyPaneResources() so its @fluentui/react dependency stays out of the entry bundle.
 import type { AsyncCombo as AsyncComboType } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
 import { Constants } from '../../common/Constants';
 import PnPTelemetry from "@pnp/telemetry-js";
@@ -63,9 +56,6 @@ import { ItemSelectionMode } from '../../models/common/IItemSelectionProps';
 import { DynamicPropertyHelper } from '../../helpers/DynamicPropertyHelper';
 import { IQueryModifierConfiguration } from '../../queryModifier/IQueryModifierConfiguration';
 import { loadMsGraphToolkit } from '../../helpers/GraphToolKitHelper';
-// Property-pane builders are loaded lazily (type-only here) so their @fluentui/react and
-// @pnp/spfx-property-controls dependency graphs are emitted in the property-pane chunk instead
-// of the synchronous web part entry bundle. They are downloaded only when the pane is opened.
 import type { DataSourcePropertyPaneBuilder as DataSourcePropertyPaneBuilderType } from './propertyPane/DataSourcePropertyPaneBuilder';
 import type { AboutPropertyPaneBuilder as AboutPropertyPaneBuilderType } from './propertyPane/AboutPropertyPaneBuilder';
 import type { ConnectionsPropertyPaneBuilder as ConnectionsPropertyPaneBuilderType } from './propertyPane/ConnectionsPropertyPaneBuilder';
@@ -81,7 +71,6 @@ import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
 import { Link } from '@fluentui/react/lib/Link';
 import { IComboBoxOption } from '@fluentui/react/lib/ComboBox';
 import { IToggleProps, Toggle } from '@fluentui/react/lib/Toggle';
-// PropertyFieldMessage is loaded with the property-pane chunk (see loadPropertyPaneResources).
 
 const LogSource = "SearchResultsWebPart";
 
@@ -129,19 +118,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _textDialogComponent: any = null;
     private _propertyPanePropertyEditor = null;
 
-    /**
-     * Lazily-loaded `ConnectionsPropertyPaneBuilder` class reference. Loaded as part of the
-     * `'pnp-modern-search-property-pane'` chunk in `loadPropertyPaneResources()`, so it is only
-     * downloaded when the property pane is opened. View-mode page loads do not pull it.
-     */
     private _connectionsPropertyPaneBuilderClass: typeof ConnectionsPropertyPaneBuilderType = null;
 
-    /**
-     * Lazily-loaded property-pane builder/control references. Like the connections builder above,
-     * these are loaded as part of the `'pnp-modern-search-property-pane'` chunk in
-     * `loadPropertyPaneResources()`, so their heavy dependencies (Fluent UI, property controls)
-     * are only downloaded when the property pane is opened. View-mode page loads do not pull them.
-     */
     private _dataSourcePropertyPaneBuilderClass: typeof DataSourcePropertyPaneBuilderType = null;
     private _aboutPropertyPaneBuilderClass: typeof AboutPropertyPaneBuilderType = null;
     private _stylingPageGroupsBuilderClass: typeof StylingPageGroupsBuilderType = null;
@@ -983,7 +961,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // Reset existing definitions to default
             this.availableDataSourceDefinitions = AvailableDataSources.BuiltinDataSources;
             this.availableLayoutDefinitions = AvailableLayouts.BuiltinLayouts.filter(layout => { return layout.type === LayoutType.Results; });
-            // Builtin web components are re-seeded at the top of loadExtensions() (loaded async).
             this.availableWebComponentDefinitions = [];
             this.availableCustomQueryModifierDefinitions = [];
             this._selectedCustomQueryModifier = [];
@@ -1140,7 +1117,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      */
     private async loadExtensions(librariesConfiguration: IExtensibilityConfiguration[]) {
 
-        // Seed builtin web components from a shared async chunk (keeps Fluent UI out of the entry).
         const { AvailableComponents } = await import(
             /* webpackChunkName: 'pnp-modern-search-web-components' */
             '../../components/AvailableComponents'
@@ -1211,7 +1187,6 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
     public async loadPropertyPaneResources(): Promise<void> {
 
-        // Load shared property-controls used by the base web part property-pane groups
         await this.loadCommonPropertyPaneResources();
 
         const { PropertyFieldCodeEditor, PropertyFieldCodeEditorLanguages } = await import(

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -11,8 +11,6 @@ import {
     PropertyPaneButton,
     PropertyPaneButtonType
 } from '@microsoft/sp-property-pane';
-// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
-// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
 import * as commonStrings from 'CommonStrings';
 import * as webPartStrings from 'SearchVerticalsWebPartStrings';
 import { ISearchVerticalsContainerProps } from './components/ISearchVerticalsContainerProps';
@@ -161,33 +159,33 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                 React.Suspense,
                 { fallback: null },
                 React.createElement(
-                SearchVerticalsContainer,
-                {
-                    verticals: verticalsToBeDisplayed,
-                    webPartTitleProps: {
-                        displayMode: this.displayMode,
-                        title: this.properties.title,
-                        updateProperty: (value: string) => {
-                            this.properties.title = value;
-                            this.render();
+                    SearchVerticalsContainer,
+                    {
+                        verticals: verticalsToBeDisplayed,
+                        webPartTitleProps: {
+                            displayMode: this.displayMode,
+                            title: this.properties.title,
+                            updateProperty: (value: string) => {
+                                this.properties.title = value;
+                                this.render();
+                            },
+                            themeVariant: this._themeVariant,
+                            className: commonStyles.wpTitle
                         },
+                        tokenService: this.tokenService,
                         themeVariant: this._themeVariant,
-                        className: commonStyles.wpTitle
-                    },
-                    tokenService: this.tokenService,
-                    themeVariant: this._themeVariant,
-                    onVerticalSelected: this.onVerticalSelected.bind(this),
-                    defaultSelectedKey: defaultSelectedKey,
-                    verticalBackgroundColor: this.properties.verticalBackgroundColor,
-                    verticalBorderColor: this.properties.verticalBorderColor,
-                    verticalBorderThickness: this.properties.verticalBorderThickness,
-                    verticalFontSize: this.properties.verticalFontSize,
-                    verticalMouseOverColor: this.properties.verticalMouseOverColor,
-                    titleFont: this.properties.titleFont,
-                    titleFontSize: this.properties.titleFontSize,
-                    titleFontColor: this.properties.titleFontColor,
-                    instanceId: this.instanceId
-                } as ISearchVerticalsContainerProps
+                        onVerticalSelected: this.onVerticalSelected.bind(this),
+                        defaultSelectedKey: defaultSelectedKey,
+                        verticalBackgroundColor: this.properties.verticalBackgroundColor,
+                        verticalBorderColor: this.properties.verticalBorderColor,
+                        verticalBorderThickness: this.properties.verticalBorderThickness,
+                        verticalFontSize: this.properties.verticalFontSize,
+                        verticalMouseOverColor: this.properties.verticalMouseOverColor,
+                        titleFont: this.properties.titleFont,
+                        titleFontSize: this.properties.titleFontSize,
+                        titleFontColor: this.properties.titleFontColor,
+                        instanceId: this.instanceId
+                    } as ISearchVerticalsContainerProps
                 )
             );
         }
@@ -331,7 +329,6 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
 
     protected async loadPropertyPaneResources(): Promise<void> {
 
-        // Load shared property-controls used by the base web part property-pane groups
         await this.loadCommonPropertyPaneResources();
 
         // tslint:disable-next-line:no-shadowed-variable

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -11,12 +11,13 @@ import {
     PropertyPaneButton,
     PropertyPaneButtonType
 } from '@microsoft/sp-property-pane';
-import { PropertyFieldColorPicker, PropertyFieldColorPickerStyle } from '@pnp/spfx-property-controls/lib/PropertyFieldColorPicker';
+// PropertyFieldColorPicker is edit-mode only and is provided by BaseWebPart's lazily-loaded
+// _basePropertyFieldColorPicker / _basePropertyFieldColorPickerStyle (shared property-pane chunk).
 import * as commonStrings from 'CommonStrings';
 import * as webPartStrings from 'SearchVerticalsWebPartStrings';
 import { ISearchVerticalsContainerProps } from './components/ISearchVerticalsContainerProps';
 import { ISearchVerticalsWebPartProps } from './ISearchVerticalsWebPartProps';
-import SearchVerticalsContainer from './components/SearchVerticalsContainer';
+const SearchVerticalsContainer = React.lazy(() => import(/* webpackChunkName: 'pnp-modern-search-verticals-container' */ './components/SearchVerticalsContainer'));
 import { ComponentType } from '../../common/ComponentType';
 import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsoft/sp-dynamic-data';
 import { IDataVerticalSourceData } from '../../models/dynamicData/IDataVerticalSourceData';
@@ -157,6 +158,9 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                 verticalsToBeDisplayed = await this._filterVerticalsByAudience(verticalsToBeDisplayed);
             }
             renderRootElement = React.createElement(
+                React.Suspense,
+                { fallback: null },
+                React.createElement(
                 SearchVerticalsContainer,
                 {
                     verticals: verticalsToBeDisplayed,
@@ -184,6 +188,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                     titleFontColor: this.properties.titleFontColor,
                     instanceId: this.instanceId
                 } as ISearchVerticalsContainerProps
+                )
             );
         }
 
@@ -325,6 +330,9 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
     }
 
     protected async loadPropertyPaneResources(): Promise<void> {
+
+        // Load shared property-controls used by the base web part property-pane groups
+        await this.loadCommonPropertyPaneResources();
 
         // tslint:disable-next-line:no-shadowed-variable
         const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
@@ -507,7 +515,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
             groupName: webPartStrings.PropertyPane.Styling.WebPartContentStylingGroupName,
             isCollapsed: true,
             groupFields: [
-                PropertyFieldColorPicker('verticalBackgroundColor', {
+                this._basePropertyFieldColorPicker('verticalBackgroundColor', {
                     label: webPartStrings.PropertyPane.Styling.VerticalBackgroundColorLabel,
                     selectedColor: this.properties.verticalBackgroundColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -516,10 +524,10 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'verticalBackgroundColorFieldId'
                 }),
-                PropertyFieldColorPicker('verticalMouseOverColor', {
+                this._basePropertyFieldColorPicker('verticalMouseOverColor', {
                     label: webPartStrings.PropertyPane.Styling.MouseOverColorLabel,
                     selectedColor: this.properties.verticalMouseOverColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -528,10 +536,10 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'verticalMouseOverColorFieldId'
                 }),
-                PropertyFieldColorPicker('verticalBorderColor', {
+                this._basePropertyFieldColorPicker('verticalBorderColor', {
                     label: webPartStrings.PropertyPane.Styling.VerticalBorderColorLabel,
                     selectedColor: this.properties.verticalBorderColor,
                     onPropertyChange: this.onPropertyPaneFieldChanged,
@@ -540,7 +548,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                     debounce: 1000,
                     isHidden: false,
                     alphaSliderHidden: false,
-                    style: PropertyFieldColorPickerStyle.Inline,
+                    style: this._basePropertyFieldColorPickerStyle.Inline,
                     key: 'verticalBorderColorFieldId'
                 }),
                 PropertyPaneSlider('verticalBorderThickness', {


### PR DESCRIPTION
## Summary

Reduces the shipped bundle size by deferring heavy vendor libraries into shared **async** chunks instead of duplicating them in every web part entry. No features or behavior changed — this is a bundling/loading-only optimization.

## Results

| Metric | Before | After | Change |
|---|---|---|---|
| sppkg | 3,423,866 | 3,024,627 | **-11.7%** |
| Search Box entry | 662,370 | 341,110 | -48% |
| Search Filters entry | 1,710,515 | 757,124 | -56% |
| Search Results entry | 1,765,330 | 688,926 | -61% |
| Search Verticals entry | 667,523 | 386,978 | -42% |

Heavy vendors (FluentUI ~1.5MB, `@pnp/spfx-property-controls` ~688KB, handlebars, adaptivecards, ace) now emit **once** as shared async chunks rather than per entry.

## What changed

- **`config/spfx-customize-webpack.js`**: `splitChunks` set to `chunks: 'async'` with named `cacheGroups` (fluentui, pnp-controls, handlebars, adaptivecards, code-editor) so shared vendor chunks are emitted once and carry a clear `pnp-modern-search-*` prefix for CDN identification. Added `ignore-loader` rules for unused spfx-controls-react controls (HoverReactionsBar, dashboard, toolbar) that pull in northstar.
- **`src/common/BaseWebPart.ts`**: removed synchronous `@pnp/spfx-property-controls` imports; property-pane controls now loaded on demand via a shared `loadCommonPropertyPaneResources()` async loader.
- **All 4 web parts** (`SearchResultsWebPart`, `SearchFiltersWebPart`, `SearchBoxWebPart`, `SearchVerticalsWebPart`): containers loaded via `React.lazy` + `Suspense`; property-pane builders converted to `import type` + on-demand loading; `AvailableComponents` deferred in results & filters.

## SPFx constraint note

SPFx injects only a single entry script per web part, so initial split chunks would never load. All splitting is `async` only — every synchronous import path to heavy vendors was eliminated so they resolve through dynamic `import()`.

## Testing

- `npm run build` succeeds for all 4 web parts.
- Confirmed `pnp-modern-search-*` chunks load on read-mode pages.