### PR TITLE
fix: multi-filter external items return 0 results in Microsoft Search (#4796)

### DIFF
--- a/search-parts/src/components/CollapsibleContentComponent.tsx
+++ b/search-parts/src/components/CollapsibleContentComponent.tsx
@@ -61,6 +61,8 @@ export interface ICollapsibleContentComponentState {
 export class CollapsibleContentComponent extends React.Component<ICollapsibleContentComponentProps, ICollapsibleContentComponentState> {
 
     private componentRef = React.createRef<HTMLDivElement>();
+    private headerRef = React.createRef<HTMLDivElement>();
+    private headerDividerProps: IGroupDividerProps;
     private storageKey: string;
 
     public constructor(props) {
@@ -88,6 +90,7 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
         this._onRenderCell = this._onRenderCell.bind(this);
         this._onRenderHeader = this._onRenderHeader.bind(this);
         this._onTogglePanel = this._onTogglePanel.bind(this);
+        this._collapsePanel = this._collapsePanel.bind(this);
     }
 
     public componentDidUpdate(prevProps: ICollapsibleContentComponentProps) {
@@ -171,7 +174,38 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
             groups={groups}
         />;
 
-        return <div ref={this.componentRef} data-name={this.props.groupName} data-is-scrollable={true}>{groupedList}</div>;
+        return <div ref={this.componentRef} data-name={this.props.groupName} data-is-scrollable={true} onKeyDown={(e) => {
+            // Allow keyboard users to close an opened widget and return to its header (#3900).
+            // Escape from anywhere inside the expanded widget collapses it and moves focus back
+            // to the header so it can be re-opened or navigated away from.
+            if (e.key === 'Escape' && !this.state.isCollapsed) {
+                this._collapsePanel();
+            }
+        }}>{groupedList}</div>;
+    }
+
+    /**
+     * Collapses the panel (if expanded) and returns focus to the header so keyboard users are not
+     * trapped inside the filter options (#3900).
+     */
+    private _collapsePanel() {
+        if (this.state.isCollapsed) {
+            return;
+        }
+
+        sessionStorage.setItem(this.storageKey, JSON.stringify(true));
+        this.setState({ isCollapsed: true });
+
+        if (this.headerDividerProps && this.headerDividerProps.onToggleCollapse) {
+            this.headerDividerProps.onToggleCollapse(this.headerDividerProps.group);
+        }
+
+        // Restore focus to the header once the collapse has been applied.
+        window.requestAnimationFrame(() => {
+            if (this.headerRef.current) {
+                this.headerRef.current.focus();
+            }
+        });
     }
 
     private _onTogglePanel(props: IGroupDividerProps) {
@@ -187,6 +221,9 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
     }
 
     private _onRenderHeader(props: IGroupDividerProps): JSX.Element {
+        // Keep a reference to the divider props so the panel can be collapsed programmatically
+        // (e.g. on Escape) and stay in sync with the GroupedList internal collapse state (#3900).
+        this.headerDividerProps = props;
         let textColor: string = this.props.themeVariant && this.props.themeVariant.isInverted ? (this.props.themeVariant ? this.props.themeVariant.semanticColors.bodyText : '#323130') : this.props.themeVariant.semanticColors.inputText;
         const warningDescriptionId = `pnp-warning-${(this.props.groupName || 'group').toString().replace(/[^a-zA-Z0-9_-]/g, '-')}`;
         const textComponentStyles: IStyleFunctionOrObject<ITextProps, ITextStyles> = {
@@ -197,14 +234,17 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
         return (
             <div style={{ position: 'relative' }}>
                 <div
+                    ref={this.headerRef}
                     className={styles.collapsible__filterPanel__body__group__header}
                     role={"menubar"}
                     tabIndex={0}
                     onClick={() => {
                         this._onTogglePanel(props);
                     }}
-                    onKeyPress={(e) => {
-                        if (e.charCode === 13) {
+                    onKeyDown={(e) => {
+                        // Enter or Space toggles the widget open/closed from the header.
+                        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                            e.preventDefault();
                             this._onTogglePanel(props);
                         }
                     }}

--- a/search-parts/src/components/CollapsibleContentComponent.tsx
+++ b/search-parts/src/components/CollapsibleContentComponent.tsx
@@ -91,6 +91,22 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
         this._onRenderHeader = this._onRenderHeader.bind(this);
         this._onTogglePanel = this._onTogglePanel.bind(this);
         this._collapsePanel = this._collapsePanel.bind(this);
+        this._onContainerKeyDown = this._onContainerKeyDown.bind(this);
+    }
+
+    public componentDidMount(): void {
+        // Listen for Escape on the container imperatively rather than via a JSX handler on a static
+        // element. The container is not an interactive control itself; it only catches Escape as it
+        // bubbles up from the filter options (#3900).
+        if (this.componentRef.current) {
+            this.componentRef.current.addEventListener('keydown', this._onContainerKeyDown);
+        }
+    }
+
+    public componentWillUnmount(): void {
+        if (this.componentRef.current) {
+            this.componentRef.current.removeEventListener('keydown', this._onContainerKeyDown);
+        }
     }
 
     public componentDidUpdate(prevProps: ICollapsibleContentComponentProps) {
@@ -174,14 +190,18 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
             groups={groups}
         />;
 
-        return <div ref={this.componentRef} data-name={this.props.groupName} data-is-scrollable={true} onKeyDown={(e) => {
-            // Allow keyboard users to close an opened widget and return to its header (#3900).
-            // Escape from anywhere inside the expanded widget collapses it and moves focus back
-            // to the header so it can be re-opened or navigated away from.
-            if (e.key === 'Escape' && !this.state.isCollapsed) {
-                this._collapsePanel();
-            }
-        }}>{groupedList}</div>;
+        return <div ref={this.componentRef} data-name={this.props.groupName} data-is-scrollable={true}>{groupedList}</div>;
+    }
+
+    /**
+     * Allow keyboard users to close an opened widget and return to its header (#3900). Escape from
+     * anywhere inside the expanded widget collapses it and moves focus back to the header so it can
+     * be re-opened or navigated away from.
+     */
+    private _onContainerKeyDown(e: KeyboardEvent): void {
+        if (e.key === 'Escape' && !this.state.isCollapsed) {
+            this._collapsePanel();
+        }
     }
 
     /**

--- a/search-parts/src/components/CollapsibleContentComponent.tsx
+++ b/search-parts/src/components/CollapsibleContentComponent.tsx
@@ -61,7 +61,7 @@ export interface ICollapsibleContentComponentState {
 export class CollapsibleContentComponent extends React.Component<ICollapsibleContentComponentProps, ICollapsibleContentComponentState> {
 
     private componentRef = React.createRef<HTMLDivElement>();
-    private headerRef = React.createRef<HTMLDivElement>();
+    private readonly headerRef = React.createRef<HTMLDivElement>();
     private headerDividerProps: IGroupDividerProps;
     private storageKey: string;
 
@@ -196,12 +196,12 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
         sessionStorage.setItem(this.storageKey, JSON.stringify(true));
         this.setState({ isCollapsed: true });
 
-        if (this.headerDividerProps && this.headerDividerProps.onToggleCollapse) {
+        if (this.headerDividerProps?.onToggleCollapse) {
             this.headerDividerProps.onToggleCollapse(this.headerDividerProps.group);
         }
 
         // Restore focus to the header once the collapse has been applied.
-        window.requestAnimationFrame(() => {
+        globalThis.requestAnimationFrame(() => {
             if (this.headerRef.current) {
                 this.headerRef.current.focus();
             }

--- a/search-parts/src/components/DocumentCardShimmersComponent.tsx
+++ b/search-parts/src/components/DocumentCardShimmersComponent.tsx
@@ -19,6 +19,14 @@ export interface DocumentCardShimmersComponentProps {
 
 export class DocumentCardShimmersComponent extends React.Component<DocumentCardShimmersComponentProps, {}> {
 
+    /**
+     * Returns the shimmer background color from the theme, tolerating a missing `themeVariant`
+     * (which can briefly happen when entering/leaving page edit mode).
+     */
+    private get _backgroundColor(): string | undefined {
+        return this.props.themeVariant?.semanticColors?.bodyBackground;
+    }
+
     public render() {
 
         if (this.props.isCompact) {
@@ -46,7 +54,7 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                         shimmerElements={[
                             { type: ElemType.line, width: '100%', height: 196 },
                         ]}
-                        backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                        backgroundColor={this._backgroundColor}
                         theme={this.props.themeVariant as ITheme}
                     />
                 }
@@ -66,7 +74,7 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                                 theme={this.props.themeVariant as ITheme}
                                 flexWrap={true}
                                 width="100%"
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 shimmerElements={[
                                     { type: ElemType.line, width: '30%', height: 11 },
                                     { type: ElemType.gap, width: '70%', height: 11 },
@@ -94,12 +102,12 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                             <ShimmerElementsGroup
                                 theme={this.props.themeVariant as ITheme}
                                 shimmerElements={[{ type: ElemType.circle, height: 32 }, { type: ElemType.gap, width: 10, height: 40 }]}
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                             />
                             <ShimmerElementsGroup
                                 theme={this.props.themeVariant as ITheme}
                                 flexWrap={true}
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 width="100%"
                                 shimmerElements={[
                                     { type: ElemType.line, width: '100%', height: 10 },
@@ -133,7 +141,7 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                 theme={this.props.themeVariant as ITheme}
                 customElementsGroup={
                     <ShimmerElementsGroup
-                        backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                        backgroundColor={this._backgroundColor}
                         shimmerElements={[
                             { type: ElemType.line, height: 106, width: 144 },
                             { type: ElemType.gap, width: 16, height: 80 }
@@ -154,7 +162,7 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                                 <ShimmerElementsGroup
                                     theme={this.props.themeVariant as ITheme}
                                     flexWrap={true}
-                                    backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                    backgroundColor={this._backgroundColor}
                                     width="100%"
                                     shimmerElements={[
                                         { type: ElemType.line, width: '100%', height: 10 },
@@ -171,12 +179,12 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                     customElementsGroup={
                         <div style={{ display: 'flex', marginTop: 10 }}>
                             <ShimmerElementsGroup
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 theme={this.props.themeVariant as ITheme}
                                 shimmerElements={[{ type: ElemType.circle, height: 32 }, { type: ElemType.gap, width: 10, height: 40 }]}
                             />
                             <ShimmerElementsGroup
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 theme={this.props.themeVariant as ITheme}
                                 flexWrap={true}
                                 width="100%"

--- a/search-parts/src/components/FileIconComponent.tsx
+++ b/search-parts/src/components/FileIconComponent.tsx
@@ -3,6 +3,7 @@ import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
 import { Icon, ITheme, IIconStyles, ImageFit } from '@fluentui/react';
 import { getFileTypeIconAsUrl, FileTypeIconSize, FileIconType, IFileTypeIconOptions } from '@fluentui/react-file-type-icons';
+import { FileTypeIconHelper } from '../helpers/FileTypeIconHelper';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { isEmpty } from '@microsoft/sp-lodash-subset';
 
@@ -55,8 +56,11 @@ export class FileIcon extends React.Component<IFileIconProps, IFileIconState> {
         // icon registry. The registry is shared across all components on the page and "the last one who
         // registers wins", so another app can swap the base url to a non-production CDN, causing icons
         // to randomly break (issue #4376). Resolving the url directly keeps it deterministic.
+        // The base url comes from FileTypeIconHelper, the same value used to register the icons, so it
+        // stays consistent and can be overridden for closed environments.
+        const iconBaseUrl = FileTypeIconHelper.getBaseUrl();
         const buildFileTypeIconProps = (options: IFileTypeIconOptions) => {
-            const src = getFileTypeIconAsUrl({ ...options, imageFileType: 'svg' });
+            const src = getFileTypeIconAsUrl({ ...options, imageFileType: 'svg' }, iconBaseUrl);
             return src ? { imageProps: { src, imageFit: ImageFit.contain, width: size + 'px', height: size + 'px' } } : null;
         };
 

--- a/search-parts/src/components/FileIconComponent.tsx
+++ b/search-parts/src/components/FileIconComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
 import { Icon, ITheme, IIconStyles, ImageFit } from '@fluentui/react';
-import { getFileTypeIconProps, FileTypeIconSize, FileIconType } from '@fluentui/react-file-type-icons';
+import { getFileTypeIconAsUrl, FileTypeIconSize, FileIconType, IFileTypeIconOptions } from '@fluentui/react-file-type-icons';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { isEmpty } from '@microsoft/sp-lodash-subset';
 
@@ -51,6 +51,15 @@ export class FileIcon extends React.Component<IFileIconProps, IFileIconState> {
 
         const size = this.props.size ? parseInt(this.props.size) as FileTypeIconSize : 16;
 
+        // Build the icon properties from an explicit CDN url instead of relying on the shared Fluent UI
+        // icon registry. The registry is shared across all components on the page and "the last one who
+        // registers wins", so another app can swap the base url to a non-production CDN, causing icons
+        // to randomly break (issue #4376). Resolving the url directly keeps it deterministic.
+        const buildFileTypeIconProps = (options: IFileTypeIconOptions) => {
+            const src = getFileTypeIconAsUrl({ ...options, imageFileType: 'svg' });
+            return src ? { imageProps: { src, imageFit: ImageFit.contain, width: size + 'px', height: size + 'px' } } : null;
+        };
+
         if (this.props.extension || this.props.isContainer || this.props.imageUrl) {
 
             let isContainer = this.props.isContainer ? this.props.isContainer.toString() : undefined;
@@ -66,23 +75,23 @@ export class FileIcon extends React.Component<IFileIconProps, IFileIconState> {
                 // SharePointCAML SharePoint REST => FSObjType = 1
                 // SharePoint Search => ContentTypeId => 0x0120...
                 if ((isContainer === "true" || isContainer === "1" || isContainer.indexOf('0x0120') !== -1)) {
-                    iconProps = getFileTypeIconProps({ type: FileIconType.folder, size: size, imageFileType: 'svg' });
+                    iconProps = buildFileTypeIconProps({ type: FileIconType.folder, size: size });
                 }
 
                 // SharePoint Document Set
                 if (isContainer.indexOf('0x0120D520') !== -1) {
-                    iconProps = getFileTypeIconProps({ type: FileIconType.docset, size: size, imageFileType: 'svg' });
+                    iconProps = buildFileTypeIconProps({ type: FileIconType.docset, size: size });
                 }
             }
 
             if (this.props.extension && !iconProps) {
                 extension = isOneNote ? "onetoc" : this.props.extension.split("?")[0].split("#")[0].split('.').pop();
-                iconProps = getFileTypeIconProps({ extension: extension, size: size, imageFileType: 'svg' });
+                iconProps = buildFileTypeIconProps({ extension: extension, size: size });
             }
         }
 
         if (isEmpty(iconProps)) {
-            iconProps = getFileTypeIconProps({ type: FileIconType.genericFile, size: size, imageFileType: 'svg' });
+            iconProps = buildFileTypeIconProps({ type: FileIconType.genericFile, size: size });
         }
 
         return <Icon styles={this.props.styles} theme={this.props.themeVariant as ITheme} {...iconProps} />;

--- a/search-parts/src/components/PersonaShimmersComponent.tsx
+++ b/search-parts/src/components/PersonaShimmersComponent.tsx
@@ -19,6 +19,10 @@ export interface IPersonaCardShimmersComponentProps {
 
 export class PersonaCardShimmersComponent extends React.Component<IPersonaCardShimmersComponentProps, {}> {
 
+    private get _backgroundColor(): string | undefined {
+        return this.props.themeVariant?.semanticColors?.bodyBackground;
+    }
+
     public render() {
 
         let personaSize: number;
@@ -68,13 +72,13 @@ export class PersonaCardShimmersComponent extends React.Component<IPersonaCardSh
                         <div style={{ display: 'flex', marginTop: 10 }}>
                             <ShimmerElementsGroup
                                 theme={this.props.themeVariant as ITheme}
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 shimmerElements={[{ type: ElemType.circle, height: personaSize }, { type: ElemType.gap, width: 10, height: personaSize }]}
                             />
                             <ShimmerElementsGroup
                                 theme={this.props.themeVariant as ITheme}
                                 flexWrap={true}
-                                backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
+                                backgroundColor={this._backgroundColor}
                                 width="100%"
                                 shimmerElements={[
                                     { type: ElemType.line, width: '30%', height: 10, verticalAlign: 'center' },

--- a/search-parts/src/components/SliderComponent.module.scss
+++ b/search-parts/src/components/SliderComponent.module.scss
@@ -62,24 +62,29 @@
 
   > li {
     display: block;
-    box-sizing: border-box;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
     margin: 0 6px;
-    cursor: pointer;
-    background-color: rgba(0, 0, 0, 0.4);
-    opacity: 0.6;
-    border: 2px solid rgba(255, 255, 255, 0.9);
 
-    &:hover {
-      opacity: 0.9;
-    }
+    > button {
+      display: block;
+      box-sizing: border-box;
+      width: 12px;
+      height: 12px;
+      padding: 0;
+      border-radius: 50%;
+      cursor: pointer;
+      background-color: rgba(0, 0, 0, 0.4);
+      opacity: 0.6;
+      border: 2px solid rgba(255, 255, 255, 0.9);
 
-    &.carouselIndicatorActive {
-      background-color: rgba(255, 255, 255, 0.9);
-      opacity: 1;
-      border-color: rgba(0, 0, 0, 0.6);
+      &:hover {
+        opacity: 0.9;
+      }
+
+      &.carouselIndicatorActive {
+        background-color: rgba(255, 255, 255, 0.9);
+        opacity: 1;
+        border-color: rgba(0, 0, 0, 0.6);
+      }
     }
   }
 }

--- a/search-parts/src/components/SliderComponent.module.scss
+++ b/search-parts/src/components/SliderComponent.module.scss
@@ -2,97 +2,85 @@
   width: 100%;
   height: var(--slide-height, 360px);
   position: relative;
+}
 
-  :global {
-    div[class*="root_"] {
-      height: 100%;
+/* The clipped window that shows one page at a time */
+.carouselViewport {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+/* The horizontal track holding all pages side by side; translated to page into view */
+.carouselTrack {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  transition: transform 0.4s ease;
+}
+
+/* A single page occupying the full viewport width */
+.carouselPage {
+  flex: 0 0 100%;
+  width: 100%;
+  height: 100%;
+}
+
+/* Navigation arrows */
+.carouselButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 101;
+  width: 32px;
+  height: 32px;
+}
+
+.carouselButtonPrev {
+  left: -32px;
+}
+
+.carouselButtonNext {
+  right: -32px;
+}
+
+/* Page indicator dots */
+.carouselIndicators {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+  padding-inline-start: 0;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 8px;
+  z-index: 100;
+  margin: 0;
+
+  > li {
+    display: block;
+    box-sizing: border-box;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin: 0 6px;
+    cursor: pointer;
+    background-color: rgba(0, 0, 0, 0.4);
+    opacity: 0.6;
+    border: 2px solid rgba(255, 255, 255, 0.9);
+
+    &:hover {
+      opacity: 0.9;
     }
 
-    div[class*="container_"] {
-      height: 100%;
-      position: relative;
+    &.carouselIndicatorActive {
+      background-color: rgba(255, 255, 255, 0.9);
+      opacity: 1;
+      border-color: rgba(0, 0, 0, 0.6);
     }
-
-    div[class*="contentContainer_"] {
-      height: 100% !important;
-      overflow: hidden;
-      flex: 1 1 auto;
-    }
-
-    div[class*="slideWrapper_"] {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    div[class*="container_"] > div[class*="blockButtonsContainer_"],
-    div[class*="container_"] > div[class*="hiddenButtonsContainer_"],
-    div[class*="container_"] > div[class*="buttonsOnlyContainer_"] {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 32px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 101;
-    }
-
-    div[class*="container_"] > div[class*="blockButtonsContainer_"]:first-child,
-    div[class*="container_"] > div[class*="hiddenButtonsContainer_"]:first-child,
-    div[class*="container_"] > div[class*="buttonsOnlyContainer_"]:first-child {
-      left: -32px;
-    }
-
-    div[class*="container_"] > div[class*="blockButtonsContainer_"]:last-child,
-    div[class*="container_"] > div[class*="hiddenButtonsContainer_"]:last-child,
-    div[class*="container_"] > div[class*="buttonsOnlyContainer_"]:last-child {
-      right: -32px;
-    }
-
-    /* Style the indicators - make them visible and styled */
-    ol[class*="indicators_"],
-    div[class*="indicators_"] {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      list-style: none;
-      padding-inline-start: 0;
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: 8px;
-      z-index: 100 !important;
-      margin: 0 !important;
-      padding-bottom: 0 !important;
-      
-      > li {
-        display: block;
-        text-indent: -999px;
-        background-color: rgba(0, 0, 0, 0.4) !important;
-        width: 12px !important;
-        height: 12px !important;
-        border-radius: 50% !important;
-        margin: 0 6px !important;
-        opacity: 0.6 !important;
-        border: 2px solid rgba(255, 255, 255, 0.9) !important;
-        border-top: 2px solid rgba(255, 255, 255, 0.9) !important;
-        border-bottom: 2px solid rgba(255, 255, 255, 0.9) !important;
-        
-        &:hover {
-          opacity: 0.9 !important;
-        }
-        
-        &[class*="active_"] {
-          background-color: rgba(255, 255, 255, 0.9) !important;
-          opacity: 1 !important;
-          border-color: rgba(0, 0, 0, 0.6) !important;
-          border-top-color: rgba(0, 0, 0, 0.6) !important;
-          border-bottom-color: rgba(0, 0, 0, 0.6) !important;
-        }
-      }
-    }
-
   }
 }
 
@@ -118,7 +106,7 @@
   max-width: var(--slide-width, 318px);
   height: var(--slide-height, 360px);
   flex-shrink: 0;
-  
+
   /* Ensure slide content fills the container */
   > div {
     width: 100%;

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -143,7 +143,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
 
     private _clearAutoPlay(): void {
         if (this._autoPlayTimer !== undefined) {
-            window.clearInterval(this._autoPlayTimer);
+            globalThis.clearInterval(this._autoPlayTimer);
             this._autoPlayTimer = undefined;
         }
     }
@@ -160,7 +160,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             return;
         }
 
-        this._autoPlayTimer = window.setInterval(() => {
+        this._autoPlayTimer = globalThis.setInterval(() => {
             if (!this._isHovering) {
                 this._goToNext();
             }
@@ -271,7 +271,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             this._pageCount = carouselElements.length;
             if (previousPageCount !== this._pageCount) {
                 // Restart auto play once the rendered DOM reflects the new page count.
-                window.requestAnimationFrame(() => this._resetAutoPlay());
+                globalThis.requestAnimationFrame(() => this._resetAutoPlay());
             }
 
             const currentIndex = Math.max(0, Math.min(this.state.currentIndex, this._pageCount - 1));
@@ -336,21 +336,15 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                 {showDots &&
                     <ol className={styles.carouselIndicators}>
                         {carouselElements.map((element, index) => (
-                            <li
-                                key={index}
-                                className={index === currentIndex ? styles.carouselIndicatorActive : undefined}
-                                role="button"
-                                tabIndex={0}
-                                aria-label={strings.Layouts.Slider.GoToPageLabel.replace('{0}', String(index + 1))}
-                                aria-current={index === currentIndex}
-                                onClick={() => this._goToIndex(index)}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
-                                        e.preventDefault();
-                                        this._goToIndex(index);
-                                    }
-                                }}
-                            />
+                            <li key={`carousel-dot-${index}`}>
+                                <button
+                                    type="button"
+                                    className={index === currentIndex ? styles.carouselIndicatorActive : undefined}
+                                    aria-label={strings.Layouts.Slider.GoToPageLabel.replace('{0}', String(index + 1))}
+                                    aria-current={index === currentIndex}
+                                    onClick={() => this._goToIndex(index)}
+                                />
+                            </li>
                         ))}
                     </ol>
                 }

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -233,7 +233,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
         try {
 
             // Get item properties
-            const items = this.props.items ? this.props.items : [];
+            const items: any[] = Array.isArray(this.props.items) ? this.props.items : [];
             const sliderOptions = this.props.options ? this.props.options as ISliderOptions : {};
             const templateContext = !isEmpty(this.props.context) ? this.props.context : null;
 
@@ -242,8 +242,8 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
 
             // Group items into chunks based on numberOfSlides
             const groupedItems: any[][] = [];
-            for (let i = 0; i < (items as any[]).length; i += numberOfSlides) {
-                groupedItems.push((items as any[]).slice(i, i + numberOfSlides));
+            for (let i = 0; i < items.length; i += numberOfSlides) {
+                groupedItems.push(items.slice(i, i + numberOfSlides));
             }
 
             // Map grouped items to JSX elements (one element per page)

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -11,6 +11,7 @@ import { TemplateService } from '../services/templateService/TemplateService';
 import { DomPurifyHelper } from '../helpers/DomPurifyHelper';
 import { ServiceScope, ServiceKey } from "@microsoft/sp-core-library";
 import styles from './SliderComponent.module.scss';
+import * as strings from 'CommonStrings';
 
 export interface ISliderOptions {
 
@@ -118,7 +119,9 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
 
     public componentDidUpdate(): void {
         // Clamp the current index if the number of pages shrank (e.g. fewer results).
-        if (this.state.currentIndex > this._pageCount - 1) {
+        // Guard against _pageCount === 0 (0 > -1 would otherwise re-set the state on every
+        // update and loop indefinitely) by only clamping when there is at least one page.
+        if (this._pageCount > 0 && this.state.currentIndex > this._pageCount - 1) {
             this.setState({ currentIndex: Math.max(0, this._pageCount - 1) });
         }
     }
@@ -300,7 +303,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonPrev}`}
                         iconProps={{ iconName: 'ChevronLeft' }}
-                        ariaLabel="Previous"
+                        ariaLabel={strings.Layouts.Slider.PreviousPageLabel}
                         disabled={prevDisabled}
                         onClick={this._goToPrevious}
                     />
@@ -325,7 +328,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonNext}`}
                         iconProps={{ iconName: 'ChevronRight' }}
-                        ariaLabel="Next"
+                        ariaLabel={strings.Layouts.Slider.NextPageLabel}
                         disabled={nextDisabled}
                         onClick={this._goToNext}
                     />
@@ -338,7 +341,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                                 className={index === currentIndex ? styles.carouselIndicatorActive : undefined}
                                 role="button"
                                 tabIndex={0}
-                                aria-label={`Go to page ${index + 1}`}
+                                aria-label={strings.Layouts.Slider.GoToPageLabel.replace('{0}', String(index + 1))}
                                 aria-current={index === currentIndex}
                                 onClick={() => this._goToIndex(index)}
                                 onKeyDown={(e) => {

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -100,6 +100,13 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
      */
     private _pageCount: number = 0;
 
+    /**
+     * The page count the auto play timer was last (re)started for. Used by componentDidUpdate to
+     * detect when the rendered page count changed so the timer can be restarted safely (after the
+     * DOM has committed and only while mounted), instead of scheduling work from render().
+     */
+    private _autoPlayPageCount: number = 0;
+
     public constructor(props: ISliderComponentProps) {
         super(props);
 
@@ -114,10 +121,19 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
     }
 
     public componentDidMount(): void {
+        this._autoPlayPageCount = this._pageCount;
         this._resetAutoPlay();
     }
 
     public componentDidUpdate(): void {
+        // Restart auto play when the rendered page count changed. Doing this here (rather than from
+        // render()) ensures the timer is only (re)created while the component is mounted, avoiding
+        // leaks / "setState on unmounted component" warnings.
+        if (this._autoPlayPageCount !== this._pageCount) {
+            this._autoPlayPageCount = this._pageCount;
+            this._resetAutoPlay();
+        }
+
         // Clamp the current index if the number of pages shrank (e.g. fewer results).
         // Guard against _pageCount === 0 (0 > -1 would otherwise re-set the state on every
         // update and loop indefinitely) by only clamping when there is at least one page.
@@ -266,13 +282,9 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                 </div>;
             });
 
-            // Keep the page count in sync for auto play / bounds logic.
-            const previousPageCount = this._pageCount;
+            // Keep the page count in sync for auto play / bounds logic. The auto play timer is
+            // (re)started from componentDidUpdate when this value changes, not from render().
             this._pageCount = carouselElements.length;
-            if (previousPageCount !== this._pageCount) {
-                // Restart auto play once the rendered DOM reflects the new page count.
-                globalThis.requestAnimationFrame(() => this._resetAutoPlay());
-            }
 
             const currentIndex = Math.max(0, Math.min(this.state.currentIndex, this._pageCount - 1));
             const wrapAround = sliderOptions.wrapAround === true;

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as Handlebars from 'handlebars';
 import { MessageBar, MessageBarType } from '@fluentui/react/lib/MessageBar';
+import { IconButton } from '@fluentui/react/lib/Button';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import { isEmpty } from "@microsoft/sp-lodash-subset";
-import { Carousel, CarouselButtonsLocation, CarouselButtonsDisplay } from "@pnp/spfx-controls-react/lib/Carousel";
 import { ITemplateService } from '../services/templateService/ITemplateService';
 import { TemplateService } from '../services/templateService/TemplateService';
 import { DomPurifyHelper } from '../helpers/DomPurifyHelper';
@@ -74,12 +74,140 @@ export interface ISliderComponentProps {
 }
 
 export interface ISliderComponentState {
+
+    /**
+     * The index of the currently displayed page (group of slides).
+     */
+    currentIndex: number;
 }
 
 export class SliderComponent extends React.Component<ISliderComponentProps, ISliderComponentState> {
 
+    /**
+     * The auto play timer handle.
+     */
+    private _autoPlayTimer: number | undefined = undefined;
+
+    /**
+     * Indicates if the pointer is currently hovering the carousel (used to pause auto play).
+     */
+    private _isHovering: boolean = false;
+
+    /**
+     * The number of pages currently rendered. Kept in sync on every render so the auto play
+     * callback and bounds checks always operate on the latest value.
+     */
+    private _pageCount: number = 0;
+
     public constructor(props: ISliderComponentProps) {
         super(props);
+
+        this.state = {
+            currentIndex: 0
+        };
+
+        this._goToNext = this._goToNext.bind(this);
+        this._goToPrevious = this._goToPrevious.bind(this);
+        this._onMouseEnter = this._onMouseEnter.bind(this);
+        this._onMouseLeave = this._onMouseLeave.bind(this);
+    }
+
+    public componentDidMount(): void {
+        this._resetAutoPlay();
+    }
+
+    public componentDidUpdate(): void {
+        // Clamp the current index if the number of pages shrank (e.g. fewer results).
+        if (this.state.currentIndex > this._pageCount - 1) {
+            this.setState({ currentIndex: Math.max(0, this._pageCount - 1) });
+        }
+    }
+
+    public componentWillUnmount(): void {
+        this._clearAutoPlay();
+    }
+
+    /**
+     * Returns the auto play interval in milliseconds, or null when auto play is disabled.
+     */
+    private _getAutoPlayInterval(): number | null {
+        const sliderOptions = this.props.options ? this.props.options as ISliderOptions : {};
+        if (sliderOptions.autoPlay && sliderOptions.autoPlayDuration) {
+            return sliderOptions.autoPlayDuration * 1000;
+        }
+        return null;
+    }
+
+    private _clearAutoPlay(): void {
+        if (this._autoPlayTimer !== undefined) {
+            window.clearInterval(this._autoPlayTimer);
+            this._autoPlayTimer = undefined;
+        }
+    }
+
+    /**
+     * (Re)starts the auto play timer based on the current options. Does nothing when auto play is
+     * disabled or when there is a single page.
+     */
+    private _resetAutoPlay(): void {
+        this._clearAutoPlay();
+
+        const interval = this._getAutoPlayInterval();
+        if (interval === null || this._pageCount <= 1) {
+            return;
+        }
+
+        this._autoPlayTimer = window.setInterval(() => {
+            if (!this._isHovering) {
+                this._goToNext();
+            }
+        }, interval);
+    }
+
+    private _onMouseEnter(): void {
+        const sliderOptions = this.props.options ? this.props.options as ISliderOptions : {};
+        if (sliderOptions.pauseAutoPlayOnHover) {
+            this._isHovering = true;
+        }
+    }
+
+    private _onMouseLeave(): void {
+        this._isHovering = false;
+    }
+
+    /**
+     * Moves to a specific page, clamping to the valid range.
+     */
+    private _goToIndex(index: number): void {
+        if (this._pageCount === 0) {
+            return;
+        }
+        const clamped = Math.max(0, Math.min(index, this._pageCount - 1));
+        if (clamped !== this.state.currentIndex) {
+            this.setState({ currentIndex: clamped });
+        }
+    }
+
+    private _goToNext(): void {
+        const wrapAround = this.props.options ? (this.props.options as ISliderOptions).wrapAround : false;
+        const { currentIndex } = this.state;
+
+        if (currentIndex < this._pageCount - 1) {
+            this.setState({ currentIndex: currentIndex + 1 });
+        } else if (wrapAround) {
+            this.setState({ currentIndex: 0 });
+        }
+    }
+
+    private _goToPrevious(): void {
+        const wrapAround = this.props.options ? (this.props.options as ISliderOptions).wrapAround : false;
+        const { currentIndex } = this.state;
+
+        if (currentIndex > 0) {
+            this.setState({ currentIndex: currentIndex - 1 });
+        } else if (wrapAround) {
+            this.setState({ currentIndex: this._pageCount - 1 });
+        }
     }
 
     public render() {
@@ -90,30 +218,21 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             const sliderOptions = this.props.options ? this.props.options as ISliderOptions : {};
             const templateContext = !isEmpty(this.props.context) ? this.props.context : null;
 
-            let autoPlayInterval: number | null = null;
-
-            if (sliderOptions.autoPlay) {
-                // Check if a duration has been set
-                if (sliderOptions.autoPlayDuration) {
-                    autoPlayInterval = sliderOptions.autoPlayDuration * 1000;
-                }
-            }
-
             // Get number of slides to show at once (default to 1 if not specified)
             const numberOfSlides = sliderOptions.numberOfSlides || 1;
 
             // Group items into chunks based on numberOfSlides
             const groupedItems: any[][] = [];
-            for (let i = 0; i < items.length; i += numberOfSlides) {
-                groupedItems.push(items.slice(i, i + numberOfSlides));
+            for (let i = 0; i < (items as any[]).length; i += numberOfSlides) {
+                groupedItems.push((items as any[]).slice(i, i + numberOfSlides));
             }
 
-            // Map grouped items to JSX elements for the Carousel
+            // Map grouped items to JSX elements (one element per page)
             const carouselElements = groupedItems.map((itemGroup, groupIndex) => {
                 // Create slides for each item in the group
                 const slideElements = itemGroup.map((item, itemIndex) => {
                     const absoluteIndex = groupIndex * numberOfSlides + itemIndex;
-                    
+
                     // Create a temp context with the current so we can use global registered helpers on the current item
                     const tempTemplateContent = `{{#with item as |item|}}${this.props.template.trim()}{{/with}}`;
 
@@ -138,18 +257,36 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     </div>;
                 });
 
-                // Return a group container for multiple slides
+                // Return a group container for multiple slides (one page)
                 return <div key={groupIndex} className={styles.carouselSlideGroup}>
                     {slideElements}
                 </div>;
             });
 
+            // Keep the page count in sync for auto play / bounds logic.
+            const previousPageCount = this._pageCount;
+            this._pageCount = carouselElements.length;
+            if (previousPageCount !== this._pageCount) {
+                // Restart auto play once the rendered DOM reflects the new page count.
+                window.requestAnimationFrame(() => this._resetAutoPlay());
+            }
+
+            const currentIndex = Math.max(0, Math.min(this.state.currentIndex, this._pageCount - 1));
+            const wrapAround = sliderOptions.wrapAround === true;
+            const showControls = this._pageCount > 1;
+            const showDots = showControls && sliderOptions.showPageDots === true;
+
+            const prevDisabled = !wrapAround && currentIndex === 0;
+            const nextDisabled = !wrapAround && currentIndex === this._pageCount - 1;
+
             // Extract slideHeight and slideWidth from context (layout properties)
             const slideHeight = templateContext?.properties?.layoutProperties?.slideHeight || 360;
             const slideWidth = templateContext?.properties?.layoutProperties?.slideWidth || 318;
 
-            return <div 
+            return <div
                 className={styles.carouselContainer}
+                onMouseEnter={this._onMouseEnter}
+                onMouseLeave={this._onMouseLeave}
                 ref={(el) => {
                     if (el) {
                         el.style.setProperty('--slide-width', `${slideWidth}px`);
@@ -159,17 +296,61 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     }
                 }}
             >
-                <Carousel
-                    element={carouselElements}
-                    isInfinite={sliderOptions.wrapAround}
-                    interval={autoPlayInterval}
-                    pauseOnHover={sliderOptions.pauseAutoPlayOnHover}
-                    indicators={sliderOptions.showPageDots}
-                    buttonsLocation={CarouselButtonsLocation.center}
-                    buttonsDisplay={CarouselButtonsDisplay.block}
-                    contentHeight={slideHeight}
-                    indicatorStyle={{ bottom: '5px' }}
-                />
+                {showControls &&
+                    <IconButton
+                        className={`${styles.carouselButton} ${styles.carouselButtonPrev}`}
+                        iconProps={{ iconName: 'ChevronLeft' }}
+                        ariaLabel="Previous"
+                        disabled={prevDisabled}
+                        onClick={this._goToPrevious}
+                    />
+                }
+                <div className={styles.carouselViewport}>
+                    <div
+                        className={styles.carouselTrack}
+                        style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+                    >
+                        {carouselElements.map((element, index) => (
+                            <div
+                                key={index}
+                                className={styles.carouselPage}
+                                aria-hidden={index !== currentIndex}
+                            >
+                                {element}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                {showControls &&
+                    <IconButton
+                        className={`${styles.carouselButton} ${styles.carouselButtonNext}`}
+                        iconProps={{ iconName: 'ChevronRight' }}
+                        ariaLabel="Next"
+                        disabled={nextDisabled}
+                        onClick={this._goToNext}
+                    />
+                }
+                {showDots &&
+                    <ol className={styles.carouselIndicators}>
+                        {carouselElements.map((element, index) => (
+                            <li
+                                key={index}
+                                className={index === currentIndex ? styles.carouselIndicatorActive : undefined}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`Go to page ${index + 1}`}
+                                aria-current={index === currentIndex}
+                                onClick={() => this._goToIndex(index)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                                        e.preventDefault();
+                                        this._goToIndex(index);
+                                    }
+                                }}
+                            />
+                        ))}
+                    </ol>
+                }
             </div>;
         } catch (error) {
             return <MessageBar messageBarType={MessageBarType.error}>{error}</MessageBar>;

--- a/search-parts/src/components/SortComponent.tsx
+++ b/search-parts/src/components/SortComponent.tsx
@@ -66,6 +66,8 @@ export class SortComponent extends React.Component<ISortComponentProps, ISortCom
         if (this.props.defaultSelectedField && this.props.defaultDirection || this.state.selectedFieldName) {
 
             renderSortButton = <IconButton
+                ariaLabel={strings.Controls.SortByPlaceholderText}
+                title={strings.Controls.SortByPlaceholderText}
                 iconProps={{
                     iconName: this.props.defaultDirection === SortFieldDirection.Ascending ? "SortUp" : "SortDown"
                 }}
@@ -80,6 +82,7 @@ export class SortComponent extends React.Component<ISortComponentProps, ISortCom
         return <div style={{ display: 'flex' }}>
             <Dropdown
                 placeholder={strings.Controls.SortByPlaceholderText}
+                ariaLabel={strings.Controls.SortByPlaceholderText}
                 styles={dropdownStyles}
                 defaultSelectedKey={this.props.defaultSelectedField ? this.props.defaultSelectedField : null}
                 options={options}

--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -47,6 +47,19 @@ export interface IFilterCheckBoxProps {
     isMulti?: boolean;
 
     /**
+     * The total number of values in the parent filter. Used for the `aria-setsize`
+     * attribute so screen readers announce single-select radios as "x of y" instead
+     * of "1 of 1" (each value is rendered as its own web component).
+     */
+    valueCount?: number;
+
+    /**
+     * The 0-based index of this value within the parent filter. Used to compute the
+     * 1-based `aria-posinset` attribute (see `valueCount`).
+     */
+    valueIndex?: number;
+
+    /**
      * The current theme settings
      */
     themeVariant?: IReadonlyTheme;
@@ -61,6 +74,33 @@ export interface IFilterCheckBoxState {
 }
 
 export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProps, IFilterCheckBoxState> {
+
+    private _rootRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+    public componentDidMount(): void {
+        this._applyRadioSetSizeAria();
+    }
+
+    public componentDidUpdate(): void {
+        this._applyRadioSetSizeAria();
+    }
+
+    /**
+     * For single-select filters each value renders its own single-option `ChoiceGroup`, which emits a
+     * `radiogroup` containing a single radio. Screen readers therefore announce every value as
+     * "1 of 1". Setting explicit `aria-setsize`/`aria-posinset` on the radio input overrides the
+     * computed set size so the value is announced with its real position within the filter.
+     */
+    private _applyRadioSetSizeAria(): void {
+        if (this.props.isMulti || !this._rootRef.current || !this.props.valueCount || this.props.valueIndex === undefined || this.props.valueIndex === null) {
+            return;
+        }
+        const radioInput = this._rootRef.current.querySelector('input[type="radio"]');
+        if (radioInput) {
+            radioInput.setAttribute('aria-setsize', this.props.valueCount.toString());
+            radioInput.setAttribute('aria-posinset', (this.props.valueIndex + 1).toString());
+        }
+    }
 
     public render() {
 
@@ -148,6 +188,9 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
                     this.props.onChecked(this.props.filterName, filterValue);
                 }}
             />;
+
+            // Wrap so we can reach the rendered radio input and set aria-setsize/aria-posinset on it.
+            renderInput = <div ref={this._rootRef}>{renderInput}</div>;
         }
 
         return renderInput;

--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -75,7 +75,7 @@ export interface IFilterCheckBoxState {
 
 export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProps, IFilterCheckBoxState> {
 
-    private _rootRef: React.RefObject<HTMLDivElement> = React.createRef();
+    private readonly _rootRef: React.RefObject<HTMLDivElement> = React.createRef();
 
     public componentDidMount(): void {
         this._applyRadioSetSizeAria();

--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -87,16 +87,27 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
 
     /**
      * For single-select filters each value renders its own single-option `ChoiceGroup`, which emits a
-     * `radiogroup` containing a single radio. Screen readers therefore announce every value as
-     * "1 of 1". Setting explicit `aria-setsize`/`aria-posinset` on the radio input overrides the
-     * computed set size so the value is announced with its real position within the filter.
+     * `radiogroup` containing a single radio with a unique `name` attribute. Screen readers therefore
+     * announce every value as "1 of 1" because native radios are positioned relative to other radios
+     * sharing the same `name` (and `aria-setsize` is ignored for native radios in most SRs).
+     *
+     * To make the value announce its real position within the filter we (1) neutralize the inner
+     * per-value `radiogroup` role, (2) give every value radio of the same filter a shared, stable
+     * `name` so the browser/SR treats them as one radio set, and (3) set explicit
+     * `aria-setsize`/`aria-posinset` as a fallback for SRs that honor them.
      */
     private _applyRadioSetSizeAria(): void {
         if (this.props.isMulti || !this._rootRef.current || !this.props.valueCount || this.props.valueIndex === undefined || this.props.valueIndex === null) {
             return;
         }
+        const radioGroup = this._rootRef.current.querySelector('[role="radiogroup"]');
+        if (radioGroup) {
+            radioGroup.setAttribute('role', 'presentation');
+        }
         const radioInput = this._rootRef.current.querySelector('input[type="radio"]');
         if (radioInput) {
+            const sharedName = `pnp-filter-${this.props.instanceId || ''}-${this.props.filterName || ''}`;
+            radioInput.setAttribute('name', sharedName);
             radioInput.setAttribute('aria-setsize', this.props.valueCount.toString());
             radioInput.setAttribute('aria-posinset', (this.props.valueIndex + 1).toString());
         }

--- a/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
+++ b/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
@@ -54,6 +54,14 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                             '.ms-ChoiceField + .ms-ChoiceField': {
                                                                 marginLeft: 0
                                                             },
+                                                            // Render the visual '/' separator between the two operators as a
+                                                            // presentational pseudo-element instead of a (disabled) radio option,
+                                                            // so screen readers announce only the two real options (e.g. '1 of 2').
+                                                            '.ms-ChoiceField + .ms-ChoiceField::before': {
+                                                                content: '"/"',
+                                                                padding: '0 4px',
+                                                                color: this.props.themeVariant && this.props.themeVariant.isInverted ? '#fff' : (this.props.themeVariant ? this.props.themeVariant.semanticColors.bodyText : undefined)
+                                                            },
                                                             'label::before, label::after': {
                                                                 display: 'none',
                                                             },
@@ -76,11 +84,6 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                         key: FilterConditionOperator.AND,
                                                         text: commonStrings.Filters.AndOperator,
                                                         title: commonStrings.Filters.UseAndOperatorValues
-                                                    },
-                                                    {
-                                                        key: null,
-                                                        text: "/",
-                                                        disabled: true
                                                     },
                                                     {
                                                         key: FilterConditionOperator.OR,

--- a/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
+++ b/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
@@ -60,7 +60,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                             '.ms-ChoiceField + .ms-ChoiceField::before': {
                                                                 content: '"/"',
                                                                 padding: '0 4px',
-                                                                color: this.props.themeVariant && this.props.themeVariant.isInverted ? '#fff' : (this.props.themeVariant ? this.props.themeVariant.semanticColors.bodyText : undefined)
+                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors.bodyText
                                                             },
                                                             'label::before, label::after': {
                                                                 display: 'none',

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -1244,14 +1244,16 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         const aggregationFilters: string[] = [];
 
         if (dataContext.filters.selectedFilters.length > 0) {
-            if (dataContext.filters.selectedFilters.length > 1 &&
-                dataContext.filters.selectedFilters.filter(f => f.values.length > 0).length > 1) {
-                const refinementString = DataFilterHelper.buildFqlRefinementString(dataContext.filters.selectedFilters, this.dayjs).join(',');
-                if (!isEmpty(refinementString)) {
-                    aggregationFilters.push(`${dataContext.filters.filterOperator}(${refinementString})`);
-                }
-            } else {
-                aggregationFilters.push(...DataFilterHelper.buildFqlRefinementString(dataContext.filters.selectedFilters, this.dayjs));
+            // The Microsoft Search API expects KQL-formatted refinement strings in aggregationFilters.
+            // Using FQL here causes multi-filter combinations to return 0 results (issue #4796).
+            const refinementString = DataFilterHelper.buildKqlRefinementString(
+                dataContext.filters.selectedFilters,
+                this.dayjs,
+                dataContext.filters.filterOperator
+            );
+
+            if (!isEmpty(refinementString)) {
+                aggregationFilters.push(refinementString);
             }
         }
 

--- a/search-parts/src/helpers/DataFilterHelper.ts
+++ b/search-parts/src/helpers/DataFilterHelper.ts
@@ -1,5 +1,5 @@
 import { isEmpty } from "@microsoft/sp-lodash-subset";
-import { IDataFilter, IDataFilterConfiguration, FilterType, IDataFilterResult, FilterComparisonOperator } from "@pnp/modern-search-extensibility";
+import { IDataFilter, IDataFilterConfiguration, FilterType, IDataFilterResult, FilterComparisonOperator, FilterConditionOperator } from "@pnp/modern-search-extensibility";
 import { BuiltinTokenNames } from "../services/tokenService/TokenService";
 import { BuiltinFilterTypes } from "../layouts/AvailableTemplates";
 
@@ -92,12 +92,12 @@ export class DataFilterHelper {
     }
 
     /**
-     * Build the refinement condition in FQL format
+     * Build the refinement condition in KQL format
      * @param selectedFilters The selected filter array
      * @param dayjs The dayjs instance to resolve dates
-     * @param encodeTokens If true, encodes the taxonomy refinement tokens in UTF-8 to work with GET requests. Javascript encodes natively in UTF-16 by default.
+     * @param filterOperator The logical operator (AND/OR) to use between filters. Defaults to OR.
      */
-    public static buildKqlRefinementString(selectedFilters: IDataFilter[], dayjs: any): string {
+    public static buildKqlRefinementString(selectedFilters: IDataFilter[], dayjs: any, filterOperator: FilterConditionOperator = FilterConditionOperator.OR): string {
         let refinementQueryConditions: string[] = [];
         selectedFilters.forEach(filter => {
 
@@ -142,7 +142,8 @@ export class DataFilterHelper {
             }
         });
 
-        return refinementQueryConditions.join(" OR "); // only used when building aggregation with OR between filters
+        const filterJoinOperator = filterOperator === FilterConditionOperator.AND ? " AND " : " OR ";
+        return refinementQueryConditions.join(filterJoinOperator);
     }
 
     /**

--- a/search-parts/src/helpers/FileTypeIconHelper.ts
+++ b/search-parts/src/helpers/FileTypeIconHelper.ts
@@ -1,0 +1,100 @@
+import { FLUENT_CDN_BASE_URL } from "@fluentui/style-utilities";
+
+/**
+ * Single source of truth for the base URL used to resolve Fluent UI file type icons.
+ *
+ * The file type icons are served from a Microsoft CDN. The exact URL is version-stamped by Fluent UI
+ * (e.g. `.../fabric-cdn-prod_20260506.001/...`) and changes with every Fluent release, so we always
+ * derive the *path* (which includes the version) from `FLUENT_CDN_BASE_URL` rather than hard-coding it.
+ *
+ * Resolving the URL ourselves (instead of relying on `getFileTypeIconProps`, which looks names up in
+ * Fluent's shared, mutable icon registry) keeps icon rendering deterministic and immune to other apps
+ * on the page re-registering the icons against a different CDN (issue #4376).
+ *
+ * Resolution order for the base URL:
+ *   1. A global override (closed / sovereign / air-gapped environments) - used verbatim:
+ *        window.__pnpModernSearchFileTypeIconBaseUrl = "https://my-cdn/assets/item-types/";
+ *      The override must include the trailing `assets/item-types/` segment and a trailing slash.
+ *   2. The SharePoint page CDN host derived from `pageContext.legacyPageContext.cdnPrefix` (provided
+ *      via `setCdnPrefix`) combined with the version-correct icon path from `FLUENT_CDN_BASE_URL`.
+ *      This keeps requests on the same CDN host SharePoint itself uses (e.g.
+ *      "res-1.public.onecdn.static.microsoft"), which is more likely to be reachable in restricted
+ *      environments than the default `res.cdn.office.net` host.
+ *   3. The Fluent UI default CDN (`FLUENT_CDN_BASE_URL`).
+ */
+export class FileTypeIconHelper {
+
+    /**
+     * The name of the global variable used to override the file type icon base URL.
+     */
+    public static readonly OverrideGlobalName = "__pnpModernSearchFileTypeIconBaseUrl";
+
+    /**
+     * The SharePoint CDN prefix (from `pageContext.legacyPageContext.cdnPrefix`), provided by the
+     * caller that has access to the SPFx page context (see `TemplateService`). Cached so the value is
+     * available to render-time callers (e.g. `FileIconComponent`) that do not have a page context.
+     */
+    private static _cdnPrefix: string | undefined = undefined;
+
+    /**
+     * Stores the SharePoint CDN prefix read from the SPFx page context
+     * (`pageContext.legacyPageContext.cdnPrefix`). Call once during initialization.
+     */
+    public static setCdnPrefix(cdnPrefix: string | undefined): void {
+        FileTypeIconHelper._cdnPrefix = cdnPrefix;
+    }
+
+    /**
+     * Returns the base URL used to resolve and register file type icons.
+     */
+    public static getBaseUrl(): string {
+
+        // 1. Explicit override wins, used as-is.
+        const override = (typeof window !== "undefined")
+            ? (window as unknown as { [key: string]: string })[FileTypeIconHelper.OverrideGlobalName]
+            : undefined;
+
+        if (override && typeof override === "string" && override.trim().length > 0) {
+            return override.trim();
+        }
+
+        // The version-stamped icon path, e.g. "/files/fabric-cdn-prod_20260506.001/assets/item-types/".
+        // Always taken from Fluent so it matches the bundled icon version.
+        const fluentBaseUrl = `${FLUENT_CDN_BASE_URL}/assets/item-types/`;
+
+        // 2. Reuse the SharePoint CDN host (cdnPrefix) when available, keeping the Fluent icon path.
+        try {
+            const cdnHost = FileTypeIconHelper.getSharePointCdnHost();
+            if (cdnHost) {
+                const iconPath = new URL(fluentBaseUrl).pathname;
+                return `https://${cdnHost}${iconPath}`;
+            }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        } catch (error) {
+            // Fall through to the Fluent default below.
+        }
+
+        // 3. Fluent UI default CDN.
+        return fluentBaseUrl;
+    }
+
+    /**
+     * Normalizes the cached SharePoint CDN prefix to a bare host (e.g.
+     * "res-1.public.onecdn.static.microsoft"). The `cdnPrefix` typically carries a trailing path
+     * segment (such as "/bld") that is not part of the icon path, so it is stripped.
+     * Returns undefined when no usable host is available.
+     */
+    private static getSharePointCdnHost(): string | undefined {
+
+        const cdnPrefix = FileTypeIconHelper._cdnPrefix ? FileTypeIconHelper._cdnPrefix.trim() : undefined;
+
+        if (!cdnPrefix) {
+            return undefined;
+        }
+
+        // cdnPrefix looks like "res-1.public.onecdn.static.microsoft/bld" - keep only the host part.
+        const host = cdnPrefix.replace(/^https?:\/\//i, "").split("/")[0];
+
+        return host && host.length > 0 ? host : undefined;
+    }
+}

--- a/search-parts/src/helpers/FileTypeIconHelper.ts
+++ b/search-parts/src/helpers/FileTypeIconHelper.ts
@@ -50,9 +50,8 @@ export class FileTypeIconHelper {
     public static getBaseUrl(): string {
 
         // 1. Explicit override wins, used as-is.
-        const override = (typeof window !== "undefined")
-            ? (window as unknown as { [key: string]: string })[FileTypeIconHelper.OverrideGlobalName]
-            : undefined;
+        const globalScope = globalThis as unknown as { [key: string]: string };
+        const override = globalScope[FileTypeIconHelper.OverrideGlobalName];
 
         if (override && typeof override === "string" && override.trim().length > 0) {
             return override.trim();
@@ -69,9 +68,9 @@ export class FileTypeIconHelper {
                 const iconPath = new URL(fluentBaseUrl).pathname;
                 return `https://${cdnHost}${iconPath}`;
             }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
-            // Fall through to the Fluent default below.
+            // Malformed CDN host/path: fall back to the Fluent default CDN below.
+            console.warn('[FileTypeIconHelper] Failed to resolve SharePoint CDN base URL, falling back to Fluent default.', error);
         }
 
         // 3. Fluent UI default CDN.

--- a/search-parts/src/layouts/filters/custom/filters-custom.html
+++ b/search-parts/src/layouts/filters/custom/filters-custom.html
@@ -13,6 +13,8 @@
 				data-value="{{value}}" 
 				data-selected="{{selected}}" 
 				data-disabled="{{disabled}}"
+				data-value-count="{{../values.length}}"
+				data-value-index="{{@index}}"
 				data-theme-variant="{{JSONstringify @root.theme}}"
 			>
 			</pnp-filtercheckbox>

--- a/search-parts/src/layouts/filters/custom/filters-custom.html
+++ b/search-parts/src/layouts/filters/custom/filters-custom.html
@@ -6,6 +6,7 @@
 
 		<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}"></pnp-filtersearchbox>
 	
+		<div role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 		{{#each filter.values}}
 			<pnp-filtercheckbox 
 				data-filter-name="{{filter.filterName}}" 
@@ -13,12 +14,14 @@
 				data-value="{{value}}" 
 				data-selected="{{selected}}" 
 				data-disabled="{{disabled}}"
+				data-is-multi="{{../isMulti}}"
 				data-value-count="{{../values.length}}"
 				data-value-index="{{@index}}"
 				data-theme-variant="{{JSONstringify @root.theme}}"
 			>
 			</pnp-filtercheckbox>
 		{{/each}}
+		</div>
 		
 		{{#eq filter.values.length 0}}
 			<div>{{@root.strings.FilterNoValuesMessage}}</div>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -210,6 +210,8 @@
 											</div>
 
 							<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
+												{{#each filter.values}}
+													<div title="{{#with (split name '|')}}{{[1]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
 														<pnp-filtercheckbox 
 															data-instance-id="{{@root.instanceId}}" 
 															data-filter-name="{{filter.filterName}}" 

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -181,6 +181,8 @@
 													data-disabled="{{disabled}}" 
 													data-count="{{count}}"
 													data-is-multi="{{../isMulti}}"
+													data-value-count="{{../values.length}}"
+													data-value-index="{{@index}}"
 													data-theme-variant="{{JSONstringify @root.theme}}"
 												>
 												</pnp-filtercheckbox>
@@ -221,6 +223,8 @@
 															data-disabled="{{disabled}}" 
 															data-count="{{count}}"
 															data-is-multi="{{../isMulti}}"
+															data-value-count="{{../values.length}}"
+															data-value-index="{{@index}}"
 															data-theme-variant="{{JSONstringify @root.theme}}"
 														>
 														</pnp-filtercheckbox>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -169,7 +169,7 @@
 										<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
 									</div>
 
-									<div class="filter--values-list">
+									<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 										{{#each filter.values}}
 											<div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
 												<pnp-filtercheckbox 
@@ -209,11 +209,7 @@
 												<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
 											</div>
 
-											<div class="filter--values-list">
-												{{#each filter.values}}
-												
-													<!-- <div title="{{#with (split name '|')}}{{[1]}}({{[0]}}){{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value"> -->
-														<div title="{{#with (split name '|')}}{{[1]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
+							<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 														<pnp-filtercheckbox 
 															data-instance-id="{{@root.instanceId}}" 
 															data-filter-name="{{filter.filterName}}" 

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -185,7 +185,7 @@
                                                         <pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
                                                     </div>
                                                     
-                                                    <div class="filter--values-list">
+                                                    <div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
                                                         {{#each filter.values}}
                                                             <div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
                                                                 <pnp-filtercheckbox 
@@ -225,7 +225,7 @@
                                                             <pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
                                                         </div>
 
-                                                        <div class="filter--values-list">
+                                                        <div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
                                                             {{#each filter.values}}
                                                                 {{#eq (itemAt (split name "|") 1) "membership"}}
                                                                     <div title="{{#with (split name '|')}}{{[2]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -197,6 +197,8 @@
                                                                     data-disabled="{{disabled}}" 
                                                                     data-count="{{count}}"
                                                                     data-is-multi="{{../isMulti}}"
+                                                                    data-value-count="{{../values.length}}"
+                                                                    data-value-index="{{@index}}"
                                                                     data-theme-variant="{{JSONstringify @root.theme}}"
                                                                 >
                                                                 </pnp-filtercheckbox>
@@ -236,6 +238,8 @@
                                                                             data-disabled="{{disabled}}" 
                                                                             data-count="{{count}}"
                                                                             data-is-multi="{{../isMulti}}"
+                                                                            data-value-count="{{../values.length}}"
+                                                                            data-value-index="{{@index}}"
                                                                             data-theme-variant="{{JSONstringify @root.theme}}"
                                                                         >
                                                                         </pnp-filtercheckbox>
@@ -254,6 +258,8 @@
                                                                             data-disabled="{{disabled}}" 
                                                                             data-count="{{count}}"
                                                                             data-is-multi="{{../isMulti}}"
+                                                                            data-value-count="{{../values.length}}"
+                                                                            data-value-index="{{@index}}"
                                                                             data-theme-variant="{{JSONstringify @root.theme}}"
                                                                         >
                                                                         </pnp-filtercheckbox>

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -148,7 +148,7 @@
 										<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
 									</div>
 
-									<div class="filter--values-list">
+									<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 										{{#each filter.values}}
 											<div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
 												<pnp-filtercheckbox 
@@ -188,7 +188,7 @@
 											<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
 										</div>
 
-										<div class="filter--values-list">
+										<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 											{{#each filter.values}}
 											
 											<!-- From localSharePointResults: Admin@tcwlv.onmicrosoft.com | Kasper Larsen | 693A30232E667C6D656D626572736869707C61646D696E407463776C762E6F6E6D6963726F736F66742E636F6D i:0#.f|membership|admin@tcwlv.onmicrosoft.com -->

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -160,6 +160,8 @@
 													data-disabled="{{disabled}}" 
 													data-count="{{count}}"
 													data-is-multi="{{../isMulti}}"
+													data-value-count="{{../values.length}}"
+													data-value-index="{{@index}}"
 													data-theme-variant="{{JSONstringify @root.theme}}"
 												>
 												</pnp-filtercheckbox>
@@ -205,6 +207,8 @@
 															data-disabled="{{disabled}}" 
 															data-count="{{count}}"
 															data-is-multi="{{../isMulti}}"
+															data-value-count="{{../values.length}}"
+															data-value-index="{{@index}}"
 															data-theme-variant="{{JSONstringify @root.theme}}"
 														>
 														</pnp-filtercheckbox>
@@ -223,6 +227,8 @@
 															data-disabled="{{disabled}}" 
 															data-count="{{count}}"
 															data-is-multi="{{../isMulti}}"
+															data-value-count="{{../values.length}}"
+															data-value-index="{{@index}}"
 															data-theme-variant="{{JSONstringify @root.theme}}"
 														>
 														</pnp-filtercheckbox>

--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -284,6 +284,9 @@ declare interface ICommonStrings {
         SliderWrapAround: string;
         SlideWidth: string;
         SlideHeight: string;
+        PreviousPageLabel: string;
+        NextPageLabel: string;
+        GoToPageLabel: string;
       };
       People: {
         Name: string;

--- a/search-parts/src/loc/cs-cz.js
+++ b/search-parts/src/loc/cs-cz.js
@@ -281,7 +281,10 @@ define([], function () {
                 SliderShowPageDots: "Zobrazit body stránky",
                 SliderWrapAround: "Nekonečné rolování",
                 SlideHeight: "Výška karuselu (v px)",
-                SlideWidth: "Šířka karuselu (v px)"
+                SlideWidth: "Šířka karuselu (v px)",
+                PreviousPageLabel: "Předchozí stránka",
+                NextPageLabel: "Další stránka",
+                GoToPageLabel: "Přejít na stránku {0}"
             },
             People: {
                 Name: "Lidé",

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -283,7 +283,10 @@ define([], function () {
                 SliderShowPageDots: "Vis sidevisningsprikker",
                 SliderWrapAround: "Infinitiv scrolling",
                 SlideHeight: "Slide-højde (i px)",
-                SlideWidth: "Slide bredde (i px)"
+                SlideWidth: "Slide bredde (i px)",
+                PreviousPageLabel: "Forrige side",
+                NextPageLabel: "Næste side",
+                GoToPageLabel: "Gå til side {0}"
             },
             People: {
                 Name: "Personer",

--- a/search-parts/src/loc/de-de.js
+++ b/search-parts/src/loc/de-de.js
@@ -283,7 +283,10 @@ define([], function () {
                 SliderShowPageDots: "Seitenpunkte anzeigen",
                 SliderWrapAround: "Unendlicher Bildlauf",
                 SlideHeight: "Slide Höhe (in px)",
-                SlideWidth: "Slide Breite (in px)"
+                SlideWidth: "Slide Breite (in px)",
+                PreviousPageLabel: "Vorherige Seite",
+                NextPageLabel: "Nächste Seite",
+                GoToPageLabel: "Gehe zu Seite {0}"
             },
             People: {
                 Name: "People",

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -284,7 +284,10 @@ define([], function () {
                 SliderShowPageDots: "Show page dots",
                 SliderWrapAround: "Infinite scrolling",
                 SlideHeight: "Slide height (in px)",
-                SlideWidth: "Slide width (in px)"
+                SlideWidth: "Slide width (in px)",
+                PreviousPageLabel: "Previous page",
+                NextPageLabel: "Next page",
+                GoToPageLabel: "Go to page {0}"
             },
             People: {
                 Name: "People",

--- a/search-parts/src/loc/es-es.js
+++ b/search-parts/src/loc/es-es.js
@@ -284,7 +284,10 @@ define([], function () {
                 SliderShowPageDots: "Mostrar puntos de la página",
                 SliderWrapAround: "Desplazamiento infinito",
                 SlideHeight: "Altura de la diapositiva (en px)",
-                SlideWidth: "Ancho de la diapositiva (en px)"
+                SlideWidth: "Ancho de la diapositiva (en px)",
+                PreviousPageLabel: "Página anterior",
+                NextPageLabel: "Página siguiente",
+                GoToPageLabel: "Ir a la página {0}"
             },
             People: {
                 Name: "Personas",

--- a/search-parts/src/loc/fi-fi.js
+++ b/search-parts/src/loc/fi-fi.js
@@ -281,7 +281,10 @@ define([], function () {
                 SliderShowPageDots: "Näytä sivujen pallurat",
                 SliderWrapAround: "Ääretön skrollaus",
                 SlideHeight: "Korkeus (px)",
-                SlideWidth: "Leveys (px)"
+                SlideWidth: "Leveys (px)",
+                PreviousPageLabel: "Edellinen sivu",
+                NextPageLabel: "Seuraava sivu",
+                GoToPageLabel: "Siirry sivulle {0}"
             },
             People: {
                 Name: "Henkilöt",

--- a/search-parts/src/loc/fr-fr.js
+++ b/search-parts/src/loc/fr-fr.js
@@ -283,7 +283,10 @@ define([], function () {
                 SliderShowPageDots: "Afficher les points de numéro de page",
                 SliderWrapAround: "Défilement à l’infini",
                 SlideHeight: "Hauteur de la diapositive (en pixels)",
-                SlideWidth: "Largeur de la diapositive (en pixels)"
+                SlideWidth: "Largeur de la diapositive (en pixels)",
+                PreviousPageLabel: "Page précédente",
+                NextPageLabel: "Page suivante",
+                GoToPageLabel: "Aller à la page {0}"
             },
             People: {
                 Name: "Personnel",

--- a/search-parts/src/loc/it-it.js
+++ b/search-parts/src/loc/it-it.js
@@ -284,7 +284,10 @@ define([], function () {
                 SliderShowPageDots: "Mostra punti della pagina",
                 SliderWrapAround: "Scorrimento infinito",
                 SlideHeight: "Altezza diapositiva (in px)",
-                SlideWidth: "Larghezza diapositiva (in px)"
+                SlideWidth: "Larghezza diapositiva (in px)",
+                PreviousPageLabel: "Pagina precedente",
+                NextPageLabel: "Pagina successiva",
+                GoToPageLabel: "Vai alla pagina {0}"
             },
             People: {
                 Name: "Persone",

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -282,7 +282,10 @@ define([], function () {
                 SliderShowPageDots: "Visa sidepunkter",
                 SliderWrapAround: "Uendelig rulling",
                 SlideHeight: "Lysbildehøyde (px)",
-                SlideWidth: "Lysbildebredde (px)"
+                SlideWidth: "Lysbildebredde (px)",
+                PreviousPageLabel: "Forrige side",
+                NextPageLabel: "Neste side",
+                GoToPageLabel: "Gå til side {0}"
             },
             People: {
                 Name: "Person",

--- a/search-parts/src/loc/nl-nl.js
+++ b/search-parts/src/loc/nl-nl.js
@@ -283,7 +283,10 @@ define([], function () {
                 SliderShowPageDots: "Toon puntjes voor callout",
                 SliderWrapAround: "Oneindig scrollen",
                 SlideHeight: "Slide hoogte (in px)",
-                SlideWidth: "Slide breedte (in px)"
+                SlideWidth: "Slide breedte (in px)",
+                PreviousPageLabel: "Vorige pagina",
+                NextPageLabel: "Volgende pagina",
+                GoToPageLabel: "Ga naar pagina {0}"
             },
             People: {
                 Name: "Personen",

--- a/search-parts/src/loc/pl-pl.js
+++ b/search-parts/src/loc/pl-pl.js
@@ -284,7 +284,10 @@ define([], function () {
                 SliderShowPageDots: "Pokaż kropki",
                 SliderWrapAround: "Nieskończone przewijanie",
                 SlideHeight: "Wysokość slajdu (w pikselach)",
-                SlideWidth: "Szerokość slajdu (w pikselach)"
+                SlideWidth: "Szerokość slajdu (w pikselach)",
+                PreviousPageLabel: "Poprzednia strona",
+                NextPageLabel: "Następna strona",
+                GoToPageLabel: "Przejdź do strony {0}"
             },
             People: {
                 Name: "Osoba",

--- a/search-parts/src/loc/pt-br.js
+++ b/search-parts/src/loc/pt-br.js
@@ -283,7 +283,10 @@ define([], function () {
                 SliderShowPageDots: "Mostrar pontos da página",
                 SliderWrapAround: "Rolagem infinita",
                 SlideHeight: "Altura do slide (em px)",
-                SlideWidth: "Largura do slide (em px)"
+                SlideWidth: "Largura do slide (em px)",
+                PreviousPageLabel: "Página anterior",
+                NextPageLabel: "Próxima página",
+                GoToPageLabel: "Ir para a página {0}"
             },
             People: {
                 Name: "Pessoas",

--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -284,7 +284,10 @@ define([], function () {
                 SliderShowPageDots: "Visa sidpunkter",
                 SliderWrapAround: "Oändlig scroll",
                 SlideHeight: "Reglagehöjd (px)",
-                SlideWidth: "Reglagebredd (px)"
+                SlideWidth: "Reglagebredd (px)",
+                PreviousPageLabel: "Föregående sida",
+                NextPageLabel: "Nästa sida",
+                GoToPageLabel: "Gå till sida {0}"
             },
             People: {
                 Name: "Person",

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -252,13 +252,17 @@ export class TemplateService implements ITemplateService {
                 return new hb.SafeString(inverse + buildMissingPlaceholder("block helper", `#${name}`, placeholderTitle));
             });
 
+            // Provide the SharePoint CDN prefix so file type icons are served from the same CDN host
+            // SharePoint uses (more likely reachable in restricted environments). The version-correct
+            // icon path still comes from Fluent. This is reused by FileIconComponent via
+            // FileTypeIconHelper.getBaseUrl(), so it must be set even when another component on the page
+            // already initialized the Fluent file type icons (otherwise getBaseUrl() falls back to the
+            // Fluent default host).
+            FileTypeIconHelper.setCdnPrefix(this.pageContext?.legacyPageContext?.cdnPrefix);
+
             // Register icons and pull the fonts from the default SharePoint cdn.
             // Do not load icons twice as it may generate warnings
             if (!GlobalSettings.getValue("fileTypeIconsInitialized")) {
-                // Provide the SharePoint CDN prefix so file type icons are served from the same CDN host
-                // SharePoint uses (more likely reachable in restricted environments). The version-correct
-                // icon path still comes from Fluent. Resolved once here and reused by FileIconComponent.
-                FileTypeIconHelper.setCdnPrefix(this.pageContext?.legacyPageContext?.cdnPrefix);
                 initializeFileTypeIcons(FileTypeIconHelper.getBaseUrl());
                 GlobalSettings.setValue("fileTypeIconsInitialized", true);
             }

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -30,6 +30,7 @@ import {
 } from "@pnp/modern-search-extensibility";
 import { IComponentFieldsConfiguration } from "../../models/common/IComponentFieldsConfiguration";
 import { initializeFileTypeIcons } from "@fluentui/react-file-type-icons";
+import { FileTypeIconHelper } from "../../helpers/FileTypeIconHelper";
 import { GlobalSettings } from "@fluentui/react";
 import {
     IDataResultType,
@@ -254,7 +255,11 @@ export class TemplateService implements ITemplateService {
             // Register icons and pull the fonts from the default SharePoint cdn.
             // Do not load icons twice as it may generate warnings
             if (!GlobalSettings.getValue("fileTypeIconsInitialized")) {
-                initializeFileTypeIcons();
+                // Provide the SharePoint CDN prefix so file type icons are served from the same CDN host
+                // SharePoint uses (more likely reachable in restricted environments). The version-correct
+                // icon path still comes from Fluent. Resolved once here and reused by FileIconComponent.
+                FileTypeIconHelper.setCdnPrefix(this.pageContext?.legacyPageContext?.cdnPrefix);
+                initializeFileTypeIcons(FileTypeIconHelper.getBaseUrl());
                 GlobalSettings.setValue("fileTypeIconsInitialized", true);
             }
         });

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -168,6 +168,12 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
             this.errorMessage = error.message ? error.message : error;
         }
 
+        // Re-check disposal here: the await above yields control and the instance can be disposed in
+        // the meantime, leaving 'this.context' undefined when this code resumes.
+        if (this._webPartDisposed || !this.context) {
+            return;
+        }
+
         if (this.context.propertyPane && this.context.propertyPane.isPropertyPaneOpen()) {
             this.context.propertyPane.refresh();
         }

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -130,7 +130,20 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
         return super.onInit();
     }
 
+    /**
+     * Tracks whether the Web Part has been disposed. Async callbacks may resolve after the instance
+     * is torn down; rendering then crashes because 'this.context' is no longer available. This flag
+     * lets render() bail out safely.
+     */
+    private _webPartDisposed: boolean = false;
+
     public async render(): Promise<void> {
+
+        // The Web Part may have been disposed while an async callback was in flight. Rendering a
+        // disposed instance crashes because 'this.context' is no longer available, so bail out early.
+        if (this._webPartDisposed) {
+            return;
+        }
 
         // Check audience targeting - if user is not in audience, don't render
         const isInAudience = await this.isInAudience();
@@ -265,6 +278,7 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
     }
 
     protected onDispose(): void {
+        this._webPartDisposed = true;
         window.removeEventListener('hashchange', this._boundRender);
         if (this._pushStateCallback) {
             window.history.pushState = this._pushStateCallback;

--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -22,7 +22,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
      * `option` element references resolve to the correct instance for screen readers.
      */
     private get _idPrefix(): string {
-        return this.props.domElement && this.props.domElement.id ? this.props.domElement.id : 'pnp-searchbox';
+        return this.props.domElement?.id ? this.props.domElement.id : 'pnp-searchbox';
     }
 
     public constructor(props: ISearchBoxAutoCompleteProps) {

--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -16,6 +16,15 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
     private _onChangeDebounced = null;
     private _containerElemRef: React.RefObject<any> = null;
 
+    /**
+     * Per-instance prefix used to keep generated DOM ids (suggestion groups/options) unique when
+     * multiple Search Box Web Parts are rendered on the same page, so that `aria-labelledby` and the
+     * `option` element references resolve to the correct instance for screen readers.
+     */
+    private get _idPrefix(): string {
+        return this.props.domElement && this.props.domElement.id ? this.props.domElement.id : 'pnp-searchbox';
+    }
+
     public constructor(props: ISearchBoxAutoCompleteProps) {
 
         super(props);
@@ -75,7 +84,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                     }
                 });
 
-                const groupLabelId = `pnp-searchbox-suggestion-group-${groupIndex}`;
+                const groupLabelId = `${this._idPrefix}-suggestion-group-${groupIndex}`;
 
                 return (
                     // NOSONAR - intentional WAI-ARIA listbox grouping; native <optgroup>/<select> cannot render rich suggestion content (icons, sanitized HTML, links)
@@ -123,7 +132,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
 
         const baseProps = {
             key: suggestionIndex,
-            id: `pnp-searchbox-suggestion-${suggestionIndex}`,
+            id: `${this._idPrefix}-suggestion-${suggestionIndex}`,
             role: 'option',
             'aria-setsize': totalSuggestions,
             'aria-posinset': suggestionIndex + 1,

--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -78,6 +78,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                 const groupLabelId = `pnp-searchbox-suggestion-group-${groupIndex}`;
 
                 return (
+                    // NOSONAR - intentional WAI-ARIA listbox grouping; native <optgroup>/<select> cannot render rich suggestion content (icons, sanitized HTML, links)
                     <div key={groupLabelId} role="group" aria-labelledby={groupLabelId}>
                         <Label id={groupLabelId} className={styles.suggestionGroupName}>{groupName}</Label>
                         <div>

--- a/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
+++ b/search-parts/src/webparts/searchBox/components/SearchBoxAutoComplete/SearchBoxAutoComplete.tsx
@@ -56,8 +56,14 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                 return groups;
             }, {});
 
+            // Total number of suggestions that will actually be rendered (capped per group). Used to
+            // expose `aria-setsize`/`aria-posinset` so screen readers announce "x of y" correctly.
+            const totalRenderedSuggestions = Object.keys(suggestionGroups).reduce((total, groupName) => {
+                return total + Math.min(suggestionGroups[groupName].suggestions.length, this.props.numberOfSuggestionsPerGroup);
+            }, 0);
+
             let indexIncrementer = -1;
-            const renderedSuggestionGroups = Object.keys(suggestionGroups).map(groupName => {
+            const renderedSuggestionGroups = Object.keys(suggestionGroups).map((groupName, groupIndex) => {
                 const currentGroup = suggestionGroups[groupName];
                 let renderedSuggestions: JSX.Element[] = [];
 
@@ -65,21 +71,23 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
 
                     if (i < this.props.numberOfSuggestionsPerGroup) {
                         indexIncrementer++;
-                        renderedSuggestions.push(this._renderSuggestion(item.suggestion, indexIncrementer));
+                        renderedSuggestions.push(this._renderSuggestion(item.suggestion, indexIncrementer, totalRenderedSuggestions));
                     }
                 });
 
+                const groupLabelId = `pnp-searchbox-suggestion-group-${groupIndex}`;
+
                 return (
-                    <>
-                        <Label className={styles.suggestionGroupName}>{groupName}</Label>
+                    <div key={groupLabelId} role="group" aria-labelledby={groupLabelId}>
+                        <Label id={groupLabelId} className={styles.suggestionGroupName}>{groupName}</Label>
                         <div>
                             {renderedSuggestions}
                         </div>
-                    </>
+                    </div>
                 );
             });
 
-            renderSuggestions = <div className={styles.suggestionPanel}>
+            renderSuggestions = <div className={styles.suggestionPanel} role="listbox" aria-label={webPartStrings.SearchBox.DefaultPlaceholder}>
                 {renderedSuggestionGroups}
             </div>;
         }
@@ -87,7 +95,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
         return renderSuggestions;
     }
 
-    private _renderSuggestion(suggestion: ISuggestion, suggestionIndex: number): JSX.Element {
+    private _renderSuggestion(suggestion: ISuggestion, suggestionIndex: number, totalSuggestions: number): JSX.Element {
         const thisComponent = this;
 
         const suggestionInner = <>
@@ -114,6 +122,11 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
 
         const baseProps = {
             key: suggestionIndex,
+            id: `pnp-searchbox-suggestion-${suggestionIndex}`,
+            role: 'option',
+            'aria-setsize': totalSuggestions,
+            'aria-posinset': suggestionIndex + 1,
+            'aria-selected': false,
             title: suggestion.hoverText ? suggestion.hoverText : "",
             className: styles.suggestionItem,
             'data-is-focusable': true, // Used by FocusZone component
@@ -373,18 +386,18 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                         }
                     }}
                 >
-                    <span style={{ 
+                    <span style={{
                         marginRight: '6px',
                         color: 'white',
                         fontSize: textFontSize,
                         fontWeight: '400'
                     }}>{buttonText}</span>
-                    <Icon 
-                        iconName={iconName} 
-                        style={{ 
-                            fontSize: iconFontSize, 
+                    <Icon
+                        iconName={iconName}
+                        style={{
+                            fontSize: iconFontSize,
                             color: 'white'
-                        }} 
+                        }}
                     />
                 </DefaultButton>
             );
@@ -474,7 +487,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
             if (parentStackingContext) {
                 parentStackingContext.classList.add(styles.parentStackingCtx);
             }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) { }
 
         let searchBoxRef = React.createRef<ISearchBox>();
@@ -518,7 +531,7 @@ export default class SearchBoxAutoComplete extends React.Component<ISearchBoxAut
                             className={styles.searchTextField}
                             value={this.state.searchInputValue}
                             autoComplete="off"
-                            style={{...dynamicSearchBoxTextStyle, ...dynamicPlaceholderStyle, ...dynamicIconStyle}}
+                            style={{ ...dynamicSearchBoxTextStyle, ...dynamicPlaceholderStyle, ...dynamicIconStyle }}
                             //data-is-focusable={this.state.proposedQuerySuggestions.length > 0}
                             onChange={(event) => {
                                 if (!this._onChangeDebounced) {

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -278,6 +278,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         // In the case of an external template is selected, the render is done asynchronously waiting for the content to be fetched
         await this.initTemplate();
 
+        // Re-check disposal after the awaited audience/template work before resolving the layout
+        // instance, which uses this.context (torn down on dispose).
+        if (this._webPartDisposed || !this.context) {
+            return;
+        }
+
         // Get and initialize layout instance if different (i.e avoid to create a new instance every time)
         if (this.lastLayoutKey !== this.properties.selectedLayoutKey) {
             this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions, this.displayMode);

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -284,7 +284,14 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             this.lastLayoutKey = this.properties.selectedLayoutKey;
         }
 
-        // Refresh the property pane to get layout and data source options
+        // Refresh the property pane to get layout and data source options.
+        // Re-check disposal here: the awaits above (audience, template, layout) yield control, and the
+        // instance can be disposed in the meantime (e.g. another Web Part's source change races with
+        // removal in edit mode), leaving 'this.context' undefined when this code resumes.
+        if (this._webPartDisposed || !this.context) {
+            return;
+        }
+
         if (this.context.propertyPane.isPropertyPaneOpen()) {
             this.context.propertyPane.refresh();
         }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -154,6 +154,14 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     private readonly groupedTermSets: Map<string, Array<{ id: string, name: string, groupId: string, groupName: string }>> = new Map();
     private readonly hierarchicalSettingsUiStateByItemId: Map<string, IHierarchicalSettingsUiState> = new Map();
 
+    /**
+     * Tracks whether the Web Part has been disposed. Async callbacks (dynamic data 'available sources
+     * changed', theme change, etc.) may resolve after the instance is torn down; rendering then
+     * crashes because 'this.context' is no longer available (`Cannot read properties of undefined
+     * (reading 'propertyPane')`). This flag lets render() bail out safely.
+     */
+    private _webPartDisposed: boolean = false;
+
     constructor() {
         super();
         this._updateTitleProperty = this._updateTitleProperty.bind(this);
@@ -248,6 +256,13 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     }
 
     public async render(): Promise<void> {
+
+        // The Web Part may have been disposed while an async callback (dynamic data 'available sources
+        // changed', theme change, ...) was in flight. Rendering a disposed instance crashes because
+        // 'this.context' is no longer available (e.g. reading 'propertyPane'), so bail out early.
+        if (this._webPartDisposed) {
+            return;
+        }
 
         // Check audience targeting - if user is not in audience, don't render
         const isInAudience = await this.isInAudience();
@@ -461,6 +476,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     }
 
     protected onDispose(): void {
+        this._webPartDisposed = true;
         this.hierarchicalSettingsUiStateByItemId.clear();
         // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- paired with render in renderCompleted
         ReactDom.unmountComponentAtNode(this.domElement);

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2455,7 +2455,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         // Notify dynamic data consumers data have changed.
         // Selection changes can occur while the web part is being torn down, so guard against a missing
         // or disposed context/dynamicDataSourceManager (same pattern as _onDataRetrieved).
-        if (this.properties.allowWebPartConnections && this.context && this.context.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
+        if (this.properties.allowWebPartConnections && this.context?.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
             this.context.dynamicDataSourceManager.notifyPropertyChanged(DynamicDataProperties.AvailableFieldValuesFromResults);
 
             // Also notify consumers connected to the whole results source object so a connection to the

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2451,7 +2451,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._currentDataResultsSourceData.selectedItems = cloneDeep(currentSelectedItems);
 
-        // Notfify dynamic data consumers data have changed.
+        // Notify dynamic data consumers data have changed.
         // Selection changes can occur while the web part is being torn down, so guard against a missing
         // or disposed context/dynamicDataSourceManager (same pattern as _onDataRetrieved).
         if (this.properties.allowWebPartConnections && this.context && this.context.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2434,8 +2434,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._currentDataResultsSourceData.selectedItems = cloneDeep(currentSelectedItems);
 
-        // Notfify dynamic data consumers data have changed
-        if (this.properties.allowWebPartConnections) {
+        // Notfify dynamic data consumers data have changed.
+        // Selection changes can occur while the web part is being torn down, so guard against a missing
+        // or disposed context/dynamicDataSourceManager (same pattern as _onDataRetrieved).
+        if (this.properties.allowWebPartConnections && this.context && this.context.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
             this.context.dynamicDataSourceManager.notifyPropertyChanged(DynamicDataProperties.AvailableFieldValuesFromResults);
 
             // Also notify consumers connected to the whole results source object so a connection to the

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -490,6 +490,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         // Check if instanceId is defined - it might not be initialized yet during early render cycles
         if (!instanceId) {
             Log.verbose(`[SearchResultsWebPart.renderCompleted]`, `instanceId is not yet initialized, skipping render`, this.context?.serviceScope);
+            super.renderCompleted();
             return;
         }
 
@@ -2432,7 +2433,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             }
         }
 
-        // Notfify dynamic data consumers data have changed
+        // Notify dynamic data consumers data have changed
         if (this.properties.allowWebPartConnections && this.context && this.context.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
             this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchResults);
         }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2421,6 +2421,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         // Notfify dynamic data consumers data have changed
         if (this.properties.allowWebPartConnections) {
             this.context.dynamicDataSourceManager.notifyPropertyChanged(DynamicDataProperties.AvailableFieldValuesFromResults);
+
+            // Also notify consumers connected to the whole results source object so a connection to the
+            // 'selectedItems' sub-property is refreshed when the selection changes (otherwise it stays empty).
+            this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchResults);
         }
     }
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -264,6 +264,14 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      */
     private _hasPotentialIncomingConnections: boolean = false;
 
+    /**
+     * Tracks whether the Web Part has been disposed. Async callbacks (theme change, dynamic data
+     * 'available sources changed', extension loading, etc.) may resolve after the instance is torn
+     * down; rendering then crashes inside SPFx's async render watchdog (`Cannot read properties of
+     * undefined (reading 'webPartTag')`). This flag lets render() bail out safely.
+     */
+    private _webPartDisposed: boolean = false;
+
     constructor() {
         super();
 
@@ -275,6 +283,13 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
     public async render(): Promise<void> {
         try {
+
+            // The Web Part may have been disposed while an async callback (theme change, dynamic data
+            // source change, extension loading, ...) was in flight. Rendering a disposed instance
+            // crashes SPFx's async render watchdog, so bail out early.
+            if (this._webPartDisposed) {
+                return;
+            }
 
             // Check audience targeting - if user is not in audience, don't render
             const isInAudience = await this.isInAudience();
@@ -703,6 +718,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     }
 
     protected onDispose(): void {
+        this._webPartDisposed = true;
         if (this._pushStateCallback) {
             window.history.pushState = this._pushStateCallback;
         }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -293,6 +293,13 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             // Check audience targeting - if user is not in audience, don't render
             const isInAudience = await this.isInAudience();
+
+            // The Web Part may have been disposed while awaiting audience evaluation; bail out before
+            // touching this.context (SPFx tears it down on dispose).
+            if (this._webPartDisposed || !this.context) {
+                return;
+            }
+
             this._isHiddenByAudience = !isInAudience;
             if (!isInAudience) {
                 // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- cleanup on audience hide, paired with onDispose
@@ -321,6 +328,12 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             // Refresh the token values with the latest information from environment (i.e connections and settings)
             await this.setTokens();
+
+            // Re-check disposal after the awaited init/token work before resolving context-dependent
+            // data source and layout instances (LayoutHelper.getLayoutInstance uses this.context).
+            if (this._webPartDisposed || !this.context) {
+                return;
+            }
 
             // We resolve data source and layout instances directly in the render method to avoid unexpected render triggers due to Web Part property bag manipulation 
             // SPFx has an inner routine in reactive mode to trigger a render every time a property bag value is updated conflicting with the way data source and layouts share properties (see _afterPropertyUpdated)
@@ -374,6 +387,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             }
 
             if (this.dataSource) {
+                // Re-check disposal after the prior awaits before building the data context.
+                if (this._webPartDisposed || !this.context) {
+                    return;
+                }
                 this._currentDataContext = await this.getDataContext();
             }
             return this.renderCompleted();

--- a/search-parts/src/webparts/searchResults/services/TokenSetter.ts
+++ b/search-parts/src/webparts/searchResults/services/TokenSetter.ts
@@ -122,7 +122,10 @@ export class TokenSetter {
             } as IDataFilterTokenValue
         };
 
-        filterTokens[this.destinationFieldName].valueAsText = itemFieldValues.length > 0 ? itemFieldValues.join(',') : undefined;  // This allow the `{? <KQL expression>}` to work
+        // 'itemFieldValues' can be undefined when the source connection is not (yet) fully wired.
+        // Guard against it so we still publish the token (resolving to an empty value) instead of
+        // throwing, which would abort token setup and leave '{filters.<field>}' unresolved.
+        filterTokens[this.destinationFieldName].valueAsText = (itemFieldValues && itemFieldValues.length > 0) ? itemFieldValues.join(',') : undefined;  // This allow the `{? <KQL expression>}` to work
         this.tokenService.setTokenValue(BuiltinTokenNames.filters, filterTokens);
     }
 

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -100,7 +100,20 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
         }
     }
 
+    /**
+     * Tracks whether the Web Part has been disposed. Async callbacks may resolve after the instance
+     * is torn down; rendering then crashes because 'this.context' is no longer available. This flag
+     * lets render() bail out safely.
+     */
+    private _webPartDisposed: boolean = false;
+
     public async render(): Promise<void> {
+
+        // The Web Part may have been disposed while an async callback was in flight. Rendering a
+        // disposed instance crashes because 'this.context' is no longer available, so bail out early.
+        if (this._webPartDisposed) {
+            return;
+        }
 
         // Check audience targeting - if user is not in audience, don't render
         const isInAudience = await this.isInAudience();
@@ -272,6 +285,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
     }
 
     protected onDispose(): void {
+        this._webPartDisposed = true;
         // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- paired with render in renderCompleted
         ReactDom.unmountComponentAtNode(this.domElement);
     }

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -126,26 +126,8 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
 
         let renderRootElement: JSX.Element = null;
 
-        let defaultSelectedKey: string = undefined;
-
-        // Check if we can find a default vertical to set
-        if (this.properties.defaultVerticalQueryStringParam) {
-            const queryParms: UrlQueryParameterCollection = new UrlQueryParameterCollection(window.location.href.toLowerCase());
-            const defaultQueryVal: string = queryParms.getValue(this.properties.defaultVerticalQueryStringParam.toLowerCase());
-
-            if (defaultQueryVal) {
-                const defaultSelected: IDataVerticalConfiguration[] = this.properties.verticals.filter(v => v.tabName.toLowerCase() === decodeURIComponent(defaultQueryVal));
-                if (defaultSelected.length === 1) {
-                    defaultSelectedKey = defaultSelected[0].key;
-                }
-            }
-        } else {
-            const pagename = window.location.pathname.toLowerCase();
-            const defaultSelected: IDataVerticalConfiguration[] = this.properties.verticals.filter(v => v.isLink && v.linkUrl.toLowerCase().indexOf(pagename) > -1);
-            if (defaultSelected.length === 1) {
-                defaultSelectedKey = defaultSelected[0].key;
-            }
-        }
+        // Resolve the vertical that should be selected by default (from query string or current page).
+        const defaultSelectedKey: string = this._resolveDefaultSelectedKey();
 
         if (this.displayMode === DisplayMode.Edit && this.properties.verticals.length === 0) {
 
@@ -206,6 +188,30 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
 
         // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- render is paired with unmount in onDispose
         ReactDom.render(renderRootElement, this.domElement);
+    }
+
+    /**
+     * Resolves the key of the vertical that should be selected by default, based either on the
+     * configured query-string parameter or on the current page URL (for link verticals).
+     * Returns undefined when no single matching vertical is found.
+     */
+    private _resolveDefaultSelectedKey(): string {
+
+        if (this.properties.defaultVerticalQueryStringParam) {
+            const queryParms: UrlQueryParameterCollection = new UrlQueryParameterCollection(window.location.href.toLowerCase());
+            const defaultQueryVal: string = queryParms.getValue(this.properties.defaultVerticalQueryStringParam.toLowerCase());
+
+            if (defaultQueryVal) {
+                const defaultSelected: IDataVerticalConfiguration[] = this.properties.verticals.filter(v => v.tabName.toLowerCase() === decodeURIComponent(defaultQueryVal));
+                return defaultSelected.length === 1 ? defaultSelected[0].key : undefined;
+            }
+
+            return undefined;
+        }
+
+        const pagename = window.location.pathname.toLowerCase();
+        const defaultSelected: IDataVerticalConfiguration[] = this.properties.verticals.filter(v => v.isLink && v.linkUrl.toLowerCase().indexOf(pagename) > -1);
+        return defaultSelected.length === 1 ? defaultSelected[0].key : undefined;
     }
 
     /**

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -186,14 +186,19 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
         }
 
 
+        // The Web Part may have been disposed while awaiting audience filtering above. Rendering a
+        // disposed instance crashes because 'this.context' is no longer available, so bail out.
+        if (this._webPartDisposed || !this.context) {
+            return;
+        }
+
         // eslint-disable-next-line @rushstack/pair-react-dom-render-unmount -- render is paired with unmount in onDispose
         ReactDom.render(renderRootElement, this.domElement);
     }
 
     /**
      * Resolves the key of the vertical that should be selected by default, based either on the
-     * configured query-string parameter or on the current page URL (for link verticals).
-     * Returns undefined when no single matching vertical is found.
+     * configured query-string parameter or on the current page URL (for link verticals).     * Returns undefined when no single matching vertical is found.
      */
     private _resolveDefaultSelectedKey(): string {
 

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -198,7 +198,8 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
 
     /**
      * Resolves the key of the vertical that should be selected by default, based either on the
-     * configured query-string parameter or on the current page URL (for link verticals).     * Returns undefined when no single matching vertical is found.
+     * configured query-string parameter or on the current page URL (for link verticals).
+     * Returns undefined when no single matching vertical is found.
      */
     private _resolveDefaultSelectedKey(): string {
 


### PR DESCRIPTION
## Summary

This PR bundles a batch of bug fixes and accessibility improvements across the Search Results, Search Filters, Search Box and Search Verticals web parts, plus a primary data-source fix for Microsoft Search external items.

All changes are typecheck-clean (`tsc --noEmit`) and have been functionally verified except where noted.

## Fixes

### Data source / connections
- **#4796 — Multiple filters on external items return 0 results (Microsoft Search).** `MicrosoftSearchDataSource.buildAggregationFilters` was emitting **FQL** refinement strings where the `/search/query` endpoint expects **KQL**. A single filter worked, but combining two or more produced FQL the endpoint could not satisfy. `DataFilterHelper.buildKqlRefinementString` now honors the configured between-filter operator (AND/OR), and the Microsoft Search data source builds the aggregation filter as KQL. The FQL helper is unchanged and still used by SharePoint Search and the hierarchical filter. (commit `4a85c2ca`) — thanks @x-mcg for the analysis.
- **#4135 — `selectedItems` returned as `[object Object]` / `{filters.<field>}` unresolved when connecting web parts.** Item selection now notifies the `SearchResults` source object so object-connected consumers refresh on selection, and `TokenSetter` is guarded against undefined selected values that previously threw and left `{filters.<field>}` unresolved. (commits `f3196aba`, `68bbcf5e`)

### File icons
- **#4376 — Random problem with the image URL generated by pnp-iconfile.** `FileIconComponent` now resolves file-type icons via a deterministic production CDN URL (`getFileTypeIconAsUrl`) instead of the shared mutable icon registry (`getFileTypeIconProps`), and the CDN base URL is resolved via `FileTypeIconHelper` using the SP `cdnPrefix` host with an override option. This prevents icons from breaking when another app on the page registers file-type icons against a non-production CDN. (commits `51efa550`, `04205e0a`)

### Layouts
- **#4801 — Slider template broken in 4.22.** Slider carousel is now a controlled component and the shimmer theme is guarded. (commit `8c65de6f`)
- **Horizontal filter layout regression** — restored the `{{#each}}` loop in the horizontal filter "people" branch that had been dropped in a prior commit. (commit `f3196aba`)

### Accessibility
- **#3900 — Filter widget could not be closed after opening.** An opened filter widget can now be closed with **Escape**, returning focus to the header. (commit `a06aa9f4`)
- **#3901 — Filter AND/OR screen-reader miscount ("1 of 3").** Removed the disabled `/` separator radio from the AND/OR operator `ChoiceGroup` so screen readers announce **"x of 2"**; the separator is now a presentational CSS pseudo-element. (commit `b8760858`)
- **#3902 — Single-select filter radios announced incorrectly.** Single-select filter radios now expose `aria-setsize`/`aria-posinset` so they announce as "x of y". (commits `6a626300`, `dc682888`)
- **#3903 — Search Box query suggestions screen-reader issue.** Added `listbox`/`option` ARIA semantics to the query suggestions. (commit `2ccd40b9`)
- **#4026 — "ARIA input fields must have an accessible name".** Added an accessible name to the sort dropdown and direction button. (commit `19b427d1`)

### Stability / runtime crashes
- **Render-after-dispose crashes (`webPartTag` / `propertyPane` undefined).** Stale `availableSourcesChanged` / theme-changed callbacks could call `render()` on disposed web part instances. Added a disposal guard at the top of `render()` in Search Results, Filters, Box and Verticals, plus a post-await re-check before accessing `this.context.propertyPane` (disposal can occur mid-render during awaits). (commits `df7d351a`, `ea045a7d`, `677d240d`)
- **`semanticColors` shimmer crash.** Guarded `PersonaShimmers`/`DocumentCardShimmers` theme access via optional chaining, fixing a crash when shimmers render before the theme provider populates. (commit `f3196aba`)

## Related Safari / iOS issues (closed separately)

The following could not be reproduced on the current `develop` branch and were closed with a request to re-test on a newer release and reopen if still present:
- #4465 — Search Results not rendering in Safari (cached dynamic-import / chunk-load failure signature; addressed by async chunk-splitting + load-retry + render lifecycle guards on `develop`).
- #2984 — People Search iOS Safari redirect.
- #4096 — iOS Safari (Webkit) error as Entra ID B2B Guest User.

## Testing

- `tsc --noEmit` passes for all changes.
- Functionally verified: #4135 (multi-value `{filters}` token resolves), #3901 (AND/OR announces "1 of 2" / "2 of 2"), and the dispose-related crashes.
- #4796 needs functional verification against a Copilot connector with multiple refinable properties (single filter unchanged; 2+ filters with AND → intersection; with OR → union; SharePoint Search unaffected).
