### PR TITLE
fix(#4825): populate Manage Columns picker for Microsoft Search data source

### DIFF
--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -2487,7 +2487,12 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
      * Always recomputed (no caching) to reflect latest user changes immediately.
      */
     private getSelectedProperties(): string[] {
-        return (this.dataSource?.properties?.selectedProperties || []).filter((p: string) => !!p);
+        // Different data sources expose the configured retrievable fields under different property names:
+        // SharePoint Search uses 'selectedProperties', while Microsoft Search uses 'fields'. Fall back to
+        // 'fields' so consumers (e.g. the Details List "Manage Columns" picker) are populated for both (issue #4825).
+        const dataSourceProperties: any = this.dataSource?.properties || {};
+        const selectedProperties: string[] = dataSourceProperties.selectedProperties || dataSourceProperties.fields || [];
+        return selectedProperties.filter((p: string) => !!p);
     }
 
     private _updateTitleProperty(value: string) {


### PR DESCRIPTION
## Issue

Fixes #4825

With the **Microsoft Search** data source, the Details List layout's **Manage Columns → "Column Value"** dropdown is empty — you can't pick a property to add as a column. It works with SharePoint Search.

## Root cause

The column picker is populated from `SearchResultsWebPart.getSelectedProperties()`, which only read the data source's `selectedProperties` property. That name is **SharePoint-Search-specific** — the Microsoft Search data source stores its retrievable fields under **`fields`** (the "Selected Fields" control). So for Microsoft Search, `getSelectedProperties()` resolved to `[]` and the picker had nothing to show.

## Fix

Fall back to `fields` when `selectedProperties` is absent, so the picker is populated for both data sources:

```ts
const dataSourceProperties: any = this.dataSource?.properties || {};
const selectedProperties: string[] = dataSourceProperties.selectedProperties || dataSourceProperties.fields || [];
return selectedProperties.filter((p: string) => !!p);
```

For Microsoft Search this surfaces the user's configured Selected Fields (which default to the common field set) in the Manage Columns picker — matching the reporter's expectation.

## Validation

- `npm run build` (production) passes; `.sppkg` produced.
- No new strings; single-file change.