### PR TITLE
Add built-in formatSPFileSize Handlebars helper

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -257,7 +257,35 @@ Supported output format tokens include all [dayjs format tokens](https://day.js.
 
 **Description** Convert a UTF-8 hexadecimal string back to text. The helper also accepts the filter value format used in deep links, including optional surrounding quotes and the `ǂǂ` prefix.
 
-**Example** `{{hexToString '"ǂǂ4b656f6768e280997320437269737073"'}}` returns `Keogh’s Crisps`.
+**Example** `{{hexToString ‘"ǂǂ4b656f6768e280997320437269737073"’}}` returns `Keogh’s Crisps`.
+
+#### formatSPFileSize
+
+**Syntax** `{{formatSPFileSize <value>}}`
+
+**Description** Formats a file size in bytes to a human-readable string matching SharePoint’s native file size display. Uses binary (1024-based) divisors with tiered decimal precision.
+
+**Example** `{{formatSPFileSize File_x0020_Size}}`
+
+| Input (bytes) | Output |
+|---|---|
+| 0 | `0 bytes` |
+| 500 | `500 bytes` |
+| 1023 | `1023 bytes` |
+| 1024 | `1 KB` |
+| 1536 | `1.5 KB` |
+| 34972 | `34.2 KB` |
+| 51200 | `50 KB` |
+| 148098 | `145 KB` |
+| 1048576 | `1 MB` |
+| 1209452 | `1.15 MB` |
+| 10485760 | `10 MB` |
+| 11624602 | `11.1 MB` |
+| 82849344 | `79.0 MB` |
+| 104857600 | `100 MB` |
+| 1073741824 | `1.00 GB` |
+| 8486862848 | `7.90 GB` |
+| 1099511627776 | `1.00 TB` |
 
 #### Deep Link Example For Search Filters
 

--- a/search-parts/src/helpers/HandlebarsHelpers.ts
+++ b/search-parts/src/helpers/HandlebarsHelpers.ts
@@ -232,6 +232,36 @@ function helperHexToString(hex: any): string {
     return StringHelper.hexToString(String(hex));
 }
 
+function helperFormatSPFileSize(bytes: any): Handlebars.SafeString {
+    const b = parseInt(String(bytes), 10);
+    if (isNaN(b) || b < 0) return new Handlebars.SafeString("0 KB");
+
+    const isInteger = (n: number): boolean => n % 1 === 0;
+
+    const KB = 1024;
+    const MB = 1024 * KB;
+    const GB = 1024 * MB;
+    const TB = 1024 * GB;
+
+    if (b < KB) return new Handlebars.SafeString(b + " bytes");
+    if (b < MB) {
+        const kb = b / KB;
+        if (isInteger(kb)) return new Handlebars.SafeString(Math.round(kb) + " KB");
+        if (kb < 100) return new Handlebars.SafeString(kb.toFixed(1) + " KB");
+        return new Handlebars.SafeString(Math.round(kb) + " KB");
+    } else if (b < GB) {
+        const mb = b / MB;
+        if (isInteger(mb)) return new Handlebars.SafeString(Math.round(mb) + " MB");
+        if (mb < 10)  return new Handlebars.SafeString(mb.toFixed(2) + " MB");
+        if (mb < 100) return new Handlebars.SafeString(mb.toFixed(1) + " MB");
+        return new Handlebars.SafeString(Math.round(mb) + " MB");
+    } else if (b < TB) {
+        return new Handlebars.SafeString((b / GB).toFixed(2) + " GB");
+    } else {
+        return new Handlebars.SafeString((b / TB).toFixed(2) + " TB");
+    }
+}
+
 // ─── Object helpers ───────────────────────────────────────────────────────────
 
 function helperJSONstringify(obj: any, indent: any): string {
@@ -502,6 +532,7 @@ export function getHandlebarsHelpers(): Record<string, (...args: any[]) => any> 
         startsWith: helperStartsWith,
         stringToHex: helperStringToHex,
         hexToString: helperHexToString,
+        formatSPFileSize: helperFormatSPFileSize,
 
         // object
         JSONstringify: helperJSONstringify,


### PR DESCRIPTION
## Summary

- Add `formatSPFileSize` built-in Handlebars helper that formats a file size in bytes to a human-readable string matching SharePoint's native `OWS_FILESIZEDISPLAY` display (need to map this to a refinableInt).
- Uses binary (1024-based) divisors with tiered decimal precision: 2 d.p. for values < 10, 1 d.p. for values < 100, whole number for ≥ 100 (within each unit), matching the behaviour users see in SharePoint document libraries
- Document the new helper in `docs/extensibility/templating.md` with a full input/output example table

## Usage

```handlebars
{{formatSPFileSize File_x0020_Size}}
```

## Example outputs

| Input (bytes) | Output |
|---|---|
| 0 | `0 bytes` |
| 1023 | `1023 bytes` |
| 1024 | `1 KB` |
| 1536 | `1.5 KB` |
| 148098 | `145 KB` |
| 1048576 | `1 MB` |
| 1209452 | `1.15 MB` |
| 10485760 | `10 MB` |
| 82849344 | `79.0 MB` |
| 1073741824 | `1.00 GB` |
| 8486862848 | `7.90 GB` |
| 1099511627776 | `1.00 TB` |

## Test plan

- [ ] Verify helper is registered and callable in a search results Handlebars template using `{{formatSPFileSize File_x0020_Size}}`
- [ ] Confirm outputs match the table above for byte, KB, MB, GB, and TB ranges
- [ ] Confirm `0` and negative/invalid values return `0 bytes` / `0 KB` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
