### PR TITLE
fix(#4820): restore Flickity-compatible slider class hooks + add full-width option

### DIFF
--- a/search-parts/src/components/SliderComponent.module.scss
+++ b/search-parts/src/components/SliderComponent.module.scss
@@ -99,6 +99,15 @@
   width: 100%;
 }
 
+/* Full-width (full-bleed) mode: stretch each slide to the full viewport width,
+   dropping the fixed slide-width cap. Opt-in via the `fullWidth` slider option. */
+.carouselFullWidth {
+  .carouselSlide {
+    width: 100%;
+    max-width: none;
+  }
+}
+
 .carouselSlide {
   position: relative;
   width: min(

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -44,6 +44,12 @@ export interface ISliderOptions {
      * At the end of cells, wrap-around to the other end for infinite scrolling.
      */
     wrapAround?: boolean;
+
+    /**
+     * Stretches each slide to the full width of the slider viewport (drops the fixed slide width cap).
+     * Useful for full-bleed/hero sliders. Opt-in so existing fixed-width sliders are unaffected.
+     */
+    fullWidth?: boolean;
 }
 
 export interface ISliderComponentProps {
@@ -271,7 +277,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                         }
                     );
 
-                    return <div key={absoluteIndex} className={styles.carouselSlide}>
+                    return <div key={absoluteIndex} className={`${styles.carouselSlide} flickity-cell`}>
                         <div dangerouslySetInnerHTML={{ __html: DomPurifyHelper.instance.sanitize(templateContentValue) }}></div>
                     </div>;
                 });
@@ -290,6 +296,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             const wrapAround = sliderOptions.wrapAround === true;
             const showControls = this._pageCount > 1;
             const showDots = showControls && sliderOptions.showPageDots === true;
+            const fullWidth = sliderOptions.fullWidth === true;
 
             const prevDisabled = !wrapAround && currentIndex === 0;
             const nextDisabled = !wrapAround && currentIndex === this._pageCount - 1;
@@ -299,7 +306,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             const slideWidth = templateContext?.properties?.layoutProperties?.slideWidth || 318;
 
             return <div
-                className={styles.carouselContainer}
+                className={`${styles.carouselContainer} flickity-enabled pnp-slider${fullWidth ? ` ${styles.carouselFullWidth}` : ''}`}
                 onMouseEnter={this._onMouseEnter}
                 onMouseLeave={this._onMouseLeave}
                 ref={(el) => {
@@ -313,16 +320,16 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             >
                 {showControls &&
                     <IconButton
-                        className={`${styles.carouselButton} ${styles.carouselButtonPrev}`}
+                        className={`${styles.carouselButton} ${styles.carouselButtonPrev} flickity-button flickity-prev-next-button previous`}
                         iconProps={{ iconName: 'ChevronLeft' }}
                         ariaLabel={strings.Layouts.Slider.PreviousPageLabel}
                         disabled={prevDisabled}
                         onClick={this._goToPrevious}
                     />
                 }
-                <div className={styles.carouselViewport}>
+                <div className={`${styles.carouselViewport} flickity-viewport`}>
                     <div
-                        className={styles.carouselTrack}
+                        className={`${styles.carouselTrack} flickity-slider`}
                         style={{ transform: `translateX(-${currentIndex * 100}%)` }}
                     >
                         {carouselElements.map((element, index) => (
@@ -338,7 +345,7 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                 </div>
                 {showControls &&
                     <IconButton
-                        className={`${styles.carouselButton} ${styles.carouselButtonNext}`}
+                        className={`${styles.carouselButton} ${styles.carouselButtonNext} flickity-button flickity-prev-next-button next`}
                         iconProps={{ iconName: 'ChevronRight' }}
                         ariaLabel={strings.Layouts.Slider.NextPageLabel}
                         disabled={nextDisabled}
@@ -346,9 +353,9 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     />
                 }
                 {showDots &&
-                    <ol className={styles.carouselIndicators}>
+                    <ol className={`${styles.carouselIndicators} flickity-page-dots`}>
                         {carouselElements.map((element, index) => (
-                            <li key={`carousel-dot-${index}`}>
+                            <li key={`carousel-dot-${index}`} className={index === currentIndex ? 'dot is-selected' : 'dot'}>
                                 <button
                                     type="button"
                                     className={index === currentIndex ? styles.carouselIndicatorActive : undefined}

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -326,14 +326,6 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonPrev} flickity-button flickity-prev-next-button previous`}
                         iconProps={{ iconName: 'ChevronLeft' }}
-                        onRenderIcon={() => (
-                            // Render a real <svg> (not the Fluent icon font) so community templates that style
-                            // `.flickity-button svg { fill: ... }` keep working. The svg `fill="currentColor"`
-                            // presentation attribute themes by default but is overridable by template CSS.
-                            <svg className="flickity-button-icon" viewBox="0 0 100 100" fill="currentColor" aria-hidden="true">
-                                <path className="arrow" d="M 10,50 L 60,100 L 70,90 L 30,50 L 70,10 L 60,0 Z" />
-                            </svg>
-                        )}
                         ariaLabel={strings.Layouts.Slider.PreviousPageLabel}
                         disabled={prevDisabled}
                         onClick={this._goToPrevious}
@@ -359,12 +351,6 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonNext} flickity-button flickity-prev-next-button next`}
                         iconProps={{ iconName: 'ChevronRight' }}
-                        onRenderIcon={() => (
-                            // Mirror of the previous-button arrow (rotated 180°). See note on the previous button.
-                            <svg className="flickity-button-icon" viewBox="0 0 100 100" fill="currentColor" aria-hidden="true">
-                                <path className="arrow" d="M 10,50 L 60,100 L 70,90 L 30,50 L 70,10 L 60,0 Z" transform="translate(100, 100) rotate(180)" />
-                            </svg>
-                        )}
                         ariaLabel={strings.Layouts.Slider.NextPageLabel}
                         disabled={nextDisabled}
                         onClick={this._goToNext}

--- a/search-parts/src/components/SliderComponent.tsx
+++ b/search-parts/src/components/SliderComponent.tsx
@@ -48,6 +48,8 @@ export interface ISliderOptions {
     /**
      * Stretches each slide to the full width of the slider viewport (drops the fixed slide width cap).
      * Useful for full-bleed/hero sliders. Opt-in so existing fixed-width sliders are unaffected.
+     * Only takes effect when a single slide is shown per page (numberOfSlides = 1); it is ignored for
+     * multi-slide pages, where stretching every slide to 100% would overflow the page.
      */
     fullWidth?: boolean;
 }
@@ -296,7 +298,9 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
             const wrapAround = sliderOptions.wrapAround === true;
             const showControls = this._pageCount > 1;
             const showDots = showControls && sliderOptions.showPageDots === true;
-            const fullWidth = sliderOptions.fullWidth === true;
+            // Full width only makes sense with a single slide per page; ignore it for multi-slide pages
+            // so we never stretch several slides to 100% inside the same page.
+            const fullWidth = sliderOptions.fullWidth === true && numberOfSlides === 1;
 
             const prevDisabled = !wrapAround && currentIndex === 0;
             const nextDisabled = !wrapAround && currentIndex === this._pageCount - 1;
@@ -322,6 +326,14 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonPrev} flickity-button flickity-prev-next-button previous`}
                         iconProps={{ iconName: 'ChevronLeft' }}
+                        onRenderIcon={() => (
+                            // Render a real <svg> (not the Fluent icon font) so community templates that style
+                            // `.flickity-button svg { fill: ... }` keep working. The svg `fill="currentColor"`
+                            // presentation attribute themes by default but is overridable by template CSS.
+                            <svg className="flickity-button-icon" viewBox="0 0 100 100" fill="currentColor" aria-hidden="true">
+                                <path className="arrow" d="M 10,50 L 60,100 L 70,90 L 30,50 L 70,10 L 60,0 Z" />
+                            </svg>
+                        )}
                         ariaLabel={strings.Layouts.Slider.PreviousPageLabel}
                         disabled={prevDisabled}
                         onClick={this._goToPrevious}
@@ -347,6 +359,12 @@ export class SliderComponent extends React.Component<ISliderComponentProps, ISli
                     <IconButton
                         className={`${styles.carouselButton} ${styles.carouselButtonNext} flickity-button flickity-prev-next-button next`}
                         iconProps={{ iconName: 'ChevronRight' }}
+                        onRenderIcon={() => (
+                            // Mirror of the previous-button arrow (rotated 180°). See note on the previous button.
+                            <svg className="flickity-button-icon" viewBox="0 0 100 100" fill="currentColor" aria-hidden="true">
+                                <path className="arrow" d="M 10,50 L 60,100 L 70,90 L 30,50 L 70,10 L 60,0 Z" transform="translate(100, 100) rotate(180)" />
+                            </svg>
+                        )}
                         ariaLabel={strings.Layouts.Slider.NextPageLabel}
                         disabled={nextDisabled}
                         onClick={this._goToNext}


### PR DESCRIPTION
## Issue

Helps #4820

After the GPL **Flickity** dependency was removed (#4386) and the slider was reimplemented in-house, community templates that relied on Flickity's DOM/CSS hooks — notably the **Valo-style news slider** — broke in two ways:

1. **CSS hooks gone** — templates target `.flickity-enabled`, `.flickity-viewport`, `.flickity-page-dots`, `.flickity-button`, `.flickity-button svg`, none of which the new `SliderComponent` emitted (it uses hashed CSS-module classes).
2. **Not full width** — `.carouselSlide` caps width at `--slide-width` (default 318px), so full-bleed/hero sliders could no longer stretch to 100%.

## Changes

**1. Backwards-compatible class aliases** added to the slider DOM (additive, alongside the existing module classes):

| Element | Alias added |
|---|---|
| container | `flickity-enabled`, `pnp-slider` |
| viewport | `flickity-viewport` |
| track | `flickity-slider` |
| slide | `flickity-cell` |
| dots `<ol>` | `flickity-page-dots` |
| each dot `<li>` | `dot` / `dot is-selected` |
| nav buttons | `flickity-button flickity-prev-next-button` + `previous`/`next` |

This restores the selectors the Valo template targets (page dots, nav buttons, viewport) without re-introducing Flickity.

**2. Opt-in `fullWidth` slider option** — passed via `data-options` (e.g. `"fullWidth":true`); drops the fixed slide-width cap and stretches slides to 100% of the viewport. Opt-in so existing fixed-width sliders are unaffected.

## Notes / honest caveats

- The engines differ (CSS-transform track vs Flickity's absolutely-positioned cells), so a few selectors (`.flickity-cell` positioning, transitions) won't be byte-identical — but full width, page dots, nav buttons, and viewport hooks work, which is what the community templates need.
- No new localized strings; purely additive class hooks + one optional flag.
- cc @kasperbolarsen @saskiapicht — this gives a product-side base to update the Valo template against.

## Validation

- `npm run build` (production) passes; `.sppkg` produced.
- Files: `SliderComponent.tsx`, `SliderComponent.module.scss`.