### PR TITLE
feat(filters): add people template bad-mapping warning (issue #4839)

### DIFF
--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -135,7 +135,7 @@
 							</pnp-filtercombobox>
 						</div>
 				{{else}}
-					<pnp-collapsible data-group-name="{{filter.displayName}}" data-show-warning-marker="{{filter.showLimitExceededWarning}}" data-warning-marker-tooltip="{{filter.limitExceededWarningText}}" data-default-collapsed="{{#or hasSelectedValues expandByDefault selectedOnce}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
+					<pnp-collapsible data-group-name="{{filter.displayName}}" data-group-storage-key="{{@root.instanceId}}::{{filter.filterName}}" data-show-warning-marker="{{filter.showWarningMarker}}" data-warning-marker-tooltip="{{filter.warningMarkerTooltipText}}" data-default-collapsed="{{#or filter.hasSelectedValues filter.expandByDefault}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
 							
 						<template id="collapsible-header">
 						</template>
@@ -194,44 +194,47 @@
 									</div>
 								{{else}}
 									{{#eq filter.selectedTemplate 'PeopleTemplate'}}
-											{{#if filter.isMulti}}
-												<div class="filter--option">
-													<pnp-filteroperator 
-														data-instance-id="{{@root.instanceId}}"
-														data-filter-name="{{filter.filterName}}" 
-														data-operator="{{filter.operator}}" 
-														data-theme-variant="{{JSONstringify @root.theme}}"
-													></pnp-filteroperator>
-												</div>
-											{{/if}}
+									{{#if filter.showPeopleTemplateMappingWarning}}
+										<div class="filter--message">{{filter.peopleTemplateMappingWarningText}}</div>
+									{{/if}}
+									{{#if filter.isMulti}}
+										<div class="filter--option">
+											<pnp-filteroperator 
+												data-instance-id="{{@root.instanceId}}"
+												data-filter-name="{{filter.filterName}}" 
+												data-operator="{{filter.operator}}" 
+												data-theme-variant="{{JSONstringify @root.theme}}"
+											></pnp-filteroperator>
+										</div>
+									{{/if}}
 								
-											<div class="filter--option">
-												<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
-											</div>
+									<div class="filter--option">
+										<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
+									</div>
 
-							<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
-												{{#each filter.values}}
-													<div title="{{#with (split name '|')}}{{[1]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
-														<pnp-filtercheckbox 
-															data-instance-id="{{@root.instanceId}}" 
-															data-filter-name="{{filter.filterName}}" 
-															data-name= "{{#with (split name '|')}}{{[1]}}{{/with}}" 
-															data-value="{{value}}" 
-															data-selected="{{selected}}" 
-															data-disabled="{{disabled}}" 
-															data-count="{{count}}"
-															data-is-multi="{{../isMulti}}"
-															data-value-count="{{../values.length}}"
-															data-value-index="{{@index}}"
-															data-theme-variant="{{JSONstringify @root.theme}}"
-														>
-														</pnp-filtercheckbox>
-														{{#if ../showCount}}
-															<span data-ui-test-id="filterCount">({{count}})</span>
-														{{/if}}
-													</div>
-												{{/each}}
-											</div>				
+									<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
+										{{#each filter.values}}
+												<div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
+													<pnp-filtercheckbox 
+														data-instance-id="{{@root.instanceId}}" 
+														data-filter-name="{{filter.filterName}}" 
+														data-name="{{name}}" 
+														data-value="{{value}}" 
+														data-selected="{{selected}}" 
+														data-disabled="{{disabled}}" 
+														data-count="{{count}}"
+														data-is-multi="{{../isMulti}}"
+														data-value-count="{{../values.length}}"
+														data-value-index="{{@index}}"
+														data-theme-variant="{{JSONstringify @root.theme}}"
+													>
+													</pnp-filtercheckbox>
+													{{#if ../showCount}}
+														<span data-ui-test-id="filterCount">({{count}})</span>
+													{{/if}}
+												</div>
+										{{/each}}
+									</div>				
 									{{else}}
 
 										{{#eq filter.selectedTemplate 'DateIntervalFilterTemplate'}}

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -97,8 +97,14 @@
             padding: 5px;
         }
 
-        .panelOpenBar span {
+        .panelOpenBar button {
             margin-left: 3px;
+            border: 0;
+            padding: 0;
+            background: transparent;
+            color: inherit;
+            font: inherit;
+            cursor: pointer;
         }
 
         .panelOpenBar:hover {
@@ -128,7 +134,7 @@
 
             <template id="panel-open">
                 <div class="panelOpenBar">
-                    <pnp-icon data-name="Filter" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon><span role="button" tabindex="0" aria-label="{{@root.properties.layoutProperties.btnLabel}}">{{@root.properties.layoutProperties.btnLabel}}</span>
+                    <pnp-icon data-name="Filter" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-icon><button type="button" aria-label="{{@root.properties.layoutProperties.btnLabel}}">{{@root.properties.layoutProperties.btnLabel}}</button>
                 </div>
             </template>
 
@@ -154,7 +160,7 @@
                                             </pnp-filtercombobox>
                                         </div>
                                 {{else}}
-                                    <pnp-collapsible data-group-name="{{filter.displayName}}" data-show-warning-marker="{{filter.showLimitExceededWarning}}" data-warning-marker-tooltip="{{filter.limitExceededWarningText}}" data-default-collapsed="{{#or hasSelectedValues expandByDefault selectedOnce}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
+                                    <pnp-collapsible data-group-name="{{filter.displayName}}" data-group-storage-key="{{@root.instanceId}}::{{filter.filterName}}" data-show-warning-marker="{{filter.showWarningMarker}}" data-warning-marker-tooltip="{{filter.warningMarkerTooltipText}}" data-default-collapsed="{{#or filter.hasSelectedValues filter.expandByDefault}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
                                             
                                         <template id="collapsible-content" item-class="filter--value">
                 
@@ -210,6 +216,9 @@
                                                     </div>
                                                 {{else}}
                                                     {{#eq filter.selectedTemplate 'PeopleTemplate'}}
+                                                        {{#if filter.showPeopleTemplateMappingWarning}}
+                                                            <div class="filter--message">{{filter.peopleTemplateMappingWarningText}}</div>
+                                                        {{/if}}
                                                         {{#if filter.isMulti}}
                                                             <div class="filter--option">
                                                                 <pnp-filteroperator 
@@ -227,47 +236,25 @@
 
                                                         <div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
                                                             {{#each filter.values}}
-                                                                {{#eq (itemAt (split name "|") 1) "membership"}}
-                                                                    <div title="{{#with (split name '|')}}{{[2]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
-                                                                        <pnp-filtercheckbox 
-                                                                            data-instance-id="{{@root.instanceId}}" 
-                                                                            data-filter-name="{{filter.filterName}}" 
-                                                                            data-name= "{{#with (split name '|')}}{{[2]}}{{/with}}" 
-                                                                            data-value="{{value}}" 
-                                                                            data-selected="{{selected}}" 
-                                                                            data-disabled="{{disabled}}" 
-                                                                            data-count="{{count}}"
-                                                                            data-is-multi="{{../isMulti}}"
-                                                                            data-value-count="{{../values.length}}"
-                                                                            data-value-index="{{@index}}"
-                                                                            data-theme-variant="{{JSONstringify @root.theme}}"
-                                                                        >
-                                                                        </pnp-filtercheckbox>
-                                                                        {{#if ../showCount}}
-                                                                            <span data-ui-test-id="filterCount">({{count}})</span>
-                                                                        {{/if}}
-                                                                    </div>
-                                                                {{else}}
-                                                                    <div title="{{#with (split name '|')}}{{[1]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
-                                                                        <pnp-filtercheckbox 
-                                                                            data-instance-id="{{@root.instanceId}}" 
-                                                                            data-filter-name="{{filter.filterName}}" 
-                                                                            data-name= "{{#with (split name '|')}}{{[1]}}{{/with}}" 
-                                                                            data-value="{{value}}" 
-                                                                            data-selected="{{selected}}" 
-                                                                            data-disabled="{{disabled}}" 
-                                                                            data-count="{{count}}"
-                                                                            data-is-multi="{{../isMulti}}"
-                                                                            data-value-count="{{../values.length}}"
-                                                                            data-value-index="{{@index}}"
-                                                                            data-theme-variant="{{JSONstringify @root.theme}}"
-                                                                        >
-                                                                        </pnp-filtercheckbox>
-                                                                        {{#if ../showCount}}
-                                                                            <span data-ui-test-id="filterCount">({{count}})</span>
-                                                                        {{/if}}
-                                                                    </div>
-                                                                {{/eq}}
+                                                                <div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
+                                                                    <pnp-filtercheckbox 
+                                                                        data-instance-id="{{@root.instanceId}}" 
+                                                                        data-filter-name="{{filter.filterName}}" 
+                                                                        data-name="{{name}}" 
+                                                                        data-value="{{value}}" 
+                                                                        data-selected="{{selected}}" 
+                                                                        data-disabled="{{disabled}}" 
+                                                                        data-count="{{count}}"
+                                                                        data-is-multi="{{../isMulti}}"
+                                                                        data-value-count="{{../values.length}}"
+                                                                        data-value-index="{{@index}}"
+                                                                        data-theme-variant="{{JSONstringify @root.theme}}"
+                                                                    >
+                                                                    </pnp-filtercheckbox>
+                                                                    {{#if ../showCount}}
+                                                                        <span data-ui-test-id="filterCount">({{count}})</span>
+                                                                    {{/if}}
+                                                                </div>
                                                             {{/each}}
                                                         </div>
                                                     {{else}}

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -24,9 +24,6 @@
 		}
 		
 	    .filter--name {
-			font-family: {{@root.theme.fonts.large.fontFamily}};
-			font-weight: {{@root.theme.fonts.large.fontWeight}};
-			font-size: {{@root.theme.fonts.large.fontSize}};
 			margin-bottom: 5px;
 		}
 
@@ -115,7 +112,7 @@
 							</pnp-filtercombobox>
 						</div>
 				{{else}}
-					<pnp-collapsible data-group-name="{{filter.displayName}}" data-show-warning-marker="{{filter.showLimitExceededWarning}}" data-warning-marker-tooltip="{{filter.limitExceededWarningText}}" data-default-collapsed="{{#or hasSelectedValues expandByDefault selectedOnce}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
+					<pnp-collapsible data-group-name="{{filter.displayName}}" data-group-storage-key="{{@root.instanceId}}::{{filter.filterName}}" data-show-warning-marker="{{filter.showWarningMarker}}" data-warning-marker-tooltip="{{filter.warningMarkerTooltipText}}" data-default-collapsed="{{#or filter.hasSelectedValues filter.expandByDefault}}false{{else}}true{{/or}}" data-theme-variant="{{JSONstringify @root.theme}}">
 						
 						<template id="collapsible-header">
 														
@@ -173,6 +170,9 @@
 									</div>
 								{{else}}
 									{{#eq filter.selectedTemplate 'PeopleTemplate'}}
+										{{#if filter.showPeopleTemplateMappingWarning}}
+											<div class="filter--message">{{filter.peopleTemplateMappingWarningText}}</div>
+										{{/if}}
 										{{#if filter.isMulti}}
 											<div class="filter--option">
 												<pnp-filteroperator 
@@ -183,61 +183,33 @@
 												></pnp-filteroperator>
 											</div>
 										{{/if}}
-							
+						
 										<div class="filter--option">
 											<pnp-filtersearchbox data-filter="{{JSONstringify filter}}" data-instance-id="{{@root.instanceId}}" data-theme-variant="{{JSONstringify @root.theme}}"></pnp-filtersearchbox>
 										</div>
 
 										<div class="filter--values-list" role="{{#if filter.isMulti}}group{{else}}radiogroup{{/if}}" aria-label="{{filter.displayName}}">
 											{{#each filter.values}}
-											
-											<!-- From localSharePointResults: Admin@tcwlv.onmicrosoft.com | Kasper Larsen | 693A30232E667C6D656D626572736869707C61646D696E407463776C762E6F6E6D6963726F736F66742E636F6D i:0#.f|membership|admin@tcwlv.onmicrosoft.com -->
-											<!-- From localPeopleResults: i:0#.f|membership|pattif@tcwlv.onmicrosoft.com -->
-										   
-												<!-- <div title="{{#with (split name '|')}}{{[1]}}({{[0]}}){{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value"> -->
-													
-													{{#eq (itemAt (split name "|") 1) "membership"}} <!-- this must be from localPeopleResults -->
-														<div title="{{#with (split name '|')}}{{[2]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
-														<pnp-filtercheckbox 
-															data-instance-id="{{@root.instanceId}}" 
-															data-filter-name="{{filter.filterName}}" 
-															data-name= "{{#with (split name '|')}}{{[2]}}{{/with}}" 
-															data-value="{{value}}" 
-															data-selected="{{selected}}" 
-															data-disabled="{{disabled}}" 
-															data-count="{{count}}"
-															data-is-multi="{{../isMulti}}"
-															data-value-count="{{../values.length}}"
-															data-value-index="{{@index}}"
-															data-theme-variant="{{JSONstringify @root.theme}}"
-														>
-														</pnp-filtercheckbox>
-														{{#if ../showCount}}
-															<span data-ui-test-id="filterCount">({{count}})</span>
-														{{/if}}
+
+														<div title="{{name}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
+															<pnp-filtercheckbox 
+																data-instance-id="{{@root.instanceId}}" 
+																data-filter-name="{{filter.filterName}}" 
+																data-name="{{name}}" 
+																data-value="{{value}}" 
+																data-selected="{{selected}}" 
+																data-disabled="{{disabled}}" 
+																data-count="{{count}}"
+																data-is-multi="{{../isMulti}}"
+																data-value-count="{{../values.length}}"
+																data-value-index="{{@index}}"
+																data-theme-variant="{{JSONstringify @root.theme}}"
+															>
+															</pnp-filtercheckbox>
+															{{#if ../showCount}}
+																<span data-ui-test-id="filterCount">({{count}})</span>
+															{{/if}}
 														</div>
-													{{else}}
-													<div title="{{#with (split name '|')}}{{[1]}}{{/with}} {{#if ../showCount}}({{count}}){{/if}}" class="filter--value">
-														<pnp-filtercheckbox 
-															data-instance-id="{{@root.instanceId}}" 
-															data-filter-name="{{filter.filterName}}" 
-															data-name= "{{#with (split name '|')}}{{[1]}}{{/with}}" 
-															data-value="{{value}}" 
-															data-selected="{{selected}}" 
-															data-disabled="{{disabled}}" 
-															data-count="{{count}}"
-															data-is-multi="{{../isMulti}}"
-															data-value-count="{{../values.length}}"
-															data-value-index="{{@index}}"
-															data-theme-variant="{{JSONstringify @root.theme}}"
-														>
-														</pnp-filtercheckbox>
-														{{#if ../showCount}}
-															<span data-ui-test-id="filterCount">({{count}})</span>
-														{{/if}}
-														</div>
-													{{/eq}}
-													
 
 													
 											{{/each}}

--- a/search-parts/src/webparts/searchFilters/components/ISearchFiltersContainerState.ts
+++ b/search-parts/src/webparts/searchFilters/components/ISearchFiltersContainerState.ts
@@ -11,4 +11,14 @@ export interface ISearchFiltersContainerState {
      * Filters submitted to the data source
      */
     submittedFilters: IDataFilter[];
+
+    /**
+     * Indicates whether filter updates are currently being processed.
+     */
+    isUpdatingResults?: boolean;
+
+    /**
+     * The filter currently driving busy state feedback.
+     */
+    activeBusyFilterName?: string;
 }

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ISearchFiltersContainerProps } from './ISearchFiltersContainerProps';
 import { TemplateRenderer } from '../../../controls/TemplateRenderer/TemplateRenderer';
 import { ISearchFiltersContainerState } from './ISearchFiltersContainerState';
-import { isEqual, cloneDeep, sortBy } from '@microsoft/sp-lodash-subset';
+import { isEqual, cloneDeep, sortBy, flatten } from '@microsoft/sp-lodash-subset';
 import { StyledWebPartTitle } from '../../../components/StyledWebPartTitle';
 import * as webPartStrings from 'SearchFiltersWebPartStrings';
 import * as commonStrings from 'CommonStrings';
@@ -10,6 +10,7 @@ import update from 'immutability-helper';
 import {
     IDataFilterInternal,
     IDataFilterValueInternal,
+    IDataFilterValueInfo,
     IDataFilterConfiguration,
     IDataFilterResult,
     IDataFilterResultValue,
@@ -21,7 +22,6 @@ import {
     LayoutRenderType
 } from '@pnp/modern-search-extensibility';
 import { ISearchFiltersTemplateContext } from '../../../models/common/ITemplateContext';
-import { flatten } from '@microsoft/sp-lodash-subset';
 import { DisplayMode, Log } from '@microsoft/sp-core-library';
 import { DataFilterHelper } from '../../../helpers/DataFilterHelper';
 import { TaxonomyHelper } from '../../../helpers/TaxonomyHelper';
@@ -47,8 +47,12 @@ interface IFilterResultWithLimitInfo extends IDataFilterResult {
 }
 
 interface IFilterInternalWithWarning extends IDataFilterInternal {
+    showWarningMarker?: boolean;
     showLimitExceededWarning?: boolean;
     limitExceededWarningText?: string;
+    showPeopleTemplateMappingWarning?: boolean;
+    peopleTemplateMappingWarningText?: string;
+    warningMarkerTooltipText?: string;
 }
 
 interface IHierarchicalTerm {
@@ -60,16 +64,45 @@ interface IHierarchicalTerm {
     children: IHierarchicalTerm[];
 }
 
+interface IUpdateDebugContext {
+    eventId: number;
+    source: string;
+    filterName: string;
+    startedAt: number;
+    lastMarkAt: number;
+}
+
 export default class SearchFiltersContainer extends React.Component<ISearchFiltersContainerProps, ISearchFiltersContainerState> {
 
-    private componentRef: React.RefObject<any>;
+    private readonly componentRef: React.RefObject<any>;
 
     /**
      * The URL query parameter name for this specific web part instance
      */
-    private deeplinkQueryStringParam: string;
+    private readonly deeplinkQueryStringParam: string;
     private _isUpdatingDeepLink: boolean = false;
     private _lastProcessedDeepLink: string = '';
+    private _nextUpdateDebugEventId: number = 0;
+    private _skipNextUiRefreshFromLocalSelection: boolean = false;
+    private readonly _enableUpdateDebugLogging: boolean = false;
+    private readonly _peopleDisplayNameByValue: Map<string, string> = new Map<string, string>();
+    private readonly _peopleDisplayNameByName: Map<string, string> = new Map<string, string>();
+    private readonly _resolvedDisplayNameCache: Map<string, string> = new Map<string, string>();
+    private readonly _hierarchyCacheByFilterKey: Map<string, IHierarchicalTerm[]> = new Map<string, IHierarchicalTerm[]>();
+    private readonly _prunedHierarchyCacheBySelectionKey: Map<string, IHierarchicalTerm[]> = new Map<string, IHierarchicalTerm[]>();
+    private _deferredSubmittedUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+    private _busyHideTimer: ReturnType<typeof setTimeout> | null = null;
+    private _busyWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+    private _busyPrimeTimer: ReturnType<typeof setTimeout> | null = null;
+    private _busyStartedAt: number = 0;
+    private _latestDeferredSubmittedFilters: IDataFilter[] | null = null;
+    private static readonly _DISPLAY_NAME_CACHE_LIMIT = 5000;
+    private static readonly _HIERARCHY_CACHE_LIMIT = 64;
+    private static readonly _PRUNED_HIERARCHY_CACHE_LIMIT = 256;
+    private static readonly _MIN_BUSY_VISIBLE_MS = 2000;
+    private static readonly _MAX_BUSY_DURATION_MS = 10000;
+    private static readonly _BUSY_PRIME_TIMEOUT_MS = 1500;
+    private static readonly _GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
 
     public constructor(props: ISearchFiltersContainerProps) {
 
@@ -80,26 +113,27 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
         this.state = {
             currentUiFilters: [],
-            submittedFilters: []
+            submittedFilters: [],
+            isUpdatingResults: false,
+            activeBusyFilterName: undefined
         };
 
         this.componentRef = React.createRef();
-
-        this.onFilterValuesUpdated = this.onFilterValuesUpdated.bind(this);
     }
 
-    private buildHierarchy = (allTerms: any[]): IHierarchicalTerm[] => {
+    private readonly buildHierarchy = (allTerms: any[]): IHierarchicalTerm[] => {
         const termMap = new Map<string, IHierarchicalTerm>();
         const rootTerms: IHierarchicalTerm[] = [];
 
         allTerms.forEach(term => {
             const path = term.PathOfTerm || term.Name;
+            const rawTermLabel = term.Labels?._Child_Items_?.length > 0
+                ? term.Labels._Child_Items_[0].Value
+                : term.Name;
             const termObj: IHierarchicalTerm = {
                 id: term.Id,
                 name: term.Name,
-                label: term.Labels && term.Labels._Child_Items_ && term.Labels._Child_Items_.length > 0
-                    ? term.Labels._Child_Items_[0].Value
-                    : term.Name,
+                label: this.resolveFilterDisplayName(rawTermLabel, term.Name),
                 parentId: term.ParentId,
                 pathOfTerm: path,
                 children: []
@@ -127,7 +161,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return rootTerms;
     }
 
-    private pruneHierarchy = (terms: IHierarchicalTerm[], resultGuids: Set<string>, selectedGuids: Set<string>): IHierarchicalTerm[] => {
+    private readonly pruneHierarchy = (terms: IHierarchicalTerm[], resultGuids: Set<string>, selectedGuids: Set<string>): IHierarchicalTerm[] => {
         return terms.reduce((visibleTerms: IHierarchicalTerm[], term) => {
             const children = this.pruneHierarchy(term.children || [], resultGuids, selectedGuids);
             const termGuid = TaxonomyHelper.normalizeGuid(TaxonomyHelper.extractGuidFromTermId(term.id));
@@ -144,7 +178,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }, []);
     }
 
-    private buildGuidSetFromFilterValues = (filterValues: Array<{ value: string }>): Set<string> => {
+    private readonly buildGuidSetFromFilterValues = (filterValues: Array<{ value: string }>): Set<string> => {
         const guidSet = new Set<string>();
 
         (filterValues || []).forEach(filterValue => {
@@ -158,13 +192,354 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return guidSet;
     }
 
-    private areFilterValuesEquivalent = (leftValue: string, rightValue: string): boolean => {
+    private extractReadableLabelFromString(value: string): string {
+        const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
+        if (taxonomyLabelMatch?.[1]?.trim()) {
+            return taxonomyLabelMatch[1].trim();
+        }
+
+        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
+        if (genericGuidLabelMatch?.[1]?.trim()) {
+            return genericGuidLabelMatch[1].trim();
+        }
+
+        const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
+        if (claimsLabelMatch?.[1]?.trim()) {
+            return claimsLabelMatch[1].trim();
+        }
+
+        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
+        if (personLikeLabelMatch?.[1]?.trim()) {
+            return personLikeLabelMatch[1].trim();
+        }
+
+        const emailMatch = /([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/.exec(cleanedValue);
+        if (emailMatch?.[1]) {
+            return emailMatch[1];
+        }
+
+        const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
+        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
+        if (firstReadablePart) {
+            return firstReadablePart;
+        }
+
+        return '';
+    }
+
+    private normalizeDisplayCacheKey(value: string): string {
+        return `${value ?? ''}`.trim().toLowerCase();
+    }
+
+    private setDisplayNameCacheEntry(cache: Map<string, string>, key: string, label: string): void {
+        if (!key || !label) {
+            return;
+        }
+
+        if (cache.size >= SearchFiltersContainer._DISPLAY_NAME_CACHE_LIMIT) {
+            cache.clear();
+        }
+
+        cache.set(key, label);
+    }
+
+    private setLimitedCacheEntry<T>(cache: Map<string, T>, key: string, value: T, limit: number): void {
+        if (!key) {
+            return;
+        }
+
+        if (cache.size >= limit) {
+            cache.clear();
+        }
+
+        cache.set(key, value);
+    }
+
+    private getHierarchyCacheKey(filterName: string, termSetId: string, termGroupId: string): string {
+        return `${filterName}::${termSetId}::${termGroupId}`;
+    }
+
+    private getGuidSetSignature(guidSet: Set<string>): string {
+        return Array.from(guidSet.values()).sort((left, right) => left.localeCompare(right)).join(',');
+    }
+
+    private queueDeferredSubmittedFiltersUpdate(submittedFilters: IDataFilter[], sourceFilterName?: string): void {
+        this._latestDeferredSubmittedFilters = submittedFilters;
+
+        this.beginResultsUpdate(sourceFilterName);
+
+        if (this._deferredSubmittedUpdateTimer) {
+            clearTimeout(this._deferredSubmittedUpdateTimer);
+        }
+
+        this._deferredSubmittedUpdateTimer = setTimeout(() => {
+            const filtersToUpdate = this._latestDeferredSubmittedFilters;
+
+            this._deferredSubmittedUpdateTimer = null;
+            this._latestDeferredSubmittedFilters = null;
+
+            if (!filtersToUpdate) {
+                return;
+            }
+
+            this.props.onUpdateFilters(filtersToUpdate);
+            this.setFiltersDeepLink(filtersToUpdate);
+        }, 0);
+    }
+
+    private beginResultsUpdate(sourceFilterName?: string, onReady?: () => void): void {
+        if (this._busyHideTimer) {
+            clearTimeout(this._busyHideTimer);
+            this._busyHideTimer = null;
+        }
+
+        if (this._busyWatchdogTimer) {
+            clearTimeout(this._busyWatchdogTimer);
+            this._busyWatchdogTimer = null;
+        }
+
+        if (this._busyPrimeTimer) {
+            clearTimeout(this._busyPrimeTimer);
+            this._busyPrimeTimer = null;
+        }
+
+        this._busyStartedAt = performance.now();
+        this.setBusyCursor(true);
+
+        this._busyWatchdogTimer = setTimeout(() => {
+            this._busyWatchdogTimer = null;
+
+            if (this.state.isUpdatingResults) {
+                this.endResultsUpdate();
+            }
+        }, SearchFiltersContainer._MAX_BUSY_DURATION_MS);
+
+        this.setState(prevState => ({
+            isUpdatingResults: true,
+            activeBusyFilterName: sourceFilterName || prevState.activeBusyFilterName
+        }), () => {
+            if (!onReady) {
+                return;
+            }
+
+            if (typeof globalThis.requestAnimationFrame === 'function') {
+                globalThis.requestAnimationFrame(() => onReady());
+                return;
+            }
+
+            setTimeout(() => onReady(), 0);
+        });
+    }
+
+    private setBusyCursor(isBusy: boolean): void {
+        if (this.componentRef?.current) {
+            this.componentRef.current.style.cursor = isBusy ? 'progress' : '';
+        }
+
+        if (globalThis?.document?.documentElement) {
+            if (isBusy) {
+                globalThis.document.documentElement.style.setProperty('cursor', 'progress', 'important');
+            } else {
+                globalThis.document.documentElement.style.removeProperty('cursor');
+            }
+        }
+
+        if (globalThis?.document?.body) {
+            if (isBusy) {
+                globalThis.document.body.style.setProperty('cursor', 'progress', 'important');
+            } else {
+                globalThis.document.body.style.removeProperty('cursor');
+            }
+        }
+
+        this.setGlobalBusyCursorStyle(isBusy);
+    }
+
+    private setGlobalBusyCursorStyle(isBusy: boolean): void {
+        if (!globalThis?.document) {
+            return;
+        }
+
+        const styleId = SearchFiltersContainer._GLOBAL_BUSY_CURSOR_STYLE_ID;
+        const existingStyle = globalThis.document.getElementById(styleId);
+
+        if (isBusy) {
+            if (existingStyle) {
+                return;
+            }
+
+            const styleElement = globalThis.document.createElement('style');
+            styleElement.id = styleId;
+            styleElement.textContent = '* { cursor: progress !important; }';
+            globalThis.document.head.appendChild(styleElement);
+            return;
+        }
+
+        if (existingStyle) {
+            existingStyle.remove();
+        }
+    }
+
+    private shouldPrimeBusyCursorFromInteraction(target: EventTarget | null): boolean {
+        if (!(target instanceof Element)) {
+            return false;
+        }
+
+        return !!target.closest('pnp-filtercheckbox, pnp-filtercombobox, pnp-filtersearchbox, pnp-filtermultiselect, pnp-filteroperator, pnp-filterdaterange, pnp-filterdateinterval, pnp-filterhierarchical');
+    }
+
+    private readonly primeBusyCursorFromInteraction = (event: React.PointerEvent<HTMLDivElement>): void => {
+        if (this.state.isUpdatingResults) {
+            return;
+        }
+
+        if (!this.shouldPrimeBusyCursorFromInteraction(event.target)) {
+            return;
+        }
+
+        this.setBusyCursor(true);
+
+        if (this._busyPrimeTimer) {
+            clearTimeout(this._busyPrimeTimer);
+        }
+
+        this._busyPrimeTimer = setTimeout(() => {
+            this._busyPrimeTimer = null;
+
+            if (!this.state.isUpdatingResults) {
+                this.setBusyCursor(false);
+            }
+        }, SearchFiltersContainer._BUSY_PRIME_TIMEOUT_MS);
+    }
+
+    private endResultsUpdate(): void {
+        const elapsed = performance.now() - this._busyStartedAt;
+        const remaining = SearchFiltersContainer._MIN_BUSY_VISIBLE_MS - elapsed;
+
+        if (this._busyHideTimer) {
+            clearTimeout(this._busyHideTimer);
+        }
+
+        if (this._busyWatchdogTimer) {
+            clearTimeout(this._busyWatchdogTimer);
+            this._busyWatchdogTimer = null;
+        }
+
+        this._busyHideTimer = setTimeout(() => {
+            this._busyHideTimer = null;
+            this.setBusyCursor(false);
+            this.setState({
+                isUpdatingResults: false,
+                activeBusyFilterName: undefined
+            });
+        }, Math.max(0, remaining));
+    }
+
+    private warmPeopleDisplayNameCache(name: string, value: string): void {
+        const resolvedLabel = this.resolveFilterDisplayName(name, value);
+        if (!resolvedLabel) {
+            return;
+        }
+
+        const normalizedValueKey = this.normalizeDisplayCacheKey(value);
+        const normalizedNameKey = this.normalizeDisplayCacheKey(name);
+
+        if (normalizedValueKey) {
+            this.setDisplayNameCacheEntry(this._peopleDisplayNameByValue, normalizedValueKey, resolvedLabel);
+        }
+
+        if (normalizedNameKey) {
+            this.setDisplayNameCacheEntry(this._peopleDisplayNameByName, normalizedNameKey, resolvedLabel);
+        }
+    }
+
+    private warmPeopleDisplayNameCacheFromValues(values: Array<{ name?: string; value?: string }>): void {
+        (values || []).forEach(item => {
+            this.warmPeopleDisplayNameCache(`${item?.name ?? ''}`, `${item?.value ?? ''}`);
+        });
+    }
+
+    private resolveFilterDisplayName(name: string, value: string): string {
+        const rawName = `${name ?? ''}`;
+        const rawValue = `${value ?? ''}`;
+        const cacheKey = `${this.normalizeDisplayCacheKey(rawName)}::${this.normalizeDisplayCacheKey(rawValue)}`;
+
+        const resolvedFromSharedCache = this._resolvedDisplayNameCache.get(cacheKey);
+        if (resolvedFromSharedCache) {
+            return resolvedFromSharedCache;
+        }
+
+        const resolvedFromPeopleValueCache = this._peopleDisplayNameByValue.get(this.normalizeDisplayCacheKey(rawValue));
+        if (resolvedFromPeopleValueCache) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, resolvedFromPeopleValueCache);
+            return resolvedFromPeopleValueCache;
+        }
+
+        const resolvedFromPeopleNameCache = this._peopleDisplayNameByName.get(this.normalizeDisplayCacheKey(rawName));
+        if (resolvedFromPeopleNameCache) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, resolvedFromPeopleNameCache);
+            return resolvedFromPeopleNameCache;
+        }
+
+        const readableRawName = this.extractReadableLabelFromString(rawName);
+        if (readableRawName) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableRawName);
+            return readableRawName;
+        }
+
+        const decodedName = TaxonomyHelper.decodeHexString(rawName);
+        const readableDecodedName = this.extractReadableLabelFromString(decodedName);
+        if (readableDecodedName) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableDecodedName);
+            return readableDecodedName;
+        }
+        if (decodedName) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, decodedName);
+            return decodedName;
+        }
+
+        const readableRawValue = this.extractReadableLabelFromString(rawValue);
+        if (readableRawValue) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableRawValue);
+            return readableRawValue;
+        }
+
+        const decodedValue = TaxonomyHelper.decodeHexString(rawValue);
+        const readableDecodedValue = this.extractReadableLabelFromString(decodedValue);
+        if (readableDecodedValue) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableDecodedValue);
+            return readableDecodedValue;
+        }
+        if (decodedValue) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, decodedValue);
+            return decodedValue;
+        }
+
+        const fallbackValue = rawName || rawValue;
+        this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, fallbackValue);
+        return fallbackValue;
+    }
+
+    private readonly areFilterValuesEquivalent = (leftValue: string, rightValue: string): boolean => {
         if (!leftValue || !rightValue) {
             return false;
         }
 
         if (leftValue === rightValue) {
             return true;
+        }
+
+        // Fast path: for regular string refiners (most cases), skip expensive taxonomy GUID extraction.
+        const isLeftTaxonomyLike = leftValue.includes('|#') || leftValue.includes('ǂǂ');
+        const isRightTaxonomyLike = rightValue.includes('|#') || rightValue.includes('ǂǂ');
+
+        if (!isLeftTaxonomyLike && !isRightTaxonomyLike) {
+            return false;
         }
 
         const leftGuids = TaxonomyHelper.extractGuidsFromFilterValue(leftValue);
@@ -183,19 +558,728 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }, template);
     }
 
-    private getFilterSignature(filters: Array<{ filterName: string; values?: Array<{ value?: string; selected?: boolean }> }>): string {
-        return (filters || [])
-            .map(filter => {
-                const selectedValues = (filter.values || [])
-                    .filter(value => value.selected)
-                    .map(value => value.value)
-                    .sort()
-                    .join(',');
+    private createUpdateDebugContext(filterName: string, source: string, startedAt?: number): IUpdateDebugContext {
+        const now = performance.now();
 
-                return `${filter.filterName}:${selectedValues}`;
-            })
-            .sort()
-            .join('|');
+        return {
+            eventId: ++this._nextUpdateDebugEventId,
+            source,
+            filterName,
+            startedAt: typeof startedAt === 'number' ? startedAt : now,
+            lastMarkAt: now
+        };
+    }
+
+    private logUpdateStep(debugContext: IUpdateDebugContext, step: string, details?: Record<string, unknown>): void {
+        const now = performance.now();
+
+        const logPayload: Record<string, unknown> = {
+            source: debugContext.source,
+            filterName: debugContext.filterName,
+            deltaMs: (now - debugContext.lastMarkAt).toFixed(1),
+            totalMs: (now - debugContext.startedAt).toFixed(1),
+            instanceId: this.props.instanceId
+        };
+
+        if (details) {
+            Object.assign(logPayload, details);
+        }
+
+        console.info(`[PnP Modern Search][Search Filters][Update ${debugContext.eventId}] ${step}`, {
+            ...logPayload
+        });
+
+        debugContext.lastMarkAt = now;
+    }
+
+    private getSelectedFilterUiContext(currentUiFilters: IDataFilterInternal[], availableFilter: IDataFilterResult, filterConfiguration: IHierarchicalFilterConfiguration): {
+        selectedFilterIdx: number;
+        selectedFilterValues: IDataFilterValueInternal[];
+        selectedValueIndexByRaw: Map<string, number>;
+    } {
+        const selectedFilterIdx = currentUiFilters.findIndex(selectedFilter => selectedFilter.filterName === availableFilter.filterName);
+        const selectedFilterValues = selectedFilterIdx === -1 ? [] : currentUiFilters[selectedFilterIdx].values;
+        const selectedValueIndexByRaw = new Map<string, number>();
+
+        if (filterConfiguration.selectedTemplate === BuiltinFilterTemplates.People) {
+            this.warmPeopleDisplayNameCacheFromValues(availableFilter.values);
+            this.warmPeopleDisplayNameCacheFromValues(selectedFilterValues);
+        }
+
+        selectedFilterValues.forEach((value, idx) => {
+            selectedValueIndexByRaw.set(`${value.value}`, idx);
+        });
+
+        return {
+            selectedFilterIdx,
+            selectedFilterValues,
+            selectedValueIndexByRaw
+        };
+    }
+
+    private getZeroResultValues(currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number, filterConfiguration: IHierarchicalFilterConfiguration): IDataFilterValueInternal[] {
+        if (selectedFilterIdx === -1) {
+            return [];
+        }
+
+        return currentUiFilters[selectedFilterIdx].values.map(value => {
+            if (((value.selected || value.selectedOnce) && filterConfiguration.isMulti) || (value.selected && !filterConfiguration.isMulti)) {
+                value.count = 0;
+                return value;
+            }
+
+            return null;
+        }).filter(Boolean);
+    }
+
+    private isTokenDisplayName(name?: string): boolean {
+        if (!name) {
+            return false;
+        }
+
+        return name.startsWith('GPP|#')
+            || name.startsWith('GP0|#')
+            || name.startsWith('L0|#')
+            || name.startsWith('#ǂ')
+            || name.startsWith('ǂ')
+            || (name.startsWith('"') && name.includes('ǂǂ'));
+    }
+
+    private isLikelySingleUserValue(rawValue: string): boolean {
+        const candidate = `${rawValue ?? ''}`.trim().replace(/^"+|"+$/g, '');
+        if (!candidate) {
+            return false;
+        }
+
+        // Multiple users packed into one value is a strong signal of an invalid People mapping.
+        if (candidate.includes(';')) {
+            return false;
+        }
+
+        if (/^i:0#.*\|[^|@\s]+@[^|@\s]+\.[^|@\s]+$/i.test(candidate)) {
+            return true;
+        }
+
+        const emailParts = candidate.split('@');
+        const hasEmailShape = emailParts.length === 2 && emailParts[0].length > 0 && emailParts[1].includes('.') && !candidate.includes(' ');
+        if (hasEmailShape) {
+            return true;
+        }
+
+        const displayNameParts = candidate.split(/\s+/).filter(Boolean);
+        if (displayNameParts.length >= 2) {
+            const allPartsLookLikeName = displayNameParts.every(part => {
+                const normalized = part.replace(/[.'’-]/g, '');
+                return normalized.length > 0 && /^[A-Za-zÀ-ÖØ-öø-ÿ]+$/.test(normalized);
+            });
+
+            if (allPartsLookLikeName) {
+                return true;
+            }
+        }
+
+        const readableLabel = this.extractReadableLabelFromString(candidate);
+        if (readableLabel && readableLabel !== candidate) {
+            return this.isLikelySingleUserValue(readableLabel);
+        }
+
+        return false;
+    }
+
+    private hasExplicitUserIdentitySignal(rawValue: string): boolean {
+        const candidate = `${rawValue ?? ''}`.trim().replace(/^"+|"+$/g, '');
+        if (!candidate) {
+            return false;
+        }
+
+        const decodedCandidate = TaxonomyHelper.decodeHexString(candidate) || candidate;
+        const normalizedCandidates = [candidate, decodedCandidate];
+
+        const hasSignal = (value: string): boolean => {
+            if (!value) {
+                return false;
+            }
+
+            if (/i:0#\.[^|]*\|membership\|/i.test(value)) {
+                return true;
+            }
+
+            if (/\|membership\|/i.test(value)) {
+                return true;
+            }
+
+            if (value.startsWith('i:0#')) {
+                return true;
+            }
+
+            if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/i.test(value)) {
+                return true;
+            }
+
+            if (/(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|/i.test(value)) {
+                return true;
+            }
+
+            if (/\|#0?[0-9a-f-]{32,36}\|/i.test(value)) {
+                return true;
+            }
+
+            return false;
+        };
+
+        if (normalizedCandidates.some(value => hasSignal(value))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private shouldShowPeopleTemplateMappingWarning(availableFilter: IDataFilterResult): boolean {
+        const values = availableFilter?.values ?? [];
+        if (values.length === 0) {
+            return false;
+        }
+
+        let suspiciousCount = 0;
+        let packedMultiValueCount = 0;
+        let explicitIdentityCount = 0;
+        let plainDisplayNameCount = 0;
+        let nonIdentityCount = 0;
+
+        values.forEach(value => {
+            const rawName = `${value?.name ?? ''}`;
+            const rawValue = `${value?.value ?? ''}`;
+            const hasPackedMultiValue = rawName.includes(';') || rawValue.includes(';');
+
+            if (hasPackedMultiValue) {
+                packedMultiValueCount++;
+                suspiciousCount++;
+                return;
+            }
+
+            const hasExplicitIdentitySignal = this.hasExplicitUserIdentitySignal(rawName) || this.hasExplicitUserIdentitySignal(rawValue);
+            if (hasExplicitIdentitySignal) {
+                explicitIdentityCount++;
+                return;
+            }
+
+            nonIdentityCount++;
+
+            const looksLikeUser = this.isLikelySingleUserValue(rawName) || this.isLikelySingleUserValue(rawValue);
+            if (looksLikeUser) {
+                plainDisplayNameCount++;
+                return;
+            }
+
+            if (!looksLikeUser) {
+                suspiciousCount++;
+            }
+        });
+
+        if (packedMultiValueCount > 0) {
+            return true;
+        }
+
+        // If values look like plain person names but there are no identity-like tokens at all,
+        // this is typically a display-name-only mapping instead of a Q_USER mapping.
+        if (plainDisplayNameCount > 0 && explicitIdentityCount === 0) {
+            return true;
+        }
+
+        // Any meaningful amount of non-identity values in a People template indicates mapping
+        // away from Q_USER semantics.
+        const nonIdentityThreshold = Math.max(1, Math.ceil(values.length * 0.2));
+        if (nonIdentityCount >= nonIdentityThreshold) {
+            return true;
+        }
+
+        // Mixed datasets can contain a few identity-like values. Still warn when the dominant
+        // shape clearly looks like plain display names.
+        const valueCount = values.length;
+        const mostlyPlainDisplayNames = plainDisplayNameCount >= Math.max(3, Math.ceil(valueCount * 0.6));
+        const identitySignalsAreMinority = explicitIdentityCount <= Math.floor(valueCount * 0.2);
+
+        if (mostlyPlainDisplayNames && identitySignalsAreMinority) {
+            return true;
+        }
+
+        return suspiciousCount >= Math.ceil(values.length / 2);
+    }
+
+    private getMatchingSelectedValueIndex(availableRawValue: string, selectedValueIndexByRaw: Map<string, number>, selectedFilterValues: IDataFilterValueInternal[]): number {
+        const directValueIdx = selectedValueIndexByRaw.get(availableRawValue);
+        if (directValueIdx !== undefined) {
+            return directValueIdx;
+        }
+
+        const needsTaxonomyFallback = availableRawValue.includes('|#') || availableRawValue.includes('ǂǂ');
+        if (!needsTaxonomyFallback) {
+            return -1;
+        }
+
+        return selectedFilterValues.findIndex(value => this.areFilterValuesEquivalent(`${value.value ?? ''}`, availableRawValue));
+    }
+
+    private mergeAvailableValueWithSelection(availableValue: IDataFilterResultValue, selectedFilterValues: IDataFilterValueInternal[], selectedValueIndexByRaw: Map<string, number>): IDataFilterValueInternal {
+        const filterValueInternal: IDataFilterValueInternal = {
+            name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`),
+            selected: false,
+            selectedOnce: false,
+            disabled: false,
+            value: availableValue.value,
+            count: availableValue.count
+        };
+
+        const valueIdx = this.getMatchingSelectedValueIndex(`${availableValue.value}`, selectedValueIndexByRaw, selectedFilterValues);
+        if (valueIdx === -1) {
+            return filterValueInternal;
+        }
+
+        const updatedValue = selectedFilterValues[valueIdx];
+        updatedValue.count = availableValue.count;
+
+        const resolvedAvailableName = this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`);
+        const currentNameIsToken = this.isTokenDisplayName(updatedValue.name);
+        const availableNameIsToken = this.isTokenDisplayName(availableValue.name);
+
+        if (currentNameIsToken && !availableNameIsToken) {
+            updatedValue.name = resolvedAvailableName || updatedValue.name || `${availableValue.value}`;
+        } else if (!currentNameIsToken && availableNameIsToken) {
+            // Keep current readable label.
+        } else {
+            updatedValue.name = resolvedAvailableName || updatedValue.name || `${availableValue.value}`;
+        }
+
+        return updatedValue;
+    }
+
+    private buildDisplayValues(availableFilter: IDataFilterResult, currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number, selectedFilterValues: IDataFilterValueInternal[], selectedValueIndexByRaw: Map<string, number>, filterConfiguration: IHierarchicalFilterConfiguration): IDataFilterValueInternal[] {
+        if (availableFilter.values.length === 0) {
+            return this.getZeroResultValues(currentUiFilters, selectedFilterIdx, filterConfiguration);
+        }
+
+        return availableFilter.values.map(availableValue => {
+            if (selectedFilterIdx === -1) {
+                return {
+                    name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`),
+                    selected: false,
+                    selectedOnce: false,
+                    disabled: false,
+                    value: availableValue.value,
+                    count: availableValue.count
+                };
+            }
+
+            return this.mergeAvailableValueWithSelection(availableValue, selectedFilterValues, selectedValueIndexByRaw);
+        });
+    }
+
+    private appendAdditionalSelectedValues(values: IDataFilterValueInternal[], currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number): IDataFilterValueInternal[] {
+        if (selectedFilterIdx === -1) {
+            return values;
+        }
+
+        const currentValueRawSet = new Set(values.map(v => `${v.value}`));
+        const additionalValues = currentUiFilters[selectedFilterIdx].values.map(value => {
+            const rawValue = `${value.value}`;
+            const hasRawMatch = currentValueRawSet.has(rawValue);
+            const needsTaxonomyFallback = rawValue.includes('|#') || rawValue.includes('ǂǂ');
+            const hasTaxonomyMatch = !hasRawMatch && needsTaxonomyFallback
+                ? values.some(v => this.areFilterValuesEquivalent(`${v.value ?? ''}`, `${value.value ?? ''}`))
+                : false;
+
+            if (!hasRawMatch && !hasTaxonomyMatch && value.selected) {
+                return value;
+            }
+
+            return null;
+        }).filter(Boolean);
+
+        return values.concat(additionalValues);
+    }
+
+
+    private getFilterSelectionState(availableFilter: IDataFilterResult, values: IDataFilterValueInternal[], currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number): {
+        selectedOnce: boolean;
+        hasSelectedValues: boolean;
+        canApply: boolean;
+        canClear: boolean;
+    } {
+        const selectedOnce = selectedFilterIdx !== -1 && currentUiFilters[selectedFilterIdx].selectedOnce
+            ? currentUiFilters[selectedFilterIdx].selectedOnce
+            : values.some(value => value.selectedOnce);
+        const hasSelectedValues = values.some(value => value.selected);
+        const currentSelectedValuesInUiForFilter = values
+            .filter(value => value.selected)
+            .map(value => `${value.value ?? ''}`)
+            .sort((left, right) => left.localeCompare(right));
+        const alreadySubmittedValuesForFilter = flatten(
+            this.state.submittedFilters
+                .filter(submittedFilter => submittedFilter.filterName === availableFilter.filterName)
+                .map(submittedFilter => submittedFilter.values)
+        )
+            .map(value => `${value.value ?? ''}`)
+            .sort((left, right) => left.localeCompare(right));
+
+        return {
+            selectedOnce,
+            hasSelectedValues,
+            canApply: !isEqual(currentSelectedValuesInUiForFilter, alreadySubmittedValuesForFilter),
+            canClear: alreadySubmittedValuesForFilter.length > 0 || hasSelectedValues
+        };
+    }
+
+    private buildFilterResultInternal(availableFilter: IDataFilterResult, filterConfiguration: IHierarchicalFilterConfiguration, values: IDataFilterValueInternal[], currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number, filterWithLimitInfo: IFilterResultWithLimitInfo, selectionState: { selectedOnce: boolean; hasSelectedValues: boolean; canApply: boolean; canClear: boolean; }): IFilterInternalWithWarning & { termSetId?: string; termGroupId?: string; hierarchicalTerms?: IHierarchicalTerm[]; hideNodesNotInDataSet?: boolean; expandAllNodesByDefault?: boolean } {
+        const filterOperator = selectedFilterIdx === -1 ? filterConfiguration.operator : currentUiFilters[selectedFilterIdx].operator;
+        const showLimitExceededWarning = Boolean(filterConfiguration.showLimitExceededWarning && filterWithLimitInfo.isMaxBucketsExceeded);
+        const limitExceededWarningText = showLimitExceededWarning
+            ? this.formatLocalizedString(
+                webPartStrings.PropertyPane.DataFilterCollection.FilterLimitReachedWarningMessage,
+                [filterWithLimitInfo.returnedValueCount ?? values.length, filterWithLimitInfo.configuredMaxBuckets ?? values.length]
+            )
+            : undefined;
+        const showPeopleTemplateMappingWarning = this.props.webPartTitleProps?.displayMode === DisplayMode.Edit
+            && filterConfiguration.selectedTemplate === BuiltinFilterTemplates.People
+            && this.shouldShowPeopleTemplateMappingWarning(availableFilter);
+        const peopleTemplateMappingWarningText = showPeopleTemplateMappingWarning
+            ? (webPartStrings.PropertyPane.DataFilterCollection.PeopleTemplateQUserMappingWarning
+                || 'People template warning: values do not look like user identities. This property may not be mapped to a Q_USER crawled property.')
+            : undefined;
+        const warningMarkerTooltipText = peopleTemplateMappingWarningText || limitExceededWarningText;
+        const showWarningMarker = Boolean(showPeopleTemplateMappingWarning || showLimitExceededWarning);
+
+        return {
+            displayName: filterConfiguration.displayValue?.trim() ? filterConfiguration.displayValue : availableFilter.filterName,
+            filterName: availableFilter.filterName,
+            isMulti: !!filterConfiguration.isMulti,
+            showCount: !!filterConfiguration.showCount,
+            expandByDefault: !!filterConfiguration.expandByDefault,
+            showWarningMarker,
+            showLimitExceededWarning,
+            limitExceededWarningText,
+            showPeopleTemplateMappingWarning,
+            peopleTemplateMappingWarningText,
+            warningMarkerTooltipText,
+            selectedOnce: selectionState.selectedOnce,
+            selectedTemplate: filterConfiguration.selectedTemplate,
+            hasSelectedValues: selectionState.hasSelectedValues,
+            values,
+            operator: filterOperator,
+            sortIdx: filterConfiguration.sortIdx,
+            canApply: selectionState.canApply,
+            canClear: selectionState.canClear,
+            termSetId: filterConfiguration.termSetId,
+            termGroupId: filterConfiguration.termGroupId,
+            hideNodesNotInDataSet: filterConfiguration.hideNodesNotInDataSet,
+            expandAllNodesByDefault: filterConfiguration.expandAllNodesByDefault
+        };
+    }
+
+    private async populateHierarchicalTerms(filterResultInternal: IFilterInternalWithWarning & { termSetId?: string; termGroupId?: string; hierarchicalTerms?: IHierarchicalTerm[]; hideNodesNotInDataSet?: boolean; expandAllNodesByDefault?: boolean }, availableFilter: IDataFilterResult, values: IDataFilterValueInternal[], filterConfiguration: IHierarchicalFilterConfiguration, debugContext?: IUpdateDebugContext): Promise<void> {
+        if (filterConfiguration.selectedTemplate !== BuiltinFilterTemplates.Hierarchical
+            || !filterConfiguration.termSetId
+            || !filterConfiguration.termGroupId
+            || !this.props.taxonomyService) {
+            return;
+        }
+
+        try {
+            const hierarchyCacheKey = this.getHierarchyCacheKey(
+                availableFilter.filterName,
+                filterConfiguration.termSetId,
+                filterConfiguration.termGroupId
+            );
+
+            let hierarchicalTerms = this._hierarchyCacheByFilterKey.get(hierarchyCacheKey);
+            let taxonomyFetchMs = 0;
+            let usedHierarchyCache = true;
+
+            if (!hierarchicalTerms) {
+                usedHierarchyCache = false;
+                const taxonomyStartedAt = performance.now();
+                const terms = await this.props.taxonomyService.getTermsByTermSetId(
+                    this.props.context.pageContext.web.absoluteUrl,
+                    filterConfiguration.termSetId,
+                    filterConfiguration.termGroupId,
+                    filterConfiguration.cacheDuration
+                );
+                taxonomyFetchMs = performance.now() - taxonomyStartedAt;
+
+                hierarchicalTerms = this.buildHierarchy(terms);
+                this.setLimitedCacheEntry(
+                    this._hierarchyCacheByFilterKey,
+                    hierarchyCacheKey,
+                    hierarchicalTerms,
+                    SearchFiltersContainer._HIERARCHY_CACHE_LIMIT
+                );
+            }
+
+            if (debugContext) {
+                this.logUpdateStep(debugContext, 'getFiltersToDisplay:filter:taxonomyFetched', {
+                    currentFilter: availableFilter.filterName,
+                    termCount: hierarchicalTerms.length,
+                    taxonomyFetchMs: taxonomyFetchMs.toFixed(1),
+                    usedHierarchyCache
+                });
+            }
+
+            if (!filterConfiguration.hideNodesNotInDataSet) {
+                filterResultInternal.hierarchicalTerms = hierarchicalTerms;
+                return;
+            }
+
+            const resultGuids = this.buildGuidSetFromFilterValues(availableFilter.values);
+            const selectedGuids = this.buildGuidSetFromFilterValues(values.filter(value => value.selected));
+            const prunedCacheKey = `${hierarchyCacheKey}::${this.getGuidSetSignature(resultGuids)}::${this.getGuidSetSignature(selectedGuids)}`;
+
+            let prunedHierarchy = this._prunedHierarchyCacheBySelectionKey.get(prunedCacheKey);
+            if (!prunedHierarchy) {
+                prunedHierarchy = this.pruneHierarchy(hierarchicalTerms, resultGuids, selectedGuids);
+                this.setLimitedCacheEntry(
+                    this._prunedHierarchyCacheBySelectionKey,
+                    prunedCacheKey,
+                    prunedHierarchy,
+                    SearchFiltersContainer._PRUNED_HIERARCHY_CACHE_LIMIT
+                );
+            }
+
+            filterResultInternal.hierarchicalTerms = prunedHierarchy.length > 0 ? prunedHierarchy : hierarchicalTerms;
+        } catch (error) {
+            Log.error('SearchFiltersContainer', new Error(`Error fetching hierarchical terms for filter ${availableFilter.filterName}: ${error}`));
+        }
+    }
+
+    private async buildFilterToDisplay(availableFilter: IDataFilterResult, currentUiFilters: IDataFilterInternal[], filtersConfiguration: IDataFilterConfiguration[], debugContext?: IUpdateDebugContext): Promise<IDataFilterInternal | null> {
+        const filterStartedAt = performance.now();
+        const filterWithLimitInfo = availableFilter as IFilterResultWithLimitInfo;
+        const filterConfiguration = DataFilterHelper.getConfigurationForFilter(availableFilter, filtersConfiguration) as IHierarchicalFilterConfiguration;
+
+        if (!filterConfiguration) {
+            return null;
+        }
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'getFiltersToDisplay:filter:start', {
+                currentFilter: availableFilter.filterName,
+                availableValueCount: availableFilter.values.length,
+                selectedTemplate: filterConfiguration.selectedTemplate
+            });
+        }
+
+        const { selectedFilterIdx, selectedFilterValues, selectedValueIndexByRaw } = this.getSelectedFilterUiContext(currentUiFilters, availableFilter, filterConfiguration);
+        let values = this.buildDisplayValues(availableFilter, currentUiFilters, selectedFilterIdx, selectedFilterValues, selectedValueIndexByRaw, filterConfiguration);
+        values = this.appendAdditionalSelectedValues(values, currentUiFilters, selectedFilterIdx);
+
+        const selectionState = this.getFilterSelectionState(availableFilter, values, currentUiFilters, selectedFilterIdx);
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'getFiltersToDisplay:filter:valuesProcessed', {
+                currentFilter: availableFilter.filterName,
+                uiValueCount: values.length,
+                hasSelectedValues: selectionState.hasSelectedValues,
+                canApply: selectionState.canApply,
+                canClear: selectionState.canClear
+            });
+        }
+
+        values = values.map(value => {
+            value.disabled = !filterConfiguration.isMulti && selectionState.hasSelectedValues && !value.selected;
+            return value;
+        });
+
+        const filterResultInternal = this.buildFilterResultInternal(
+            availableFilter,
+            filterConfiguration,
+            values,
+            currentUiFilters,
+            selectedFilterIdx,
+            filterWithLimitInfo,
+            selectionState
+        );
+
+        await this.populateHierarchicalTerms(filterResultInternal, availableFilter, values, filterConfiguration, debugContext);
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'getFiltersToDisplay:filter:done', {
+                currentFilter: availableFilter.filterName,
+                filterElapsedMs: (performance.now() - filterStartedAt).toFixed(1)
+            });
+        }
+
+        return filterResultInternal;
+    }
+
+    private buildFilterValueInternal(filterValue: IDataFilterValueInfo): IDataFilterValueInternal {
+        return {
+            selected: filterValue.selected,
+            name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`),
+            value: filterValue.value,
+            operator: filterValue.operator,
+            selectedOnce: true
+        };
+    }
+
+    private createNewUiFilter(filterInfo: IDataFilterInfo, filterConfiguration: IDataFilterConfiguration): IDataFilterInternal & { termSetId?: string } {
+        const filterValuesInternal: IDataFilterValueInternal[] = filterInfo.filterValues.map(filterValue => {
+            return {
+                selected: filterValue.selected,
+                name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`),
+                value: filterValue.value,
+                selectedOnce: true
+            };
+        });
+
+        return {
+            displayName: filterConfiguration.displayValue?.trim() ? filterConfiguration.displayValue : filterInfo.filterName,
+            filterName: filterInfo.filterName,
+            hasSelectedValues: filterInfo.filterValues.some(value => value.selected),
+            selectedOnce: true,
+            isMulti: !!filterConfiguration.isMulti,
+            showCount: !!filterConfiguration.showCount,
+            expandByDefault: !!filterConfiguration.expandByDefault,
+            values: filterValuesInternal,
+            operator: filterInfo.operator ? filterInfo.operator : filterConfiguration.operator,
+            selectedTemplate: filterConfiguration.selectedTemplate,
+            sortIdx: filterConfiguration.sortIdx,
+            termSetId: (filterConfiguration as IHierarchicalFilterConfiguration).termSetId
+        };
+    }
+
+    private mergeFilterValuesIntoUiFilters(currentUiFilters: IDataFilterInternal[], filterIdx: number, filterInfo: IDataFilterInfo, filterConfiguration: IDataFilterConfiguration): IDataFilterInternal[] {
+        let updatedUiFilters = cloneDeep(currentUiFilters);
+
+        if (filterInfo.operator) {
+            updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { operator: { $set: filterInfo.operator } } });
+        }
+
+        if (!filterConfiguration.isMulti) {
+            updatedUiFilters[filterIdx].values = updatedUiFilters[filterIdx].values.map(value => ({
+                ...value,
+                selected: false
+            }));
+        }
+
+        filterInfo.filterValues.forEach(filterValue => {
+            const filterValueInternal = this.buildFilterValueInternal(filterValue);
+            const valueIdx = updatedUiFilters[filterIdx].values.findIndex(value => value.value === filterValue.value);
+
+            if (valueIdx === -1) {
+                updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { values: { $push: [filterValueInternal] } } });
+                return;
+            }
+
+            updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { values: { [valueIdx]: { $set: filterValueInternal } } } });
+        });
+
+        return updatedUiFilters;
+    }
+
+    private updatePendingMultiFilterState(currentUiFilters: IDataFilterInternal[], filterName: string): void {
+        const updatedFilterIdx = currentUiFilters.findIndex(filter => filter.filterName === filterName);
+        if (updatedFilterIdx === -1) {
+            return;
+        }
+
+        const updatedFilter = currentUiFilters[updatedFilterIdx];
+        updatedFilter.values = updatedFilter.values.slice().sort((left, right) => {
+            if (left.selected !== right.selected) {
+                return left.selected ? -1 : 1;
+            }
+
+            const leftLabel = `${left.name ?? left.value ?? ''}`;
+            const rightLabel = `${right.name ?? right.value ?? ''}`;
+            return leftLabel.localeCompare(rightLabel);
+        });
+
+        const currentSelectedValuesInUiForFilter = updatedFilter.values
+            .filter(value => value.selected)
+            .map(value => `${value.value}`)
+            .sort((left, right) => left.localeCompare(right));
+        const alreadySubmittedValuesForFilter = flatten(
+            this.state.submittedFilters
+                .filter(submittedFilter => submittedFilter.filterName === updatedFilter.filterName)
+                .map(submittedFilter => submittedFilter.values)
+        )
+            .map(value => `${value.value}`)
+            .sort((left, right) => left.localeCompare(right));
+
+        updatedFilter.hasSelectedValues = updatedFilter.values.some(value => value.selected);
+        updatedFilter.selectedOnce = true;
+        updatedFilter.canApply = !isEqual(currentSelectedValuesInUiForFilter, alreadySubmittedValuesForFilter);
+        updatedFilter.canClear = alreadySubmittedValuesForFilter.length > 0 || updatedFilter.hasSelectedValues;
+    }
+
+    private hasAppliedFilters(filters: IDataFilter[]): boolean {
+        return filters.some(filter => filter.values.length > 0);
+    }
+
+    private getFiltersAfterClear(currentUiFilters: IDataFilterInternal[], filterName: string): IDataFilterInternal[] {
+        return currentUiFilters.map(selectedFilter => {
+            const updatedFilter = cloneDeep(selectedFilter);
+
+            if (updatedFilter.filterName === filterName) {
+                updatedFilter.values = [];
+                updatedFilter.selectedOnce = true;
+                updatedFilter.hasSelectedValues = false;
+            } else {
+                updatedFilter.values = updatedFilter.values.filter(selectedValue => selectedValue.selected);
+            }
+
+            return updatedFilter;
+        });
+    }
+
+    private getSubmittedFiltersAfterClear(submittedFilters: IDataFilter[], filterName: string): IDataFilter[] {
+        return submittedFilters.map(submittedFilter => {
+            if (submittedFilter.filterName !== filterName) {
+                return submittedFilter;
+            }
+
+            return {
+                ...submittedFilter,
+                values: []
+            };
+        });
+    }
+
+    private commitPendingMultiFilterState(currentUiFilters: IDataFilterInternal[], debugContext?: IUpdateDebugContext): void {
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'onFilterValuesUpdated:multiFastPath:beforeStateCommit');
+        }
+
+        this._skipNextUiRefreshFromLocalSelection = true;
+        this.setState({
+            currentUiFilters: sortBy(currentUiFilters, 'sortIdx')
+        }, () => {
+            if (debugContext) {
+                this.logUpdateStep(debugContext, 'onFilterValuesUpdated:multiFastPath:stateCommitted');
+            }
+
+            this.endResultsUpdate();
+        });
+    }
+
+    private commitSubmittedFilterUpdate(currentUiFilters: IDataFilterInternal[], filterInfo: IDataFilterInfo, filterConfiguration: IDataFilterConfiguration, debugContext?: IUpdateDebugContext): void {
+        const submittedFilters = this.getSelectedFiltersFromUIFilters(currentUiFilters);
+        const sortedCurrentUiFilters = sortBy(currentUiFilters, 'sortIdx');
+        this._skipNextUiRefreshFromLocalSelection = true;
+
+        this.setState({
+            currentUiFilters: sortedCurrentUiFilters,
+            submittedFilters
+        }, () => {
+            if (debugContext) {
+                this.logUpdateStep(debugContext, 'onFilterValuesUpdated:submittedStateCommitted', {
+                    submittedFilterCount: submittedFilters.length
+                });
+            }
+
+            this.queueDeferredSubmittedFiltersUpdate(submittedFilters, filterInfo.filterName);
+
+            if (filterConfiguration.isMulti) {
+                this.forceUpdate();
+            }
+        });
     }
 
     public render(): React.ReactElement<ISearchFiltersContainerProps> {
@@ -224,7 +1308,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             const templateContext = this.getTemplateContext();
 
             renderWpContent = <TemplateRenderer
-                key={`${this.props.instanceId}_${this.props.selectedLayoutKey}_${this.getFilterSignature(this.state.currentUiFilters)}_${this.getFilterSignature(this.state.submittedFilters)}`}
+                key={`${this.props.instanceId}_${this.props.selectedLayoutKey}`}
                 templateContent={templateContent}
                 templateContext={templateContext}
                 templateService={this.props.templateService}
@@ -234,13 +1318,15 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         const containerStyles: React.CSSProperties = {
+            position: 'relative',
             backgroundColor: this.props.filterBackgroundColor || undefined,
             borderStyle: this.props.filterBorderColor || this.props.filterBorderThickness ? 'solid' : undefined,
             borderColor: this.props.filterBorderColor || undefined,
-            borderWidth: this.props.filterBorderThickness !== undefined ? `${this.props.filterBorderThickness}px` : undefined
+            borderWidth: this.props.filterBorderThickness === undefined ? undefined : `${this.props.filterBorderThickness}px`,
+            cursor: this.state.isUpdatingResults ? 'progress' : 'default'
         };
 
-        return <div ref={this.componentRef} data-instance-id={this.props.instanceId} style={containerStyles}>
+        return <div ref={this.componentRef} data-instance-id={this.props.instanceId} style={containerStyles} onPointerDownCapture={this.primeBusyCursorFromInteraction}>
             {renderTitle}
             {renderWpContent}
         </div>;
@@ -272,6 +1358,13 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
     public componentDidUpdate(prevProps: ISearchFiltersContainerProps, prevState: ISearchFiltersContainerState) {
 
+        const availableFiltersChanged = !isEqual(prevProps.availableFilters, this.props.availableFilters);
+        const currentUiFiltersChanged = !isEqual(prevState.currentUiFilters, this.state.currentUiFilters) && prevState.currentUiFilters.length > 0;
+
+        if (availableFiltersChanged && this.state.isUpdatingResults) {
+            this.endResultsUpdate();
+        }
+
         // When filters configuration is updated or the layout is changed 
         if (!isEqual(prevProps.selectedLayoutKey, this.props.selectedLayoutKey)
             || !isEqual(prevProps.properties, this.props.properties)) {
@@ -287,8 +1380,12 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         // When new filters are received from the data source
-        if (!isEqual(prevProps.availableFilters, this.props.availableFilters)
-            || (!isEqual(prevState.currentUiFilters, this.state.currentUiFilters)) && prevState.currentUiFilters.length > 0) {
+        if (availableFiltersChanged || currentUiFiltersChanged) {
+
+            if (this._skipNextUiRefreshFromLocalSelection && !availableFiltersChanged) {
+                this._skipNextUiRefreshFromLocalSelection = false;
+                return;
+            }
 
             this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);
 
@@ -306,202 +1403,42 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
      * @param currentUIFilters the current selected filters in the UI
      * @param filtersConfiguration the filter configuration from the property pane
      */
-    private async getFiltersToDisplay(availableFilters: IDataFilterResult[], currentUiFilters: IDataFilterInternal[], filtersConfiguration: IDataFilterConfiguration[]): Promise<void> {
+    private async getFiltersToDisplay(availableFilters: IDataFilterResult[], currentUiFilters: IDataFilterInternal[], filtersConfiguration: IDataFilterConfiguration[], debugContext?: IUpdateDebugContext): Promise<void> {
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'getFiltersToDisplay:start', {
+                availableFilterCount: availableFilters.length,
+                currentUiFilterCount: currentUiFilters.length
+            });
+        }
 
         const updatedFilters: IDataFilterInternal[] = [];
 
         for (const availableFilter of availableFilters) {
-            const filterWithLimitInfo = availableFilter as IFilterResultWithLimitInfo;
-
-            let values: IDataFilterValueInternal[] = [];
-
-            // Get the corresponding configuration for this filter
-            const filterConfiguration = DataFilterHelper.getConfigurationForFilter(availableFilter, filtersConfiguration) as IHierarchicalFilterConfiguration;
-
-            if (filterConfiguration) {
-
-                // Determine if the filter is already selected in the current UI filters 
-                const selectedFilterIdx = currentUiFilters.map(selectedFilter => { return selectedFilter.filterName; }).indexOf(availableFilter.filterName);
-
-                // When the selected filters combination have no results, we set the selected value counts for the current filter to 0 to be able to reset it in the UI.
-                if (availableFilter.values.length === 0) {
-
-                    if (selectedFilterIdx !== -1) {
-
-                        // Set count to 0
-                        values = currentUiFilters[selectedFilterIdx].values.map(value => {
-
-                            // Reset the count for already selected refiners
-                            if (((value.selected || value.selectedOnce) && filterConfiguration.isMulti) || (value.selected && !filterConfiguration.isMulti)) {
-                                value.count = 0;
-                            } else {
-                                return null;
-                            }
-
-                            return value;
-                        }).filter(value => value);
-                    }
-
-                } else {
-
-                    // Merge available filters with currently selected filters to ajust the count information
-                    values = availableFilter.values.map((availableValue: IDataFilterResultValue) => {
-
-                        const filterValueInternal: IDataFilterValueInternal = {
-                            name: availableValue.name,
-                            selected: false,
-                            selectedOnce: false,
-                            disabled: false,
-                            value: availableValue.value,
-                            count: availableValue.count
-                        };
-
-                        if (selectedFilterIdx !== -1) {
-
-                            const valueIdx = currentUiFilters[selectedFilterIdx].values.findIndex(value => this.areFilterValuesEquivalent(value.value as string, availableValue.value));
-
-                            // A new filter value is available
-                            if (valueIdx === -1) {
-                                return filterValueInternal;
-                            } else {
-
-                                // Update the count + name information
-                                const updatedValue = currentUiFilters[selectedFilterIdx].values[valueIdx];
-                                updatedValue.count = availableValue.count;
-                                // Only overwrite name if it's not already a human-readable label (i.e., avoid replacing labels with tokens)
-                                const currentNameIsToken = updatedValue.name && (
-                                    updatedValue.name.indexOf("GPP|#") === 0 ||
-                                    updatedValue.name.indexOf("GP0|#") === 0 ||
-                                    updatedValue.name.indexOf("L0|#") === 0 ||
-                                    (updatedValue.name.startsWith('"') && updatedValue.name.includes('ǂǂ'))
-                                );
-                                const availableNameIsToken = availableValue.name && (
-                                    availableValue.name.indexOf("GPP|#") === 0 ||
-                                    availableValue.name.indexOf("GP0|#") === 0 ||
-                                    availableValue.name.indexOf("L0|#") === 0 ||
-                                    (availableValue.name.startsWith('"') && availableValue.name.includes('ǂǂ'))
-                                );
-                                // Only update name if: current is a token and available is NOT a token (i.e., upgrade to readable)
-                                // OR if both are tokens or both are readable (normal refresh)
-                                if (currentNameIsToken && !availableNameIsToken) {
-                                    updatedValue.name = availableValue.name;
-                                } else if (!currentNameIsToken && availableNameIsToken) {
-                                    // Keep current name as it's already human-readable
-                                    // Don't overwrite with token from refiner
-                                } else {
-                                    // Both are tokens or both are readable - safe to update
-                                    updatedValue.name = availableValue.name;
-                                }
-                                return updatedValue;
-                            }
-
-                        } else {
-                            // A new filter with new values is available
-                            return filterValueInternal;
-                        }
-                    });
-                }
-
-                // Add leftover values added outside of filter values range (ex: from a date range component or taxonomy picker)
-                if (selectedFilterIdx !== -1) {
-                    const additionalValues = currentUiFilters[selectedFilterIdx].values.map(value => {
-
-                        const valueIdx = values.findIndex(v => this.areFilterValuesEquivalent(v.value as string, value.value as string));
-                        if (valueIdx === -1 && value.selected) {
-                            return value;
-                        }
-                    });
-
-                    values = values.concat(additionalValues.filter(value => value));
-                }
-
-                const selectedOnce = selectedFilterIdx !== -1 && currentUiFilters[selectedFilterIdx].selectedOnce ? currentUiFilters[selectedFilterIdx].selectedOnce : values.filter(value => { return value.selectedOnce; }).length > 0;
-                const hasSelectedValues = values.filter(value => { return value.selected; }).length > 0;
-
-                // Determine if the user has updated the filter values (used for apply/clear buttons state)
-                const currentSelectedValuesInUiForFilter = values.filter(value => { return value.selected; }).map(v => v.value).sort();
-                const alreadySubmittedValuesForFilter = flatten(this.state.submittedFilters.filter(s => s.filterName === availableFilter.filterName).map(v => v.values)).map(t => t.value).sort();
-
-                const canApply = !isEqual(currentSelectedValuesInUiForFilter, alreadySubmittedValuesForFilter);
-                const canClear = alreadySubmittedValuesForFilter.length > 0 || hasSelectedValues;
-
-                // Disabled all unselected values if the configuration is not multi to prevent multiple selection at once
-                values = values.map(value => {
-                    if (!filterConfiguration.isMulti && hasSelectedValues && !value.selected) {
-                        value.disabled = true;
-                    } else {
-                        value.disabled = false;
-                    }
-
-                    return value;
-                });
-
-                const filterOperator = currentUiFilters[selectedFilterIdx] ? currentUiFilters[selectedFilterIdx].operator : filterConfiguration.operator;
-                const showLimitExceededWarning = Boolean(filterConfiguration.showLimitExceededWarning && filterWithLimitInfo.isMaxBucketsExceeded);
-                const limitExceededWarningText = showLimitExceededWarning
-                    ? this.formatLocalizedString(
-                        webPartStrings.PropertyPane.DataFilterCollection.FilterLimitReachedWarningMessage,
-                        [filterWithLimitInfo.returnedValueCount ?? values.length, filterWithLimitInfo.configuredMaxBuckets ?? values.length]
-                    )
-                    : undefined;
-
-                // Merge information with filter configuration and other useful proeprties
-                const filterResultInternal: IFilterInternalWithWarning & { termSetId?: string; termGroupId?: string; hierarchicalTerms?: IHierarchicalTerm[]; hideNodesNotInDataSet?: boolean; expandAllNodesByDefault?: boolean } = {
-                    displayName: filterConfiguration.displayValue && filterConfiguration.displayValue.trim() ? filterConfiguration.displayValue : availableFilter.filterName,
-                    filterName: availableFilter.filterName,
-                    isMulti: !filterConfiguration.isMulti ? false : filterConfiguration.isMulti,
-                    showCount: !filterConfiguration.showCount ? false : filterConfiguration.showCount,
-                    expandByDefault: !filterConfiguration.expandByDefault ? false : filterConfiguration.expandByDefault,
-                    showLimitExceededWarning: showLimitExceededWarning,
-                    limitExceededWarningText: limitExceededWarningText,
-                    selectedOnce: selectedOnce,
-                    selectedTemplate: filterConfiguration.selectedTemplate,
-                    hasSelectedValues: hasSelectedValues,
-                    values: values,
-                    operator: filterOperator,
-                    sortIdx: filterConfiguration.sortIdx,
-                    canApply: canApply,
-                    canClear: canClear,
-                    termSetId: filterConfiguration.termSetId,
-                    termGroupId: filterConfiguration.termGroupId,
-                    hideNodesNotInDataSet: filterConfiguration.hideNodesNotInDataSet,
-                    expandAllNodesByDefault: filterConfiguration.expandAllNodesByDefault
-                };
-
-                if (filterConfiguration.selectedTemplate === BuiltinFilterTemplates.Hierarchical
-                    && filterConfiguration.termSetId
-                    && filterConfiguration.termGroupId
-                    && this.props.taxonomyService) {
-                    try {
-                        const terms = await this.props.taxonomyService.getTermsByTermSetId(
-                            this.props.context.pageContext.web.absoluteUrl,
-                            filterConfiguration.termSetId,
-                            filterConfiguration.termGroupId,
-                            filterConfiguration.cacheDuration
-                        );
-
-                        const hierarchicalTerms = this.buildHierarchy(terms);
-
-                        if (filterConfiguration.hideNodesNotInDataSet) {
-                            const resultGuids = this.buildGuidSetFromFilterValues(availableFilter.values as Array<{ value: string }>);
-                            const selectedGuids = this.buildGuidSetFromFilterValues(values.filter(value => value.selected) as Array<{ value: string }>);
-
-                            const prunedHierarchy = this.pruneHierarchy(hierarchicalTerms, resultGuids, selectedGuids);
-                            filterResultInternal.hierarchicalTerms = prunedHierarchy.length > 0 ? prunedHierarchy : hierarchicalTerms;
-                        } else {
-                            filterResultInternal.hierarchicalTerms = hierarchicalTerms;
-                        }
-                    } catch (error) {
-                        Log.error('SearchFiltersContainer', new Error(`Error fetching hierarchical terms for filter ${availableFilter.filterName}: ${error}`));
-                    }
-                }
-
+            const filterResultInternal = await this.buildFilterToDisplay(availableFilter, currentUiFilters, filtersConfiguration, debugContext);
+            if (filterResultInternal) {
                 updatedFilters.push(filterResultInternal);
             }
         }
 
+        const sortStartedAt = performance.now();
+        const sortedFilters = sortBy(updatedFilters.filter(Boolean), 'sortIdx');
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'getFiltersToDisplay:beforeSetState', {
+                sortedFilterCount: sortedFilters.length,
+                sortMs: (performance.now() - sortStartedAt).toFixed(1)
+            });
+        }
+
         this.setState({
-            currentUiFilters: update(this.state.currentUiFilters, { $set: sortBy(updatedFilters.filter(updatedFilter => updatedFilter), 'sortIdx') })
+            currentUiFilters: sortedFilters
+        }, () => {
+            if (debugContext) {
+                this.logUpdateStep(debugContext, 'getFiltersToDisplay:stateCommitted', {
+                    updatedFilterCount: updatedFilters.length
+                });
+            }
         });
     }
 
@@ -509,111 +1446,74 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
      * Update the filter status in the state according to values
      * @param filterInfo the information about the updated filter
      */
-    private onFilterValuesUpdated(filterInfo: IDataFilterInfo) {
+    private onFilterValuesUpdated(filterInfo: IDataFilterInfo, debugContext?: IUpdateDebugContext) {
 
-        let currentUiFilters: IDataFilterInternal[] = [];
-
-        // Get the configuration for this filter
-        const filterConfigIdx = this.props.filtersConfiguration.map(filter => { return filter.filterName; }).indexOf(filterInfo.filterName);
-
-        if (filterConfigIdx !== -1) {
-
-            const filterConfiguration = this.props.filtersConfiguration[filterConfigIdx];
-
-            // Get the index of the filter in the current selected filters collection
-            const filterIdx = this.state.currentUiFilters.map(filter => { return filter.filterName; }).indexOf(filterInfo.filterName);
-
-            if (filterIdx !== -1) {
-
-                currentUiFilters = cloneDeep(this.state.currentUiFilters);
-
-                // If a control specifies an operator to use between values explictly, we update it in the current collection (ex: the FilterValueOperator component nested in the combo box component)
-                if (filterInfo.operator) {
-                    currentUiFilters = update(currentUiFilters, { [filterIdx]: { operator: { $set: filterInfo.operator } } });
-                }
-
-                if (!filterConfiguration.isMulti) {
-                    currentUiFilters[filterIdx].values = currentUiFilters[filterIdx].values.map(value => ({
-                        ...value,
-                        selected: false
-                    }));
-                }
-
-                // Addition or merge scenario
-                filterInfo.filterValues.map(filterValue => {
-
-                    const filterValueInternal: IDataFilterValueInternal = {
-                        selected: filterValue.selected,
-                        name: filterValue.name,
-                        value: filterValue.value,
-                        operator: filterValue.operator,
-                        selectedOnce: true
-                    };
-
-                    const valueIdx = currentUiFilters[filterIdx].values.map(value => { return value.value; }).indexOf(filterValue.value);
-
-                    if (valueIdx === -1) {
-                        // If the value does not exist yet, we add it to the selected values
-                        currentUiFilters = update(currentUiFilters, { [filterIdx]: { values: { $push: [filterValueInternal] } } });
-                    } else {
-                        // Otherwise, we update the value in selected values
-                        currentUiFilters = update(currentUiFilters, { [filterIdx]: { values: { [valueIdx]: { $set: filterValueInternal } } } });
-                    }
-                });
-
-            } else {
-
-                const filterValuesInternal: IDataFilterValueInternal[] = filterInfo.filterValues.map(filterValue => {
-                    return {
-                        selected: filterValue.selected,
-                        name: filterValue.name,
-                        value: filterValue.value,
-                        selectedOnce: true
-                    };
-                });
-
-                const filterResultInternal: IDataFilterInternal & { termSetId?: string } = {
-                    displayName: filterConfiguration.displayValue && filterConfiguration.displayValue.trim() ? filterConfiguration.displayValue : filterInfo.filterName,
-                    filterName: filterInfo.filterName,
-                    hasSelectedValues: filterInfo.filterValues.filter(value => value.selected).length > 0,
-                    selectedOnce: true,
-                    isMulti: !filterConfiguration.isMulti ? false : filterConfiguration.isMulti,
-                    showCount: !filterConfiguration.showCount ? false : filterConfiguration.showCount,
-                    expandByDefault: !filterConfiguration.expandByDefault ? false : filterConfiguration.expandByDefault,
-                    values: filterValuesInternal,
-                    operator: filterInfo.operator ? filterInfo.operator : currentUiFilters[filterIdx].operator,
-                    selectedTemplate: filterConfiguration.selectedTemplate,
-                    sortIdx: filterConfiguration.sortIdx,
-                    termSetId: (filterConfiguration as IHierarchicalFilterConfiguration).termSetId
-                };
-
-                // If does not exist, add to selected filters collection
-                currentUiFilters = update(this.state.currentUiFilters, { $push: [filterResultInternal] });
-            }
-
-            if (!filterConfiguration.isMulti || filterInfo.forceUpdate) {
-
-                const submittedFilters = this.getSelectedFiltersFromUIFilters(currentUiFilters);
-
-                this.setState({
-                    submittedFilters: submittedFilters
-                }, () => {
-
-                    // Send only selected filters to the data source
-                    this.props.onUpdateFilters(submittedFilters);
-
-                    // Set the filter links in URL
-                    this.setFiltersDeepLink(submittedFilters);
-
-                    // Force a UI refresh is the submitted filters come from 'Apply' button to get the correct disabled/active state set
-                    if (filterConfiguration.isMulti) {
-                        this.forceUpdate();
-                    }
-                });
-            }
-
-            this.getFiltersToDisplay(this.props.availableFilters, currentUiFilters, this.props.filtersConfiguration);
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'onFilterValuesUpdated:start', {
+                selectedValueCount: (filterInfo.filterValues || []).filter(value => value.selected).length,
+                forceUpdate: !!filterInfo.forceUpdate
+            });
         }
+
+        const filterConfiguration = this.props.filtersConfiguration.find(filter => filter.filterName === filterInfo.filterName);
+        if (!filterConfiguration) {
+            this.endResultsUpdate();
+            return;
+        }
+
+        this.processFilterValuesUpdated(filterInfo, filterConfiguration, debugContext);
+    }
+
+    private processFilterValuesUpdated(filterInfo: IDataFilterInfo, filterConfiguration: IDataFilterConfiguration, debugContext?: IUpdateDebugContext): void {
+        let currentUiFilters: IDataFilterInternal[] = [];
+        const filterIdx = this.state.currentUiFilters.map(filter => filter.filterName).indexOf(filterInfo.filterName);
+
+        if (filterIdx === -1) {
+            currentUiFilters = update(this.state.currentUiFilters, { $push: [this.createNewUiFilter(filterInfo, filterConfiguration)] });
+        } else {
+            currentUiFilters = this.mergeFilterValuesIntoUiFilters(this.state.currentUiFilters, filterIdx, filterInfo, filterConfiguration);
+        }
+
+        if (debugContext) {
+            this.logUpdateStep(debugContext, 'onFilterValuesUpdated:uiMerged', {
+                filterExistsInUi: filterIdx !== -1,
+                isMulti: !!filterConfiguration.isMulti
+            });
+        }
+
+        if (filterConfiguration.isMulti && !filterInfo.forceUpdate) {
+            this.updatePendingMultiFilterState(currentUiFilters, filterInfo.filterName);
+            this.commitPendingMultiFilterState(currentUiFilters, debugContext);
+            return;
+        }
+
+        this.commitSubmittedFilterUpdate(currentUiFilters, filterInfo, filterConfiguration, debugContext);
+    }
+
+    public componentWillUnmount(): void {
+        if (this._deferredSubmittedUpdateTimer) {
+            clearTimeout(this._deferredSubmittedUpdateTimer);
+            this._deferredSubmittedUpdateTimer = null;
+        }
+
+        if (this._busyWatchdogTimer) {
+            clearTimeout(this._busyWatchdogTimer);
+            this._busyWatchdogTimer = null;
+        }
+
+        if (this._busyPrimeTimer) {
+            clearTimeout(this._busyPrimeTimer);
+            this._busyPrimeTimer = null;
+        }
+
+        if (this._busyHideTimer) {
+            clearTimeout(this._busyHideTimer);
+            this._busyHideTimer = null;
+        }
+
+        this.setBusyCursor(false);
+
+        this._latestDeferredSubmittedFilters = null;
     }
 
     /**
@@ -652,7 +1552,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
                     // Guard rail: normalize malformed taxonomy tokens before submitting to query/URL.
                     // This prevents trailing garbage characters in GP0/GPP/L0 GUID payloads.
-                    newValue.value = this.sanitizeTaxonomyRefinementValue(newValue.value as string);
+                    newValue.value = this.sanitizeTaxonomyRefinementValue(`${newValue.value ?? ''}`);
 
                     return newValue;
                 });
@@ -678,7 +1578,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             }
         });
 
-        return selectedFilters.filter(filter => filter);
+        return selectedFilters.filter(Boolean);
     }
 
     private sanitizeTaxonomyRefinementValue(rawValue: string): string {
@@ -691,7 +1591,8 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return rawValue;
         }
 
-        const tokenMatch = decodedValue.match(/^((?:GP0|GPP|L0)\|#0?)([-0-9a-fA-F]+)/i);
+        const tokenRegex = /^((?:GP0|GPP|L0)\|#0?)([-0-9a-f]+)/i;
+        const tokenMatch = tokenRegex.exec(decodedValue);
         if (!tokenMatch) {
             return rawValue;
         }
@@ -708,7 +1609,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private encodeTaxonomyRefinementToken(token: string): string {
         const hex = token
             .split('')
-            .map(char => char.charCodeAt(0).toString(16).padStart(2, '0'))
+            .map(char => (char.codePointAt(0) || 0).toString(16).padStart(2, '0'))
             .join('');
 
         return `"ǂǂ${hex}"`;
@@ -724,15 +1625,27 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             // We ensure the event if not propagated outside the component (i.e. other Web Part instances)
             ev.stopImmediatePropagation();
 
-            const dataFilterInfo = ev.detail as IDataFilterInfo;
+            const dataFilterInfo = ev.detail as IDataFilterInfo & { selectionStartedAt?: number };
 
             // Only process the filter event if it belongs to this web part instance
             if (dataFilterInfo.instanceId === this.props.instanceId) {
-                // Need the 'selected' because web components are stateless so we need to know if the filter has been selected or removed
-                this.onFilterValuesUpdated(dataFilterInfo);
+                this.beginResultsUpdate(dataFilterInfo.filterName, () => {
+                    const debugContext = this._enableUpdateDebugLogging
+                        ? this.createUpdateDebugContext(dataFilterInfo.filterName, ExtensibilityConstants.EVENT_FILTER_UPDATED, dataFilterInfo.selectionStartedAt)
+                        : undefined;
+
+                    if (debugContext) {
+                        this.logUpdateStep(debugContext, 'event:received', {
+                            selectedValueCount: (dataFilterInfo.filterValues || []).filter(value => value.selected).length
+                        });
+                    }
+
+                    // Need the 'selected' because web components are stateless so we need to know if the filter has been selected or removed
+                    this.onFilterValuesUpdated(dataFilterInfo, debugContext);
+                });
             }
 
-        }).bind(this));
+        }));
     }
 
     /**
@@ -748,23 +1661,42 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
             // Only process the event if it belongs to this web part instance
             if (eventDetail.instanceId === this.props.instanceId) {
-                const submittedFilters = this.getSelectedFiltersFromUIFilters(this.state.currentUiFilters);
-
-                // Set the filter links in URL
-                this.setFiltersDeepLink(submittedFilters);
-
-                // Refresh the UI
-                this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);
-
-                this.setState({
-                    submittedFilters: submittedFilters
+                const startedAt = performance.now();
+                const currentUiFilters = this.state.currentUiFilters;
+                console.info('[PnP Modern Search][Search Filters] applyAll:start', {
+                    instanceId: this.props.instanceId
                 });
 
-                // Send selected filters to the data source
-                this.props.onUpdateFilters(submittedFilters);
+                this.beginResultsUpdate(currentUiFilters.find(filter => filter.values.some(value => value.selected))?.filterName, () => {
+                    const submittedFilters = this.getSelectedFiltersFromUIFilters(currentUiFilters);
+
+                    // Set the filter links in URL
+                    this.setFiltersDeepLink(submittedFilters);
+
+                    // Refresh the UI
+                    this.getFiltersToDisplay(this.props.availableFilters, currentUiFilters, this.props.filtersConfiguration);
+
+                    this.setState({
+                        submittedFilters: submittedFilters
+                    }, () => {
+                        console.info('[PnP Modern Search][Search Filters] applyAll:submittedStateCommitted', {
+                            submittedFilterCount: submittedFilters.length,
+                            totalMs: (performance.now() - startedAt).toFixed(1),
+                            instanceId: this.props.instanceId
+                        });
+                    });
+
+                    // Send selected filters to the data source
+                    this.props.onUpdateFilters(submittedFilters);
+
+                    console.info('[PnP Modern Search][Search Filters] applyAll:onUpdateFiltersDispatched', {
+                        totalMs: (performance.now() - startedAt).toFixed(1),
+                        instanceId: this.props.instanceId
+                    });
+                });
             }
 
-        }).bind(this));
+        }));
     }
 
     /**
@@ -783,48 +1715,44 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 return;
             }
 
-            const updatedfilters = this.state.currentUiFilters.map(selectedFilter => {
+            const startedAt = performance.now();
+            console.info('[PnP Modern Search][Search Filters] clearAll:start', {
+                filterName: eventDetail.filterName,
+                instanceId: this.props.instanceId
+            });
 
-                const updatedFilter = cloneDeep(selectedFilter);
+            this.beginResultsUpdate(eventDetail.filterName, () => {
+                const updatedfilters = this.getFiltersAfterClear(this.state.currentUiFilters, eventDetail.filterName);
+                const updateSubmittedFilters = this.getSubmittedFiltersAfterClear(this.state.submittedFilters, eventDetail.filterName);
 
-                if (updatedFilter.filterName === eventDetail.filterName) {
-                    updatedFilter.values = [];
-                    updatedFilter.selectedOnce = true;
-                    updatedFilter.hasSelectedValues = false;
+                this.setState(() => ({
+                    submittedFilters: updateSubmittedFilters
+                }));
+
+                // Refresh the UI
+                this.getFiltersToDisplay(this.props.availableFilters, updatedfilters, this.props.filtersConfiguration);
+
+                // Check whether there are applied filters
+                if (this.hasAppliedFilters(updateSubmittedFilters)) {
+                    // If yes - update query string
+                    this.setFiltersDeepLink(updateSubmittedFilters);
                 } else {
-                    updatedFilter.values = updatedFilter.values.filter(filter => filter.selected);
+                    // If no - remove query string
+                    this.resetFiltersDeepLink();
                 }
-                return updatedFilter;
+
+                // Send selected filters to the data source
+                this.props.onUpdateFilters(updateSubmittedFilters);
+
+                console.info('[PnP Modern Search][Search Filters] clearAll:done', {
+                    filterName: eventDetail.filterName,
+                    submittedFilterCount: updateSubmittedFilters.length,
+                    totalMs: (performance.now() - startedAt).toFixed(1),
+                    instanceId: this.props.instanceId
+                });
             });
 
-            const updateSubmittedFilters = this.state.submittedFilters.map(submittedFilter => {
-                if (submittedFilter.filterName === eventDetail.filterName) {
-                    submittedFilter.values = [];
-                }
-                return submittedFilter;
-            });
-
-            this.setState({
-                submittedFilters: updateSubmittedFilters
-            });
-
-            // Refresh the UI
-            this.getFiltersToDisplay(this.props.availableFilters, updatedfilters, this.props.filtersConfiguration);
-
-            // Check whether there are applied filters
-            const appliedFilters = updateSubmittedFilters.filter(filter => filter.values.length > 0);
-            if (appliedFilters.length == 0) {
-                // If no - remove query string
-                this.resetFiltersDeepLink();
-            } else {
-                // If yes - update query string
-                this.setFiltersDeepLink(updateSubmittedFilters);
-            }
-
-            // Send selected filters to the data source
-            this.props.onUpdateFilters(updateSubmittedFilters);
-
-        }).bind(this));
+        }));
     }
 
     /**
@@ -843,45 +1771,63 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 return;
             }
 
-            // Find the filter wit hthis specific name
-            const filters = this.state.currentUiFilters.map(filter => {
-
-                const selectedValues = filter.values.filter(v => v.selected);
-                const selectedValueStrings = selectedValues.map(s => s.value);
-
-                // Submitted values for the current filter name
-                const submittedValues = this.state.submittedFilters.filter(f =>
-                    f.filterName === eventDetail.filterName &&
-                    f.values.some(v => selectedValueStrings.includes(v.value))
-                );
-
-                if (filter.filterName === eventDetail.filterName) {
-
-                    // We let the user apply the new filters only if the operator changes or has at least two selected values      
-                    filter.canApply = (!filter.canApply && filter.operator !== eventDetail.operator && selectedValues.length > 1) || (filter.canApply && submittedValues.length === 0);
-                    filter.operator = eventDetail.operator;
-                }
-
-                return filter;
+            const startedAt = performance.now();
+            console.info('[PnP Modern Search][Search Filters] operatorUpdate:start', {
+                filterName: eventDetail.filterName,
+                operator: eventDetail.operator,
+                instanceId: this.props.instanceId
             });
 
-            this.setState({
-                currentUiFilters: filters
+            this.beginResultsUpdate(eventDetail.filterName, () => {
+                // Find the filter wit hthis specific name
+                const filters = cloneDeep(this.state.currentUiFilters).map(filter => {
+                    if (filter.filterName === eventDetail.filterName) {
+
+                        filter.operator = eventDetail.operator;
+                        filter.canApply = false;
+                    }
+
+                    return filter;
+                });
+
+                const sortedFilters = sortBy(filters, 'sortIdx');
+                const submittedFilters = this.getSelectedFiltersFromUIFilters(sortedFilters);
+
+                this.setState({
+                    currentUiFilters: sortedFilters,
+                    submittedFilters
+                }, () => {
+
+                    if (this.hasAppliedFilters(submittedFilters)) {
+                        this.setFiltersDeepLink(submittedFilters);
+                    } else {
+                        this.resetFiltersDeepLink();
+                    }
+
+                    this.props.onUpdateFilters(submittedFilters);
+
+                    console.info('[PnP Modern Search][Search Filters] operatorUpdate:stateCommitted', {
+                        filterName: eventDetail.filterName,
+                        operator: eventDetail.operator,
+                        submittedFilterCount: submittedFilters.length,
+                        totalMs: (performance.now() - startedAt).toFixed(1),
+                        instanceId: this.props.instanceId
+                    });
+                });
             });
 
-        }).bind(this));
+        }));
     }
 
     // Build the template context
     private getTemplateContext(): ISearchFiltersTemplateContext {
-
         return {
             filters: this.state.currentUiFilters,
             selectedFilters: this.state.submittedFilters,
             instanceId: this.props.instanceId,
             theme: this.props.themeVariant,
             strings: commonStrings.Filters,
-            selectedOnce: this.state.currentUiFilters.filter(currentFilter => currentFilter.selectedOnce).length > 0,
+            selectedOnce: this.state.currentUiFilters.some(currentFilter => currentFilter.selectedOnce),
             properties: {
                 ...this.props.properties
             },
@@ -893,7 +1839,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
      */
     private getFiltersDeepLink() {
 
-        const queryString = UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, window.location.href);
+        const queryString = UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, globalThis.location.href);
 
         if (!queryString) {
             this._lastProcessedDeepLink = '';
@@ -911,11 +1857,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 const parsedFilters: IDataFilter[] = JSON.parse(decodeURIComponent(queryString));
                 const dataFilters: IDataFilter[] = parsedFilters.map(filter => {
                     const sanitizedValues = (filter.values || []).filter((value: any) => {
-                        return value && value.value !== undefined && value.value !== null && `${value.value}`.trim().length > 0;
+                        return !!value?.value && `${value.value}`.trim().length > 0;
                     }).map((value: any) => {
                         return {
                             ...value,
-                            value: this.sanitizeTaxonomyRefinementValue(value.value as string)
+                            value: this.sanitizeTaxonomyRefinementValue(`${value.value ?? ''}`)
                         };
                     });
 
@@ -930,14 +1876,18 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                     const filterConfiguration = DataFilterHelper.getConfigurationForFilter(filter, this.props.filtersConfiguration);
 
                     return {
-                        displayName: filterConfiguration.displayValue && filterConfiguration.displayValue.trim() ? filterConfiguration.displayValue : filter.filterName,
+                        displayName: filterConfiguration.displayValue?.trim() ? filterConfiguration.displayValue : filter.filterName,
                         expandByDefault: filterConfiguration.expandByDefault,
                         filterName: filter.filterName,
                         isMulti: filterConfiguration.isMulti,
                         selectedTemplate: filterConfiguration.selectedTemplate,
                         showCount: filterConfiguration.showCount,
+                        showWarningMarker: false,
                         showLimitExceededWarning: false,
                         limitExceededWarningText: undefined,
+                        showPeopleTemplateMappingWarning: false,
+                        peopleTemplateMappingWarningText: undefined,
+                        warningMarkerTooltipText: undefined,
                         selectedOnce: true,
                         operator: filter.operator,
                         values: (filter.values as IDataFilterValueInternal[]).map((value: IDataFilterValueInternal) => {
@@ -972,8 +1922,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                     this.props.onUpdateFilters(dataFilters);
                 });
 
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            } catch (e) {
+            } catch {
                 Log.verbose(`[SearchFiltersContainer.getFiltersDeepLink]`, `Filters format in the query string is invalid.`);
             }
         }
@@ -991,32 +1940,32 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 values: (filter.values || []).map(value => {
                     return {
                         ...value,
-                        value: this.sanitizeTaxonomyRefinementValue(value.value as string)
+                        value: this.sanitizeTaxonomyRefinementValue(`${value.value ?? ''}`)
                     };
                 })
-            } as IDataFilter;
+            };
         });
 
         let filtersDeepLinkUrl: string;
         if (sanitizedSubmittedFilters.length > 0) {
-            filtersDeepLinkUrl = UrlHelper.addOrReplaceQueryStringParam(window.location.href, this.deeplinkQueryStringParam, JSON.stringify(sanitizedSubmittedFilters));
+            filtersDeepLinkUrl = UrlHelper.addOrReplaceQueryStringParam(globalThis.location.href, this.deeplinkQueryStringParam, JSON.stringify(sanitizedSubmittedFilters));
         } else {
-            filtersDeepLinkUrl = UrlHelper.removeQueryStringParam(this.deeplinkQueryStringParam, window.location.href);
+            filtersDeepLinkUrl = UrlHelper.removeQueryStringParam(this.deeplinkQueryStringParam, globalThis.location.href);
         }
 
         this._lastProcessedDeepLink = UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, filtersDeepLinkUrl) || '';
 
         this._isUpdatingDeepLink = true;
-        window.history.pushState({ path: filtersDeepLinkUrl }, '', filtersDeepLinkUrl);
+        globalThis.history.pushState({ path: filtersDeepLinkUrl }, '', filtersDeepLinkUrl);
         this._isUpdatingDeepLink = false;
     }
 
     private resetFiltersDeepLink() {
         // Reset filters query string
-        const filtersDeepLinkUrl = UrlHelper.removeQueryStringParam(this.deeplinkQueryStringParam, window.location.href);
+        const filtersDeepLinkUrl = UrlHelper.removeQueryStringParam(this.deeplinkQueryStringParam, globalThis.location.href);
         this._lastProcessedDeepLink = '';
         this._isUpdatingDeepLink = true;
-        window.history.pushState({ path: filtersDeepLinkUrl }, '', filtersDeepLinkUrl);
+        globalThis.history.pushState({ path: filtersDeepLinkUrl }, '', filtersDeepLinkUrl);
         this._isUpdatingDeepLink = false;
     }
 
@@ -1034,20 +1983,20 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                     this.getFiltersDeepLink();
                 }
             };
-        })(window.history);
+        })(globalThis.history);
 
         // When the browser 'back' or 'forward' button is pressed
-        window.onpopstate = (ev) => {
+        globalThis.onpopstate = () => {
 
-            const queryString = UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, window.location.href);
+            const queryString = UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, globalThis.location.href);
 
             // Initial state where no filter are selected
             if (!queryString) {
 
-                this.setState({
-                    currentUiFilters: this.resetSelectedFilterValues(this.state.currentUiFilters),
+                this.setState(prevState => ({
+                    currentUiFilters: this.resetSelectedFilterValues(prevState.currentUiFilters),
                     submittedFilters: []
-                });
+                }));
 
                 // Notify connected Web Parts
                 this.props.onUpdateFilters([]);

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Maximální počet hodnot je 1000",
                 FilterLimitReachedWarningToggle: "Zobrazit upozornění při dosažení limitu",
                 FilterLimitReachedWarningMessage: "Byl dosažen limit výsledků — nejsou zobrazeny všechny odpovídající položky. Upřesněte hledání a zúžte seznam.",
+                PeopleTemplateQUserMappingWarning: "Upozornění šablony osob: hodnoty nevypadají jako identity uživatelů. Tato vlastnost pravděpodobně není mapována na procházenou vlastnost Q_USER.",
                 FilterDisplayName: "Zobrazovaný název",
                 FilterTemplate: "Šablona",
                 FilterExpandByDefault: "Rozbalit ve výchozím nastavení",

--- a/search-parts/src/webparts/searchFilters/loc/da-dk.js
+++ b/search-parts/src/webparts/searchFilters/loc/da-dk.js
@@ -31,6 +31,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Det maksimale antal værdier er 1000",
                 FilterLimitReachedWarningToggle: "Vis advarsel, når grænsen er nået",
                 FilterLimitReachedWarningMessage: "Resultatgrænsen er nået — ikke alle matchende elementer vises. Forfin din søgning for at indsnævre listen.",
+                PeopleTemplateQUserMappingWarning: "Advarsel for personskabelon: værdierne ligner ikke brugeridentiteter. Egenskaben er sandsynligvis ikke knyttet til en Q_USER-crawlet egenskab.",
                 FilterTemplate: "Skabelon",
                 FilterExpandByDefault: "Udvid som standard",
                 ExpandAllNodesByDefault: "Udvid alle noder som standard",

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Die maximale Anzahl von Werten ist 1000",
                 FilterLimitReachedWarningToggle: "Warnung anzeigen, wenn das Limit erreicht ist",
                 FilterLimitReachedWarningMessage: "Ergebnislimit erreicht — nicht alle passenden Elemente werden angezeigt. Verfeinern Sie Ihre Suche, um die Liste einzugrenzen.",
+                PeopleTemplateQUserMappingWarning: "Warnung für Personenvorlage: Die Werte sehen nicht wie Benutzeridentitäten aus. Diese Eigenschaft ist wahrscheinlich nicht einer Q_USER-Crawleigenschaft zugeordnet.",
                 FilterDisplayName: "Anzeige name",
                 FilterTemplate: "Vorlage",
                 FilterExpandByDefault: "Standardmäßig erweitert",

--- a/search-parts/src/webparts/searchFilters/loc/en-us.js
+++ b/search-parts/src/webparts/searchFilters/loc/en-us.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "The maximum number of values is 1000",
                 FilterLimitReachedWarningToggle: "Show warning when limit is reached",
                 FilterLimitReachedWarningMessage: "Result limit reached — not all matching items are shown. Refine your search to narrow the list",
+                PeopleTemplateQUserMappingWarning: "People template warning: values do not look like user identities. This property may not be mapped to a Q_USER crawled property.",
                 FilterDisplayName: "Display name",
                 FilterTemplate: "Template",
                 FilterExpandByDefault: "Expand by default",

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "El número máximo de valores es 1000",
                 FilterLimitReachedWarningToggle: "Mostrar advertencia cuando se alcance el límite",
                 FilterLimitReachedWarningMessage: "Se alcanzó el límite de resultados — no se muestran todos los elementos coincidentes. Refine su búsqueda para reducir la lista.",
+                PeopleTemplateQUserMappingWarning: "Advertencia de plantilla de personas: los valores no parecen identidades de usuario. Es probable que esta propiedad no esté asignada a una propiedad rastreada Q_USER.",
                 FilterDisplayName: "Nombre para mostrar",
                 FilterTemplate: "Plantilla",
                 FilterExpandByDefault: "Expandir por defecto",

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Arvojen enimmäismäärä on 1000",
                 FilterLimitReachedWarningToggle: "Näytä varoitus, kun raja saavutetaan",
                 FilterLimitReachedWarningMessage: "Tulosten enimmäismäärä on saavutettu — kaikkia vastaavia kohteita ei näytetä. Rajaa luetteloa tarkentamalla hakua.",
+                PeopleTemplateQUserMappingWarning: "Henkilömallin varoitus: arvot eivät näytä käyttäjäidentiteeteiltä. Tätä ominaisuutta ei todennäköisesti ole yhdistetty Q_USER-indeksoituun ominaisuuteen.",
                 FilterDisplayName: "Näyttönimi",
                 FilterTemplate: "Templaatti",
                 FilterExpandByDefault: "Näytä oletuksena laajennettuna",

--- a/search-parts/src/webparts/searchFilters/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchFilters/loc/fr-fr.js
@@ -32,6 +32,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Le nombre maximum de valeurs est 1000",
                 FilterLimitReachedWarningToggle: "Afficher un avertissement lorsque la limite est atteinte",
                 FilterLimitReachedWarningMessage: "Limite de résultats atteinte — tous les éléments correspondants ne sont pas affichés. Affinez votre recherche pour réduire la liste.",
+                PeopleTemplateQUserMappingWarning: "Avertissement du modèle Personnes : les valeurs ne ressemblent pas à des identités utilisateur. Cette propriété n'est probablement pas mappée à une propriété analysée Q_USER.",
                 FilterDisplayName: "Nom d'affichage",
                 FilterTemplate: "Modèle",
                 FilterExpandByDefault: "Agrandir par défaut",

--- a/search-parts/src/webparts/searchFilters/loc/it-it.js
+++ b/search-parts/src/webparts/searchFilters/loc/it-it.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Il numero massimo di valori è 1000",
                 FilterLimitReachedWarningToggle: "Mostra avviso quando il limite viene raggiunto",
                 FilterLimitReachedWarningMessage: "Limite risultati raggiunto — non vengono mostrati tutti gli elementi corrispondenti. Affina la ricerca per restringere l'elenco.",
+                PeopleTemplateQUserMappingWarning: "Avviso modello Persone: i valori non sembrano identità utente. Probabilmente questa proprietà non è mappata a una proprietà di ricerca per indicizzazione Q_USER.",
                 FilterDisplayName: "Nome visualizzato",
                 FilterTemplate: "Modello",
                 FilterExpandByDefault: "Espandi per impostazione predefinita",

--- a/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
@@ -29,6 +29,7 @@ declare interface ISearchFiltersWebPartStrings {
             FilterMaxBucketsWarning: string;
             FilterLimitReachedWarningToggle: string;
             FilterLimitReachedWarningMessage: string;
+            PeopleTemplateQUserMappingWarning: string;
             FilterDisplayName: string;
             FilterTemplate: string;
             FilterExpandByDefault: string;

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Maksimalt antall verdier er 1000",
                 FilterLimitReachedWarningToggle: "Vis advarsel når grensen er nådd",
                 FilterLimitReachedWarningMessage: "Resultatgrensen er nådd — ikke alle samsvarende elementer vises. Avgrens listen ved å gjøre søket mer spesifikt.",
+                PeopleTemplateQUserMappingWarning: "Advarsel for personmal: verdiene ser ikke ut som brukeridentiteter. Denne egenskapen er sannsynligvis ikke mappet til en Q_USER-crawlet egenskap.",
                 FilterDisplayName: "Visningsnavn",
                 FilterTemplate: "Mal",
                 FilterExpandByDefault: "Utvid som standard",

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Het maximale aantal waarden is 1000",
                 FilterLimitReachedWarningToggle: "Waarschuwing tonen wanneer de limiet is bereikt",
                 FilterLimitReachedWarningMessage: "Resultaatlimiet bereikt — niet alle overeenkomende items worden weergegeven. Verfijn uw zoekopdracht om de lijst te beperken.",
+                PeopleTemplateQUserMappingWarning: "Waarschuwing voor personen-sjabloon: waarden lijken geen gebruikersidentiteiten te zijn. Deze eigenschap is waarschijnlijk niet toegewezen aan een Q_USER-crawled property.",
                 FilterDisplayName: "Weergavenaam",
                 FilterTemplate: "Sjabloon",
                 FilterExpandByDefault: "Standaard uitklappen",

--- a/search-parts/src/webparts/searchFilters/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchFilters/loc/pl-pl.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Maksymalna liczba wartości to 1000",
                 FilterLimitReachedWarningToggle: "Pokaż ostrzeżenie po osiągnięciu limitu",
                 FilterLimitReachedWarningMessage: "Osiągnięto limit wyników — nie wszystkie pasujące elementy są wyświetlane. Doprecyzuj wyszukiwanie, aby zawęzić listę.",
+                PeopleTemplateQUserMappingWarning: "Ostrzeżenie szablonu osób: wartości nie wyglądają jak tożsamości użytkowników. Ta właściwość prawdopodobnie nie jest mapowana do przeszukiwanej właściwości Q_USER.",
                 FilterDisplayName: "Tytuł",
                 FilterTemplate: "Szablon",
                 FilterExpandByDefault: "Domyślnie rozwinięte",

--- a/search-parts/src/webparts/searchFilters/loc/pt-br.js
+++ b/search-parts/src/webparts/searchFilters/loc/pt-br.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "O número máximo de valores é 1000",
                 FilterLimitReachedWarningToggle: "Mostrar aviso quando o limite for atingido",
                 FilterLimitReachedWarningMessage: "Limite de resultados atingido — nem todos os itens correspondentes são exibidos. Refine sua pesquisa para restringir a lista.",
+                PeopleTemplateQUserMappingWarning: "Aviso do modelo de pessoas: os valores não parecem identidades de usuário. Esta propriedade provavelmente não está mapeada para uma propriedade rastreada Q_USER.",
                 FilterDisplayName: "Nome de exibição",
                 FilterTemplate: "Modelo",
                 FilterExpandByDefault: "Expandido por padrão",

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -30,6 +30,7 @@ define([], function () {
                 FilterMaxBucketsWarning: "Det maximala antalet värden är 1000",
                 FilterLimitReachedWarningToggle: "Visa varning när gränsen uppnås",
                 FilterLimitReachedWarningMessage: "Resultatgränsen har nåtts — alla matchande objekt visas inte. Förfina sökningen för att begränsa listan.",
+                PeopleTemplateQUserMappingWarning: "Varning för personmall: värdena ser inte ut som användaridentiteter. Den här egenskapen är troligen inte mappad till en Q_USER-genomsökt egenskap.",
                 FilterDisplayName: "Visningsnamn",
                 FilterTemplate: "Filtermall",
                 FilterExpandByDefault: "Expandera som standard",


### PR DESCRIPTION
## Summary
- add warning for People template when refiner values suggest an incorrect mapping
- keep values list visible while showing the warning
- show warning marker and tooltip independently from limit-warning toggle
- gate mapping warning to edit mode and reduce false positives for valid Q_USER-like values
- add localized string for PeopleTemplateQUserMappingWarning across supported locales
- align SearchFiltersContainer state interface with busy-state fields used in code

## Validation
- npm run build succeeded on feature/4839-people-template-mapping-warning
