### PR TITLE
fix(deps): bump dompurify, markdown-it, launch-editor (Dependabot)

### DIFF
--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -35,11 +35,11 @@
                 "adaptivecards": "2.11.2",
                 "adaptivecards-templating": "2.3.1",
                 "dayjs": "1.11.19",
-                "dompurify": "3.4.0",
+                "dompurify": "3.4.11",
                 "handlebars": "4.7.9",
                 "immutability-helper": "3.1.1",
                 "jspath": "0.4.0",
-                "markdown-it": "14.1.1",
+                "markdown-it": "14.2.0",
                 "react": "17.0.1",
                 "react-ace": "10.1.0",
                 "react-dom": "17.0.1",
@@ -12585,7 +12585,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.20.0",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14466,7 +14468,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.0",
+            "version": "3.4.11",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -18292,14 +18296,14 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.13.2",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-            "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.1.1",
-                "shell-quote": "^1.8.3"
+                "shell-quote": "^1.8.4"
             }
         },
         "node_modules/leven": {
@@ -18349,7 +18353,19 @@
             "license": "MIT"
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -18565,14 +18581,24 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -23076,6 +23102,8 @@
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "license": "MIT"
         },
         "node_modules/uglify-js": {

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -39,11 +39,11 @@
         "adaptivecards": "2.11.2",
         "adaptivecards-templating": "2.3.1",
         "dayjs": "1.11.19",
-        "dompurify": "3.4.0",
+        "dompurify": "3.4.11",
         "handlebars": "4.7.9",
         "immutability-helper": "3.1.1",
         "jspath": "0.4.0",
-        "markdown-it": "14.1.1",
+        "markdown-it": "14.2.0",
         "react": "17.0.1",
         "react-ace": "10.1.0",
         "react-dom": "17.0.1",
@@ -126,6 +126,7 @@
         "immutable": "4.3.8",
         "js-cookie": "3.0.7",
         "js-yaml": "4.1.1",
+        "launch-editor": "2.14.1",
         "lodash": "4.18.0",
         "lodash-es": "4.18.0",
         "markdown-to-jsx": "7.4.0",
@@ -191,6 +192,7 @@
             "immutable": "4.3.8",
             "js-cookie": "3.0.7",
             "js-yaml": "4.1.1",
+            "launch-editor": "2.14.1",
             "lodash": "4.18.0",
             "lodash-es": "4.18.0",
             "markdown-to-jsx": "7.4.0",
@@ -218,5 +220,6 @@
             "fsevents",
             "swiper"
         ]
-    }
+    },
+    "packageManager": "pnpm@10.26.0+sha512.3b3f6c725ebe712506c0ab1ad4133cf86b1f4b687effce62a9b38b4d72e3954242e643190fc51fa1642949c735f403debd44f5cb0edd657abe63a8b6a7e1e402"
 }

--- a/search-parts/pnpm-lock.yaml
+++ b/search-parts/pnpm-lock.yaml
@@ -47,6 +47,7 @@ overrides:
   immutable: 4.3.8
   js-cookie: 3.0.7
   js-yaml: 4.1.1
+  launch-editor: 2.14.1
   lodash: 4.18.0
   lodash-es: 4.18.0
   markdown-to-jsx: 7.4.0
@@ -152,8 +153,8 @@ importers:
         specifier: 1.11.19
         version: 1.11.19
       dompurify:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.4.11
+        version: 3.4.11
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -164,8 +165,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
       markdown-it:
-        specifier: 14.1.1
-        version: 14.1.1
+        specifier: 14.2.0
+        version: 14.2.0
       react:
         specifier: 17.0.1
         version: 17.0.1
@@ -3719,8 +3720,8 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -4901,8 +4902,8 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  launch-editor@2.13.2:
-    resolution: {integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -4922,8 +4923,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   lit-element@3.3.3:
     resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
@@ -5025,8 +5026,8 @@ packages:
     resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-to-jsx@7.4.0:
@@ -10861,7 +10862,7 @@ snapshots:
       jotai: 2.20.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@17.0.45)(react@17.0.1)
       lodash: 4.18.0
       maplibre-gl: 5.24.0
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       monaco-editor: 0.29.1
       nano-css: 5.6.2(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       pmtiles: 4.4.1
@@ -12702,7 +12703,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -14258,7 +14259,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  launch-editor@2.13.2:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.4
@@ -14278,7 +14279,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -14400,11 +14401,11 @@ snapshots:
       quickselect: 3.0.0
       tinyqueue: 3.0.0
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -16199,7 +16200,7 @@ snapshots:
       graceful-fs: 4.2.11
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.4.0
-      launch-editor: 2.13.2
+      launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3


### PR DESCRIPTION
## Summary

Recreates the open Dependabot dependency PRs against `develop` (Dependabot opens them against `main`, which is not our integration branch).

| Package | From | To | Original PR |
|---------|------|----|-------------|
| `dompurify` | 3.4.0 | 3.4.11 | #4828 |
| `markdown-it` | 14.1.1 | 14.2.0 | #4826 |
| `launch-editor` | 2.13.2 | 2.14.1 | #4827 |

- `dompurify` and `markdown-it` are direct dependencies (updated in `dependencies`).
- `launch-editor` is a transitive (dev) dependency, pinned via `overrides` / `pnpm.overrides`.

## Notes

- Both lockfiles regenerated: `pnpm-lock.yaml` with pnpm 10.26.0 (so `pnpm.overrides` are honored — pnpm 11 ignores that field) and `package-lock.json` with npm.
- npm audit: develop baseline 31 → this branch 28 (no new vulnerabilities introduced).
- Production build validated (`npm run build` → `.sppkg` produced).

Closes Dependabot PRs #4826, #4827, #4828 (which will be closed as superseded).