### PR TITLE
fix: harden theme fallbacks to prevent semanticColors runtime crashes

### DIFF
--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "PnP Modern Search - Search Web Parts - v4",
         "id": "59903278-dd5d-4e9e-bef6-562aae716b8b",
-        "version": "4.23.0.0",
+        "version": "4.23.1.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": true,
         "isDomainIsolated": false,

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.0",
+    "version": "4.23.1",
     "private": true,
     "engines": {
         "node": ">=22.14.0 < 23.0.0"

--- a/search-parts/src/common/BaseWebPart.ts
+++ b/search-parts/src/common/BaseWebPart.ts
@@ -18,6 +18,7 @@ import { isEqual } from '@microsoft/sp-lodash-subset';
 import { Log } from '@microsoft/sp-core-library';
 import { DisplayMode } from '@microsoft/sp-core-library';
 import { AudienceTargetingService } from '../services/audienceTargetingService/AudienceTargetingService';
+import { getTheme } from '@fluentui/react';
 
 /**
  * Generic abstract class for all Web Parts in the solution
@@ -322,7 +323,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
         this._themeProvider = this.context.serviceScope.consume(ThemeProvider.serviceKey);
 
         // If it exists, get the theme variant
-        this._themeVariant = this._themeProvider.tryGetTheme();
+        this._themeVariant = (this._themeProvider.tryGetTheme() as IReadonlyTheme) || (getTheme() as unknown as IReadonlyTheme);
 
         // Register a handler to be notified if the theme variant changes
         this._themeProvider.themeChangedEvent.add(this, this._handleThemeChangedEvent.bind(this));
@@ -335,7 +336,7 @@ export abstract class BaseWebPart<T extends IBaseWebPartProps> extends BaseClien
     private _handleThemeChangedEvent(args: ThemeChangedEventArgs): void {
 
         if (!isEqual(this._themeVariant, args.theme)) {
-            this._themeVariant = args.theme;
+            this._themeVariant = (args.theme as IReadonlyTheme) || (getTheme() as unknown as IReadonlyTheme);
             this.render();
         }
     }

--- a/search-parts/src/components/CollapsibleContentComponent.tsx
+++ b/search-parts/src/components/CollapsibleContentComponent.tsx
@@ -233,7 +233,9 @@ export class CollapsibleContentComponent extends React.Component<ICollapsibleCon
         // Keep a reference to the divider props so the panel can be collapsed programmatically
         // (e.g. on Escape) and stay in sync with the GroupedList internal collapse state (#3900).
         this.headerDividerProps = props;
-        let textColor: string = this.props.themeVariant && this.props.themeVariant.isInverted ? (this.props.themeVariant ? this.props.themeVariant.semanticColors.bodyText : '#323130') : this.props.themeVariant.semanticColors.inputText;
+        let textColor: string = this.props.themeVariant?.isInverted
+            ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
+            : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
         const warningDescriptionId = `pnp-warning-${(this.props.groupName || 'group').toString().replace(/[^a-zA-Z0-9_-]/g, '-')}`;
         const textComponentStyles: IStyleFunctionOrObject<ITextProps, ITextStyles> = {
             root: {

--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -22,6 +22,7 @@ import {
   ITheme,
   Selection,
   IconButton,
+  getTheme,
 } from "@fluentui/react";
 import * as Handlebars from "handlebars";
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
@@ -561,7 +562,7 @@ export class DetailsListComponent extends React.Component<
 
     let shimmeredDetailsListProps: IShimmeredDetailsListProps = {
       componentRef: this._detailsListRef,
-      theme: this.props.themeVariant as ITheme,
+      theme: (this.props.themeVariant as ITheme) || getTheme(),
       items: items,
       compact: this.props.isCompact,
       columns: columns,
@@ -774,9 +775,9 @@ export class DetailsListComponent extends React.Component<
     if (showCheckbox) {
       shimmerElementsRow.push(
         <ShimmerElementsGroup
-          theme={this.props.themeVariant as ITheme}
+          theme={(this.props.themeVariant as ITheme) || getTheme()}
           backgroundColor={
-            this.props.themeVariant.semanticColors.bodyBackground
+            this.props.themeVariant?.semanticColors?.bodyBackground ?? "#ffffff"
           }
           key={"checkboxGap"}
           shimmerElements={[
@@ -830,11 +831,11 @@ export class DetailsListComponent extends React.Component<
 
       shimmerElementsRow.push(
         <ShimmerElementsGroup
-          theme={this.props.themeVariant as ITheme}
+          theme={(this.props.themeVariant as ITheme) || getTheme()}
           key={columnIdx}
           width={`${groupWidth}px`}
           backgroundColor={
-            this.props.themeVariant.semanticColors.bodyBackground
+            this.props.themeVariant?.semanticColors?.bodyBackground ?? "#ffffff"
           }
           shimmerElements={shimmerElements}
         />
@@ -845,8 +846,8 @@ export class DetailsListComponent extends React.Component<
       <ShimmerElementsGroup
         key={"endGap"}
         width={"100%"}
-        backgroundColor={this.props.themeVariant.semanticColors.bodyBackground}
-        theme={this.props.themeVariant as ITheme}
+        backgroundColor={this.props.themeVariant?.semanticColors?.bodyBackground ?? "#ffffff"}
+        theme={(this.props.themeVariant as ITheme) || getTheme()}
         shimmerElements={[
           { type: ShimmerElementType.gap, width: "100%", height: gapHeight },
         ]}
@@ -854,7 +855,7 @@ export class DetailsListComponent extends React.Component<
     );
     return (
       <Shimmer
-        theme={this.props.themeVariant as ITheme}
+        theme={(this.props.themeVariant as ITheme) || getTheme()}
         customElementsGroup={
           <div style={{ display: "flex" }}>{shimmerElementsRow}</div>
         }
@@ -869,7 +870,7 @@ export class DetailsListComponent extends React.Component<
           ...rowProps.styles,
           root: {
             backgroundColor:
-              this.props.themeVariant.semanticColors.bodyBackgroundChecked,
+              this.props.themeVariant?.semanticColors?.bodyBackgroundChecked ?? "#f3f2f1",
           },
         };
       }
@@ -885,7 +886,7 @@ export class DetailsListComponent extends React.Component<
       }
 
       return (
-        <DetailsRowCheck {...props} theme={this.props.themeVariant as ITheme} />
+        <DetailsRowCheck {...props} theme={(this.props.themeVariant as ITheme) || getTheme()} />
       );
     };
 
@@ -900,7 +901,7 @@ export class DetailsListComponent extends React.Component<
             : undefined
         }
       >
-        <DetailsRow {...rowProps} theme={this.props.themeVariant as ITheme} />
+        <DetailsRow {...rowProps} theme={(this.props.themeVariant as ITheme) || getTheme()} />
       </div>
     );
   }
@@ -932,11 +933,11 @@ export class DetailsListComponent extends React.Component<
                   flexShrink: 0,
                 },
                 icon: {
-                  color: this.props.themeVariant?.semanticColors.bodySubtext,
+                  color: this.props.themeVariant?.semanticColors?.bodySubtext,
                   fontSize: "12px",
                 },
                 rootHovered: {
-                  backgroundColor: this.props.themeVariant?.semanticColors.listHeaderBackgroundHovered,
+                  backgroundColor: this.props.themeVariant?.semanticColors?.listHeaderBackgroundHovered,
                 },
               }}
               ariaLabel={`More information about ${column.name}`}
@@ -950,16 +951,15 @@ export class DetailsListComponent extends React.Component<
   private _onRenderColumnHeaderTooltip = (tooltipHostProps: ITooltipHostProps): JSX.Element => {
     const customStyles: Partial<ITooltipStyles> = {};
     customStyles.root = {
-      backgroundColor: this.props.themeVariant.semanticColors.listBackground,
-      color: this.props.themeVariant.semanticColors.listText,
+      backgroundColor: this.props.themeVariant?.semanticColors?.listBackground ?? "#ffffff",
+      color: this.props.themeVariant?.semanticColors?.listText ?? "#323130",
       selectors: {
         ":hover": {
           backgroundColor:
-            this.props.themeVariant.semanticColors
-              .listHeaderBackgroundHovered,
+            this.props.themeVariant?.semanticColors?.listHeaderBackgroundHovered ?? "#f3f2f1",
         },
         i: {
-          color: this.props.themeVariant.semanticColors.listText,
+          color: this.props.themeVariant?.semanticColors?.listText ?? "#323130",
         },
       },
     };
@@ -974,7 +974,7 @@ export class DetailsListComponent extends React.Component<
     return (
       <TooltipHost
         {...tooltipHostProps}
-        theme={this.props.themeVariant as ITheme}
+        theme={(this.props.themeVariant as ITheme) || getTheme()}
         styles={customStyles}
       />
     );
@@ -988,7 +988,7 @@ export class DetailsListComponent extends React.Component<
 
     return defaultRender!({
       ...props,
-      theme: this.props.themeVariant as ITheme,
+      theme: (this.props.themeVariant as ITheme) || getTheme(),
     });
   }
 
@@ -998,22 +998,22 @@ export class DetailsListComponent extends React.Component<
   ): JSX.Element {
 
     return (
-      <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true} stickyBackgroundColor={this.props.themeVariant.semanticColors.listBackground}>
+      <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true} stickyBackgroundColor={this.props.themeVariant?.semanticColors?.listBackground ?? "#ffffff"}>
         {defaultRender({
           ...props,
           className: detailsListStyles.detailsListHeader,
           styles: {
             root: {
               backgroundColor: "transparent",
-              color: this.props.themeVariant.semanticColors.bodyText,
-              borderBottom: `1px solid ${this.props.themeVariant.semanticColors.bodyDivider}`,
+              color: this.props.themeVariant?.semanticColors?.bodyText ?? "#323130",
+              borderBottom: `1px solid ${this.props.themeVariant?.semanticColors?.bodyDivider ?? "#edebe9"}`,
               selectors: {
                 i: {
-                  color: this.props.themeVariant.semanticColors.bodyText,
+                  color: this.props.themeVariant?.semanticColors?.bodyText ?? "#323130",
                   fontWeight: "600",
                 },
                 [`.${detailsListStyles.detailsListHeader} .ms-DetailsHeader-cellTitle`]: {
-                  color: this.props.themeVariant.semanticColors.bodyText,
+                  color: this.props.themeVariant?.semanticColors?.bodyText ?? "#323130",
                   fontWeight: "600",
                 }
               }

--- a/search-parts/src/components/DocumentCardComponent.tsx
+++ b/search-parts/src/components/DocumentCardComponent.tsx
@@ -214,7 +214,7 @@ export class DocumentCardComponent extends React.Component<
     };
 
     let previewProps: IDocumentCardPreviewProps = {
-      theme: this.props.themeVariant as ITheme,
+      theme: (this.props.themeVariant as ITheme) || getTheme(),
       previewImages: [
         {
           name: processedProps.title,
@@ -275,8 +275,8 @@ export class DocumentCardComponent extends React.Component<
         documentCardStyles.root = {
           borderWidth: "2px",
           borderColor:
-            this.props.themeVariant.semanticColors
-              .primaryButtonBackgroundHovered,
+            this.props.themeVariant?.semanticColors
+              ?.primaryButtonBackgroundHovered ?? "#0f6cbd",
         };
       }
     }
@@ -288,7 +288,7 @@ export class DocumentCardComponent extends React.Component<
         data-selection-toggle
       >
         <DocumentCard
-          theme={this.props.themeVariant as ITheme}
+          theme={(this.props.themeVariant as ITheme) || getTheme()}
           onClick={previewFunc}
           styles={documentCardStyles}
           type={
@@ -331,7 +331,7 @@ export class DocumentCardComponent extends React.Component<
               ></div>
             ) : null}
             <Link
-              theme={this.props.themeVariant as ITheme}
+              theme={(this.props.themeVariant as ITheme) || getTheme()}
               href={processedProps.href}
               target="_blank"
               styles={{
@@ -345,7 +345,7 @@ export class DocumentCardComponent extends React.Component<
               }}
             >
               <DocumentCardTitle
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 title={processedProps.title}
                 //  shouldTruncate={true}
               />
@@ -365,7 +365,7 @@ export class DocumentCardComponent extends React.Component<
             ) : null}
             {processedProps.author ? (
               <DocumentCardActivity
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 activity={activityText}
                 people={[
                   {

--- a/search-parts/src/components/DocumentCardShimmersComponent.tsx
+++ b/search-parts/src/components/DocumentCardShimmersComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup, ITheme } from '@fluentui/react';
+import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup, ITheme, getTheme } from '@fluentui/react';
 import * as ReactDOM from 'react-dom';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
@@ -48,14 +48,14 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
             minWidth: 150
         }}>
             <Shimmer
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 customElementsGroup={
                     <ShimmerElementsGroup
                         shimmerElements={[
                             { type: ElemType.line, width: '100%', height: 196 },
                         ]}
                         backgroundColor={this._backgroundColor}
-                        theme={this.props.themeVariant as ITheme}
+                        theme={(this.props.themeVariant as ITheme) || getTheme()}
                     />
                 }
                 isDataLoaded={false}
@@ -67,11 +67,11 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                 paddingLeft: 16,
             }}>
                 <Shimmer
-                    theme={this.props.themeVariant as ITheme}
+                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                     customElementsGroup={
                         <div style={{ display: 'flex' }}>
                             <ShimmerElementsGroup
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 flexWrap={true}
                                 width="100%"
                                 backgroundColor={this._backgroundColor}
@@ -96,16 +96,16 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                 paddingLeft: 16
             }}>
                 <Shimmer
-                    theme={this.props.themeVariant as ITheme}
+                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                     customElementsGroup={
                         <div style={{ display: 'flex' }}>
                             <ShimmerElementsGroup
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 shimmerElements={[{ type: ElemType.circle, height: 32 }, { type: ElemType.gap, width: 10, height: 40 }]}
                                 backgroundColor={this._backgroundColor}
                             />
                             <ShimmerElementsGroup
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 flexWrap={true}
                                 backgroundColor={this._backgroundColor}
                                 width="100%"
@@ -138,7 +138,7 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
             }}
         >
             <Shimmer
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 customElementsGroup={
                     <ShimmerElementsGroup
                         backgroundColor={this._backgroundColor}
@@ -155,12 +155,12 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                 width: '100%'
             }}>
                 <Shimmer
-                    theme={this.props.themeVariant as ITheme}
+                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                     customElementsGroup={
                         <div>
                             <div style={{ display: 'flex' }}>
                                 <ShimmerElementsGroup
-                                    theme={this.props.themeVariant as ITheme}
+                                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                                     flexWrap={true}
                                     backgroundColor={this._backgroundColor}
                                     width="100%"
@@ -175,17 +175,17 @@ export class DocumentCardShimmersComponent extends React.Component<DocumentCardS
                     }
                 />
                 <Shimmer
-                    theme={this.props.themeVariant as ITheme}
+                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                     customElementsGroup={
                         <div style={{ display: 'flex', marginTop: 10 }}>
                             <ShimmerElementsGroup
                                 backgroundColor={this._backgroundColor}
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 shimmerElements={[{ type: ElemType.circle, height: 32 }, { type: ElemType.gap, width: 10, height: 40 }]}
                             />
                             <ShimmerElementsGroup
                                 backgroundColor={this._backgroundColor}
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 flexWrap={true}
                                 width="100%"
                                 shimmerElements={[

--- a/search-parts/src/components/DownloadSelectedItemsButtonComponent.tsx
+++ b/search-parts/src/components/DownloadSelectedItemsButtonComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { BaseWebComponent } from "@pnp/modern-search-extensibility";
-import { ActionButton, IIconProps, ITheme } from "@fluentui/react";
+import { ActionButton, IIconProps, ITheme, getTheme } from "@fluentui/react";
 import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext";
 import { AadTokenProviderFactory, HttpClient, HttpClientResponse, IHttpClientOptions, ISPHttpClientOptions, SPHttpClient, SPHttpClientResponse } from "@microsoft/sp-http";
 import { Guid, Log } from "@microsoft/sp-core-library";
@@ -95,7 +95,7 @@ export class DownloadSelectedItemsButtonComponent extends React.Component<IExpor
                 !requiredPropertiesAvailable
               }
               onClick={this._downloadSelectedItems}
-              theme={this.props.themeVariant as ITheme}
+              theme={(this.props.themeVariant as ITheme) || getTheme()}
             />
           );
         }

--- a/search-parts/src/components/FileIconComponent.tsx
+++ b/search-parts/src/components/FileIconComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { Icon, ITheme, IIconStyles, ImageFit } from '@fluentui/react';
+import { Icon, ITheme, IIconStyles, ImageFit, getTheme } from '@fluentui/react';
 import { getFileTypeIconAsUrl, FileTypeIconSize, FileIconType, IFileTypeIconOptions } from '@fluentui/react-file-type-icons';
 import { FileTypeIconHelper } from '../helpers/FileTypeIconHelper';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
@@ -98,7 +98,7 @@ export class FileIcon extends React.Component<IFileIconProps, IFileIconState> {
             iconProps = buildFileTypeIconProps({ type: FileIconType.genericFile, size: size });
         }
 
-        return <Icon styles={this.props.styles} theme={this.props.themeVariant as ITheme} {...iconProps} />;
+        return <Icon styles={this.props.styles} theme={(this.props.themeVariant as ITheme) || getTheme()} {...iconProps} />;
     }
 }
 

--- a/search-parts/src/components/IconComponent.tsx
+++ b/search-parts/src/components/IconComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { ITheme } from '@fluentui/react';
+import { ITheme, getTheme } from '@fluentui/react';
 import { Icon } from '@fluentui/react/lib/Icon'
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 
@@ -29,7 +29,7 @@ export interface IIconState {
 export class FileIcon extends React.Component<IIconProps, IIconState> {
 
     public render() {
-        return <Icon iconName={this.props.name} theme={this.props.themeVariant as ITheme} />;
+        return <Icon iconName={this.props.name} theme={(this.props.themeVariant as ITheme) || getTheme()} />;
     }
 }
 

--- a/search-parts/src/components/PaginationComponent.tsx
+++ b/search-parts/src/components/PaginationComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
 import Pagination from 'react-js-pagination';
-import { Icon, ITheme } from '@fluentui/react';
+import { Icon, ITheme, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import styles from './PaginationComponent.module.scss';
 
@@ -146,10 +146,10 @@ export class PaginationComponent extends React.Component<IPaginationComponentPro
                         <div className={`${isThemeInverted ? styles.inverted : styles.standard}`}>
                             <Pagination
                                 activePage={this.state.currentPageNumber}
-                                firstPageText={<Icon theme={this.props.themeVariant as ITheme} iconName='DoubleChevronLeft' onClick={() => { this._pagelink = firstLink; }} />}
-                                lastPageText={<Icon theme={this.props.themeVariant as ITheme} iconName='DoubleChevronRight' onClick={() => { this._pagelink = lastLink; }} />}
-                                prevPageText={<Icon theme={this.props.themeVariant as ITheme} iconName='ChevronLeft' onClick={() => { this._pagelink = prevLink; }} />}
-                                nextPageText={<Icon theme={this.props.themeVariant as ITheme} iconName='ChevronRight' onClick={() => { this._pagelink = nextLink; }} />}
+                                firstPageText={<Icon theme={(this.props.themeVariant as ITheme) || getTheme()} iconName='DoubleChevronLeft' onClick={() => { this._pagelink = firstLink; }} />}
+                                lastPageText={<Icon theme={(this.props.themeVariant as ITheme) || getTheme()} iconName='DoubleChevronRight' onClick={() => { this._pagelink = lastLink; }} />}
+                                prevPageText={<Icon theme={(this.props.themeVariant as ITheme) || getTheme()} iconName='ChevronLeft' onClick={() => { this._pagelink = prevLink; }} />}
+                                nextPageText={<Icon theme={(this.props.themeVariant as ITheme) || getTheme()} iconName='ChevronRight' onClick={() => { this._pagelink = nextLink; }} />}
                                 activeLinkClass={`${styles.active} ${isThemeInverted ? styles.active__inverted : ''}`}
                                 itemsCountPerPage={this.props.itemsCountPerPage}
                                 totalItemsCount={totalCount}

--- a/search-parts/src/components/PanelComponent.tsx
+++ b/search-parts/src/components/PanelComponent.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilterInfo, ExtensibilityConstants } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { Panel, PanelType, IPanelProps, Text, ITheme } from '@fluentui/react';
+import { Panel, PanelType, IPanelProps, Text, ITheme, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { Log } from "@microsoft/sp-core-library";
 import styles from "./PanelComponent.module.scss";
@@ -103,8 +103,10 @@ export class PanelComponent extends React.Component<IPanelComponentProps, IPanel
 
     public render() {
 
+        const resolvedTheme: ITheme = this.props.themeVariant ? this.props.themeVariant as ITheme : getTheme();
+
         let panelProps: IPanelProps = {
-            theme: this.props.themeVariant as ITheme,
+            theme: resolvedTheme,
             isOpen: this.state.showPanel,
             type: this.props.size ? Number(this.props.size) : PanelType.medium,
             isHiddenOnDismiss: false,
@@ -134,7 +136,7 @@ export class PanelComponent extends React.Component<IPanelComponentProps, IPanel
         }
 
         return <div>
-            <Text theme={this.props.themeVariant as ITheme}>
+            <Text theme={resolvedTheme}>
                 <div
                     role={"menubar"}
                     tabIndex={0}

--- a/search-parts/src/components/PersonaComponent.tsx
+++ b/search-parts/src/components/PersonaComponent.tsx
@@ -8,6 +8,7 @@ import {
     Icon,
     ITheme,
     PersonaPresence,
+    getTheme,
 } from "@fluentui/react";
 import { TemplateService } from "../services/templateService/TemplateService";
 import * as ReactDOM from "react-dom";
@@ -198,7 +199,7 @@ export class PersonaComponent extends React.Component<IPersonaComponentProps, IP
         } : {};
 
         const persona: IPersonaProps = {
-            theme: this.props.themeVariant as ITheme,
+            theme: (this.props.themeVariant as ITheme) || getTheme(),
             imageUrl: hideCoin ? undefined : imageUrlResolved,
             imageShouldFadeIn: false,
             imageShouldStartVisible: true,

--- a/search-parts/src/components/PersonaShimmersComponent.tsx
+++ b/search-parts/src/components/PersonaShimmersComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup, ITheme } from '@fluentui/react';
+import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup, ITheme, getTheme } from '@fluentui/react';
 import * as ReactDOM from 'react-dom';
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
 import { BaseWebComponent } from '@pnp/modern-search-extensibility';
@@ -67,16 +67,16 @@ export class PersonaCardShimmersComponent extends React.Component<IPersonaCardSh
             }}>
 
                 <Shimmer
-                    theme={this.props.themeVariant as ITheme}
+                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                     customElementsGroup={
                         <div style={{ display: 'flex', marginTop: 10 }}>
                             <ShimmerElementsGroup
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 backgroundColor={this._backgroundColor}
                                 shimmerElements={[{ type: ElemType.circle, height: personaSize }, { type: ElemType.gap, width: 10, height: personaSize }]}
                             />
                             <ShimmerElementsGroup
-                                theme={this.props.themeVariant as ITheme}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
                                 flexWrap={true}
                                 backgroundColor={this._backgroundColor}
                                 width="100%"

--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilterInfo, IDataFilterValueInfo, ExtensibilityConstants } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Text } from '@fluentui/react';
+import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Text, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
 
@@ -103,7 +103,7 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
 
     private _getTextColor(): string {
         if (this.props.themeVariant?.isInverted) {
-            return this.props.themeVariant.semanticColors.bodyText;
+            return this.props.themeVariant?.semanticColors?.bodyText ?? '#323130';
         }
 
         return this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
@@ -235,10 +235,10 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
                         width: '100%'
                     },
                     text: {
-                        color: this.props.count && this.props.count === 0 ? this.props.themeVariant.semanticColors.disabledText : textColor
+                        color: this.props.count && this.props.count === 0 ? this.props.themeVariant?.semanticColors?.disabledText ?? '#a19f9d' : textColor
                     }
                 }}
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 defaultChecked={this.props.selected}
                 disabled={this.props.disabled}
                 title={labelValue}
@@ -279,7 +279,7 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
                         disabled: this.props.disabled,
                         styles: {
                             field: {
-                                color: this.props.count && this.props.count === 0 ? this.props.themeVariant.semanticColors.disabledText : textColor
+                                color: this.props.count && this.props.count === 0 ? this.props.themeVariant?.semanticColors?.disabledText ?? '#a19f9d' : textColor
                             }
                         }
                     }

--- a/search-parts/src/components/filters/FilterComboBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterComboBoxComponent.tsx
@@ -379,7 +379,7 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                     <div style={{
                         fontWeight: 'normal',
                         height: '100%',
-                        color: this.props.themeVariant.semanticColors.bodyText,
+                        color: this.props.themeVariant?.semanticColors?.bodyText ?? '#323130',
                         fontSize: 12,
                         marginLeft: -8
                     }}>
@@ -398,7 +398,7 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                     <div style={{
                         fontWeight: 'normal',
                         height: '100%',
-                        color: this.props.themeVariant.semanticColors.bodyText,
+                        color: this.props.themeVariant?.semanticColors?.bodyText ?? '#323130',
                         fontSize: 12,
                         marginLeft: 5
                     }}>

--- a/search-parts/src/components/filters/FilterDateIntervalComponent.tsx
+++ b/search-parts/src/components/filters/FilterDateIntervalComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilterInfo, IDataFilterValueInfo, IDataFilterInternal, ExtensibilityConstants, FilterComparisonOperator } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { ITheme, ChoiceGroup, IChoiceGroupOption, MessageBar, MessageBarType } from '@fluentui/react';
+import { ITheme, ChoiceGroup, IChoiceGroupOption, MessageBar, MessageBarType, getTheme } from '@fluentui/react';
 import * as strings from 'CommonStrings';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { DateHelper } from '../../helpers/DateHelper';
@@ -122,7 +122,7 @@ export class FilterDateIntervalComponent extends React.Component<IFilterDateInte
 
         return <div>
             <ChoiceGroup
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 options={this.state.options}
                 selectedKey={this._getIntervalKeyForValue(dateAsString)}
                 onChange={this._onChange}
@@ -134,7 +134,7 @@ export class FilterDateIntervalComponent extends React.Component<IFilterDateInte
                     flexContainer: {
                         selectors: {
                             label: {
-                                color: this.props.themeVariant.semanticColors.bodyText
+                                color: this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
                             }
                         }
                     }

--- a/search-parts/src/components/filters/FilterDateRangeComponent.tsx
+++ b/search-parts/src/components/filters/FilterDateRangeComponent.tsx
@@ -3,7 +3,7 @@ import { BaseWebComponent, FilterComparisonOperator, IDataFilterInfo, IDataFilte
 import * as ReactDOM from 'react-dom';
 import { ITheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
-import { IDatePickerProps, IDatePickerStyles, IDatePickerStyleProps, DatePicker, Link, MessageBar, MessageBarType } from '@fluentui/react';
+import { IDatePickerProps, IDatePickerStyles, IDatePickerStyleProps, DatePicker, Link, MessageBar, MessageBarType, getTheme } from '@fluentui/react';
 import * as strings from 'CommonStrings';
 import { DateHelper } from '../../helpers/DateHelper';
 
@@ -89,13 +89,13 @@ export class FilterDateRangeComponent extends React.Component<IFilterDateRangeCo
                 textField: {
                     selectors: {
                         input: {
-                            backgroundColor: this.props.themeVariant.semanticColors.bodyBackground,
-                            color: this.props.themeVariant.semanticColors.bodyText
+                            backgroundColor: this.props.themeVariant?.semanticColors?.bodyBackground ?? '#ffffff',
+                            color: this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
 
 
                         },
                         'input::placeholder': {
-                            color: this.props.themeVariant.semanticColors.bodyText
+                            color: this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
                         }
                     }
                 }
@@ -127,7 +127,7 @@ export class FilterDateRangeComponent extends React.Component<IFilterDateRangeCo
             showGoToToday: true,
             borderless: true,
             styles: datePickerStyles,
-            theme: this.props.themeVariant as ITheme,
+            theme: (this.props.themeVariant as ITheme) || getTheme(),
             strings: strings.General.DatePickerStrings,
             formatDate: this._onFormatDate,
             allowTextInput: true,
@@ -140,7 +140,7 @@ export class FilterDateRangeComponent extends React.Component<IFilterDateRangeCo
             value: this.state.selectedToDate,
             showGoToToday: true,
             styles: datePickerStyles,
-            theme: this.props.themeVariant as ITheme,
+            theme: (this.props.themeVariant as ITheme) || getTheme(),
             borderless: true,
             strings: strings.General.DatePickerStrings,
             formatDate: this._onFormatDate,
@@ -163,7 +163,7 @@ export class FilterDateRangeComponent extends React.Component<IFilterDateRangeCo
         return <div>
             <DatePicker {...fromProps} />
             <DatePicker {...toProps} />
-            <Link theme={this.props.themeVariant as ITheme} onClick={this._clearFilters} disabled={!this.state.selectedToDate && !this.state.selectedFromDate}>{strings.Filters.ClearAllFiltersButtonLabel}</Link>
+            <Link theme={(this.props.themeVariant as ITheme) || getTheme()} onClick={this._clearFilters} disabled={!this.state.selectedToDate && !this.state.selectedFromDate}>{strings.Filters.ClearAllFiltersButtonLabel}</Link>
         </div>;
     }
 

--- a/search-parts/src/components/filters/FilterMultiComponent.tsx
+++ b/search-parts/src/components/filters/FilterMultiComponent.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { BaseWebComponent, ExtensibilityConstants } from "@pnp/modern-search-extensibility";
 import * as ReactDOM from "react-dom";
-import { DefaultButton, PrimaryButton } from '@fluentui/react';
+import { DefaultButton, PrimaryButton, ITheme, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
-import { ITheme } from '@fluentui/react';
 import styles from "./FilterMultiComponent.module.scss";
 import * as strings from 'CommonStrings';
 
@@ -74,13 +73,13 @@ export class FilterMulti extends React.Component<IFilterMultiProps, IFilterMulti
             <PrimaryButton
                 className={styles.applyBtn}
                 disabled={this.props.applyDisabled}
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 onClick={this._applyFilters}>
                 {strings.Filters.ApplyAllFiltersButtonLabel}
             </PrimaryButton>
             <DefaultButton
                 className={styles.clearBtn}
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 disabled={this.props.clearDisabled}
                 onClick={this._clearFilters}>
                 {strings.Filters.ClearAllFiltersButtonLabel}

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilterInfo, IDataFilterValueInfo, ExtensibilityConstants } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Spinner, SpinnerSize, Text } from '@fluentui/react';
+import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Spinner, SpinnerSize, Text, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
 
@@ -91,7 +91,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
 
     private readonly _renderCheckboxLabel = (props?: ICheckboxProps): JSX.Element => {
         const checkboxLabel = `${props?.label ?? ''}`;
-        return <Text block nowrap styles={{ root: { color: this.props.themeVariant?.isInverted ? this.props.themeVariant.semanticColors.bodyText : this.props.themeVariant?.semanticColors?.inputText ?? '#323130' } }} title={checkboxLabel}>{checkboxLabel}</Text>;
+        return <Text block nowrap styles={{ root: { color: this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130' } }} title={checkboxLabel}>{checkboxLabel}</Text>;
     }
 
     public constructor(props: IFilterPeopleTemplateProps) {
@@ -259,7 +259,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const safeFilterName = `${this.props.filterName ?? ''}`;
 
         let renderInput: JSX.Element = null;
-        let textColor: string = this.props.themeVariant?.isInverted ? this.props.themeVariant.semanticColors.bodyText : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
+        let textColor: string = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
         const labelValue = this._resolveDisplayLabel(filterValue.name, filterValue.value);
 
         if (this.props.isMulti) {
@@ -272,10 +272,10 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         width: '100%',
                     },
                     text: {
-                        color: this.props.count && this.props.count === 0 ? this.props.themeVariant.semanticColors.disabledText : textColor
+                        color: this.props.count && this.props.count === 0 ? this.props.themeVariant?.semanticColors?.disabledText ?? '#a19f9d' : textColor
                     }
                 }}
-                theme={this.props.themeVariant as ITheme}
+                theme={(this.props.themeVariant as ITheme) || getTheme()}
                 defaultChecked={this.props.selected}
                 disabled={this.props.disabled}
                 title={labelValue}
@@ -315,7 +315,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         disabled: this.props.disabled,
                         styles: {
                             field: {
-                                color: this.props.count && this.props.count === 0 ? this.props.themeVariant.semanticColors.disabledText : textColor
+                                color: this.props.count && this.props.count === 0 ? this.props.themeVariant?.semanticColors?.disabledText ?? '#a19f9d' : textColor
                             }
                         }
                     }

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -169,7 +169,7 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
 
     private readonly getTextColor = (): string => {
         if (this.props.themeVariant?.isInverted) {
-            return this.props.themeVariant.semanticColors.bodyText;
+            return this.props.themeVariant?.semanticColors?.bodyText ?? '#323130';
         }
 
         return this.props.themeVariant?.semanticColors?.inputText ?? '#323130';

--- a/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
+++ b/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
@@ -83,7 +83,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                             '.ms-ChoiceField + .ms-ChoiceField::before': {
                                                                 content: '"/"',
                                                                 padding: '0 4px',
-                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors.bodyText
+                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
                                                             },
                                                             'label::before, label::after': {
                                                                 display: 'none',
@@ -96,7 +96,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                                 color: this.props.themeVariant ? this.props.themeVariant.palette.themePrimary : '#005a9e'
                                                             },
                                                             'label span.ms-ChoiceFieldLabel, label span.ms-ChoiceFieldLabel:hover': {
-                                                                color: this.props.themeVariant.isInverted ? '#fff' : this.props.themeVariant.semanticColors.bodyText
+                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
                                                             }
                                                         }
                                                     }

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilter, IDataFilterValue, FilterConditionOperator, FilterComparisonOperator, IDataFilterInfo, ExtensibilityConstants, IDataFilterConfiguration, IDataFilterValueInfo } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { Label, Icon, ITheme } from '@fluentui/react';
+import { Label, Icon, ITheme, getTheme } from '@fluentui/react';
 import styles from './SelectedFiltersComponent.module.scss';
 import * as strings from 'CommonStrings';
 import { Log } from '@microsoft/sp-core-library';
@@ -127,23 +127,23 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
 
                     return <>
                         <div className={styles.filterRow}>
-                            <Label theme={this.props.themeVariant as ITheme}>
+                            <Label theme={(this.props.themeVariant as ITheme) || getTheme()}>
                                 <Icon iconName='ClearFilter'
                                     data-ui-test-id={TestConstants.SelectedFiltersClearFilter}
-                                    theme={this.props.themeVariant as ITheme}
+                                    theme={(this.props.themeVariant as ITheme) || getTheme()}
                                     onClick={() => {
                                         // Remove all the values for that filter
                                         this._onRemovefilter(filter.filterName, filter.values, this.props.instanceId);
                                     }}>
                                 </Icon>
                             </Label>
-                            <Label className={styles.filterRowValues} style={{ minWidth: 0 }} theme={this.props.themeVariant as ITheme}>
+                            <Label className={styles.filterRowValues} style={{ minWidth: 0 }} theme={(this.props.themeVariant as ITheme) || getTheme()}>
                                 <div className={styles.ellipsis}>[{renderValues}]</div>
                             </Label>
                         </div>
                         {i < filters.length - 1 && filter.values.length > 0 ?
                             <div className={styles.filterRow}>
-                                <Label className={styles.operator} theme={this.props.themeVariant as ITheme}>{`${this.getConditionOperatorString(this.props.operator as FilterConditionOperator)}`}</Label>
+                                <Label className={styles.operator} theme={(this.props.themeVariant as ITheme) || getTheme()}>{`${this.getConditionOperatorString(this.props.operator as FilterConditionOperator)}`}</Label>
                             </div>
                             : null
                         }

--- a/search-parts/src/controls/TemplateRenderer/fluentUI/FluentUI.tsx
+++ b/search-parts/src/controls/TemplateRenderer/fluentUI/FluentUI.tsx
@@ -30,7 +30,7 @@ export function useLocalFluentUI(elementsRegistry: CardObjectRegistry<CardElemen
 
 export const getDefaultFluentUITheme = (): ITheme => {
     let currentTheme;
-    const themeColorsFromWindow: any = (window as any).__themeState__.theme;
+    const themeColorsFromWindow: any = (window as any)?.__themeState__?.theme;
     if (themeColorsFromWindow) {
         currentTheme = createTheme({
             palette: themeColorsFromWindow
@@ -71,9 +71,12 @@ export const createDarkTeamsTheme = (): ITheme => {
     theme = createTheme({
         ...{ palette: require("../themes/teamsDarkPalette.json") }
     });
-    theme.semanticColors.primaryButtonText = theme.semanticColors.buttonText;
-    theme.semanticColors.primaryButtonTextHovered = theme.semanticColors.buttonTextHovered;
-    theme.semanticColors.primaryButtonTextPressed = theme.semanticColors.buttonTextPressed;
+
+    if (theme?.semanticColors) {
+        theme.semanticColors.primaryButtonText = theme.semanticColors.buttonText;
+        theme.semanticColors.primaryButtonTextHovered = theme.semanticColors.buttonTextHovered;
+        theme.semanticColors.primaryButtonTextPressed = theme.semanticColors.buttonTextPressed;
+    }
 
     return theme;
 };

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -98,7 +98,7 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
             [
                 {
                     name: 'Title',
-                    value: '<a href="{{slot item @root.slots.PreviewUrl}}" target="_blank" style="color: {{@root.theme.semanticColors.link}}">\n\t{{slot item @root.slots.Title}}\n</a>',
+                    value: '<a href="{{slot item @root.slots.PreviewUrl}}" target="_blank">\n\t{{slot item @root.slots.Title}}\n</a>',
                     useHandlebarsExpr: true,
                     minWidth: '80',
                     maxWidth: '300',

--- a/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
+++ b/search-parts/src/webparts/searchVerticals/components/SearchVerticalsContainer.tsx
@@ -116,7 +116,7 @@ export default class SearchVerticalsContainer extends React.Component<ISearchVer
           className={styles.dataVerticals}
           onLinkClick={this.onVerticalSelected}
           selectedKey={this.state.selectedKey}
-          theme={this.props.themeVariant as ITheme}
+          theme={(this.props.themeVariant as ITheme) || getTheme()}
           styles={pivotStyles}>
           {renderPivotItems}
         </Pivot>


### PR DESCRIPTION
## Summary
This PR fixes runtime crashes caused by undefined theme objects reaching Fluent UI style functions (Cannot read properties of undefined (reading semanticColors)).

## Root Cause
In some runtime/edit-mode paths, themeVariant could be undefined or delayed, while Fluent UI internals assume a valid theme with semanticColors.

## Changes
- Added defensive theme fallback handling using getTheme() where themeVariant was passed directly to Fluent UI components.
- Centralized fallback in base web part theme initialization/change handling.
- Hardened panel/render paths and results/filter/persona related components to avoid undefined theme propagation.
- Removed unsafe default template semantic color dependency that could fail when theme object was unavailable.
- Bumped package/solution versions and rebuilt package.

## Validation
- Reproduced failure path with hashed app-catalog bundles.
- Verified build/package succeeds.
- Generated updated .sppkg and deployed.
- Confirmed edit mode can load without the previous semanticColors crash in the tested scenario.

## Notes
- This is a defensive stability fix; behavior should remain unchanged when themeVariant is present.
- If any residual theme-related crash appears, stack traces should now be narrower and easier to isolate.