### PR TITLE
<pnp-panel> doc fixes

### DIFF
--- a/docs/extensibility/web_components_list.md
+++ b/docs/extensibility/web_components_list.md
@@ -116,7 +116,8 @@ Here are the list of all **reusable** web components you can use to customize yo
 
 - **Usage**
 ```html
-<pnp-panel   
+<pnp-panel
+    data-theme-variant='{{JSONstringify @root.theme}}'   
     data-is-open="false" 
     data-is-light-dismiss="true"
     data-is-blocking="true"

--- a/docs/scenarios/more-info-panel-with-pnp-panel.md
+++ b/docs/scenarios/more-info-panel-with-pnp-panel.md
@@ -49,7 +49,8 @@ Under **Layouts → Columns**, add a new column at the end of your existing colu
 Paste the following as the column value:
 
 ```html
-<pnp-panel   
+<pnp-panel
+    data-theme-variant='{{JSONstringify @root.theme}}' 
     data-is-open="false" 
     data-is-light-dismiss="true"
     data-is-blocking="true"


### PR DESCRIPTION
Since testing/using the latest release and building the latest develop branch sppkg -  I have been unable to get pnp-panel to load. I click on the icon/link and nothing happens. I have found I need to add data-theme-variant='{{JSONstringify @root.theme}}' to the pnp-panel and it loads instantly.

This pull request makes a small update to the documentation for the `pnp-panel` web component. The main change is the addition of the `data-theme-variant` attribute to the usage examples, which helps ensure the component uses the correct theme variant.

- Documentation updates to usage examples:
  * Added the `data-theme-variant='{{JSONstringify @root.theme}}'` attribute to the `pnp-panel` example in `web_components_list.md` to demonstrate how to pass the theme variant.
  * Added the `data-theme-variant='{{JSONstringify @root.theme}}'` attribute to the `pnp-panel` example in `more-info-panel-with-pnp-panel.md` for consistency and improved theming guidance.