### PR TITLE
fix(#4790): always re-query on search box submit (even if query text unchanged)

### DIFF
--- a/search-parts/src/common/Constants.ts
+++ b/search-parts/src/common/Constants.ts
@@ -19,6 +19,13 @@ export class Constants {
      * The regular expression to sanitize URIs with DomPurify
      */
     public static readonly ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|file|tel|callto|msteams|rcapp|im|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
+
+    /**
+     * Page-wide GlobalSettings key holding a monotonically increasing id that is bumped every time a
+     * search is explicitly submitted from a Search Box (Enter or the Search button). Connected Search
+     * Results use it to force a fresh query even when the query text is unchanged (issue #4790).
+     */
+    public static readonly SEARCH_BOX_SUBMISSION_ID_KEY = 'pnpSearchBoxSubmissionId';
 }
 
 export enum AutoCalculatedDataSourceFields {

--- a/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
+++ b/search-parts/src/webparts/searchBox/SearchBoxWebPart.ts
@@ -885,6 +885,11 @@ export default class SearchBoxWebPart extends BaseWebPart<ISearchBoxWebPartProps
         // Set the input query text globally for the page. There can be only one input query text submitted at a time even if multiple search box components are on the page
         GlobalSettings.setValue(BuiltinTokenNames.inputQueryText, searchQuery);
 
+        // Bump a page-wide submission id on every submit so connected Search Results always re-query,
+        // even when the query text is unchanged (issue #4790).
+        const submissionId = (GlobalSettings.getValue<number>(Constants.SEARCH_BOX_SUBMISSION_ID_KEY, 0) || 0) + 1;
+        GlobalSettings.setValue(Constants.SEARCH_BOX_SUBMISSION_ID_KEY, submissionId);
+
         this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchBox);
         this.context.dynamicDataSourceManager.notifySourceChanged();
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -44,7 +44,7 @@ import { LayoutHelper } from '../../helpers/LayoutHelper';
 import { IAsyncComboProps } from '../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps';
 import type { AsyncCombo as AsyncComboType } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
 import { Constants } from '../../common/Constants';
-import { GlobalSettings } from '@fluentui/react';
+import { GlobalSettings } from '@fluentui/react/lib/Utilities';
 import PnPTelemetry from "@pnp/telemetry-js";
 import { IPageEventInfo } from '../../components/PaginationComponent';
 import { IExtensibilityConfiguration } from '../../models/common/IExtensibilityConfiguration';

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -44,6 +44,7 @@ import { LayoutHelper } from '../../helpers/LayoutHelper';
 import { IAsyncComboProps } from '../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps';
 import type { AsyncCombo as AsyncComboType } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
 import { Constants } from '../../common/Constants';
+import { GlobalSettings } from '@fluentui/react';
 import PnPTelemetry from "@pnp/telemetry-js";
 import { IPageEventInfo } from '../../components/PaginationComponent';
 import { IExtensibilityConfiguration } from '../../models/common/IExtensibilityConfiguration';
@@ -510,6 +511,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 teamsContext: this.context.sdks.microsoftTeams ? this.context.sdks.microsoftTeams.context : null,
                 renderType: this.properties.layoutRenderType,
                 dataContext: this._currentDataContext,
+                lastSubmittedQueryId: GlobalSettings.getValue<number>(Constants.SEARCH_BOX_SUBMISSION_ID_KEY, 0),
                 themeVariant: this._themeVariant,
                 serviceScope: this.webPartInstanceServiceScope,
                 webPartTitleProps: {

--- a/search-parts/src/webparts/searchResults/components/ISearchResultsContainerProps.ts
+++ b/search-parts/src/webparts/searchResults/components/ISearchResultsContainerProps.ts
@@ -15,6 +15,12 @@ export interface ISearchResultsContainerProps {
   dataContext: IDataContext;
 
   /**
+   * A page-wide id that changes every time a connected Search Box submits (Enter or the Search
+   * button), even when the query text is unchanged. Lets the results re-query on re-submission (issue #4790).
+   */
+  lastSubmittedQueryId?: number;
+
+  /**
    * The current page context
    */
   pageContext: PageContext;

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -221,6 +221,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
 
         if (!isEqual(prevProps.dataSourceKey, this.props.dataSourceKey)
             || !isEqual(prevProps.dataContext, this.props.dataContext)
+            || prevProps.lastSubmittedQueryId !== this.props.lastSubmittedQueryId
             || !isEqual(prevProps.properties.dataSourceProperties, this.props.properties.dataSourceProperties)
             || !isEqual(prevProps.properties.templateSlots, this.props.properties.templateSlots)) {
 


### PR DESCRIPTION
## Issue

Fixes #4790

When a user submits the Search Box (Enter or the Search button) with **the same query text** as before, nothing happens — no new search/refresh is triggered. Users expect a re-submit to re-run the search (refresh data / paging), and since the button isn't disabled they assume a call is made.

@wobba approved changing the default behavior to always re-query on Enter/click (rather than adding an option), so this PR does that.

## Root cause

The publish side already fires on every submit (`SearchBoxWebPart._onSearch` always calls `notifyPropertyChanged` + `notifySourceChanged`). The dedupe is on the consumer: in `SearchResultsContainer.componentDidUpdate`, the guard
```ts
!isEqual(prevProps.dataContext, this.props.dataContext)
```
is `false` on a re-submit because the rebuilt `dataContext` is structurally identical (same `inputQueryText`, page, filters) — so `getDataFromDataSource()` is skipped.

## Fix

Carry a per-submit nonce so re-submits produce a detectable change, without weakening the existing guard (which still prevents needless re-fetches on unrelated re-renders):

- **SearchBox** (`_onSearch`) bumps a page-wide submission id in Fluent UI `GlobalSettings` on every submit (same store already used for `inputQueryText`). Key: `Constants.SEARCH_BOX_SUBMISSION_ID_KEY`.
- **SearchResults** passes that id to the container as a new optional prop `lastSubmittedQueryId`.
- **SearchResultsContainer.componentDidUpdate** adds `prevProps.lastSubmittedQueryId !== this.props.lastSubmittedQueryId` to the fetch condition.

The published `@pnp/modern-search-extensibility` `IDataContext` is **not** modified (the nonce is a local container prop), so no extensibility republish is required.

## Notes / testing

- Page-wide by design: a submit refreshes all connected Search Results web parts on the page (simple, predictable). Paging/filter reset logic is unchanged — a re-submit of the same text re-fetches the current page.
- `npm run build` (production) passes.
- ⚠️ Needs a quick browser smoke test (I can't run SPFx here): same query re-submit → results refetch; confirm paging, filters and verticals still behave.