### PR TITLE
Fix hierarchical refiner multiselect behavior

### DIFF
--- a/search-parts/src/components/filters/FilterHierarchicalComponent.module.scss
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.module.scss
@@ -12,6 +12,46 @@
     margin-bottom: 8px;
   }
 
+  .selectedTermsContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .selectedTermPill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 16px;
+    background-color: var(--themePrimary, #03787c);
+    color: var(--white, #ffffff);
+    max-width: 100%;
+    min-height: 28px;
+    padding: 0 4px 0 12px;
+  }
+
+  .selectedTermLabel {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 20px;
+    max-width: 220px;
+  }
+
+  .removeSelectedTermButton {
+    margin-left: 2px;
+    color: var(--white, #ffffff);
+
+    :global(.ms-Button-flexContainer) {
+      color: var(--white, #ffffff);
+    }
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+  }
+
   .searchInput {
     width: 100%;
     padding: 6px 8px;

--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -50,7 +50,6 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
 
     private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     private pendingStateUpdateTimers: Array<ReturnType<typeof setTimeout>> = [];
-    private lastSelectedTermId: string | null = null;
     private static readonly GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
 
     private setImmediateProgressCursor(): void {
@@ -397,21 +396,7 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
         this.scheduleStateUpdate(() => {
             this.setState(prevState => {
                 const nextSelectedTerms = { ...prevState.selectedTerms };
-
-                if (checked) {
-                    if (this.lastSelectedTermId && this.lastSelectedTermId !== termId) {
-                        nextSelectedTerms[this.lastSelectedTermId] = false;
-                    }
-
-                    nextSelectedTerms[termId] = true;
-                    this.lastSelectedTermId = termId;
-                } else {
-                    nextSelectedTerms[termId] = false;
-
-                    if (this.lastSelectedTermId === termId) {
-                        this.lastSelectedTermId = null;
-                    }
-                }
+                nextSelectedTerms[termId] = checked;
 
                 return {
                     selectedTerms: nextSelectedTerms
@@ -429,7 +414,6 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
         const currentFilterValues = this.props.filter?.values || [];
         const normalizedTermLabel = this.normalizeLabel(resolvedTermLabel);
         const matchingRefiner = this.findMatchingRefiner(currentFilterValues, normalizedTermGuid, normalizedTermLabel);
-        const valuesToClear = this.createSingleSelectClearValues(currentFilterValues);
         const baseParentValues: IDataFilterValueInfo[] = [
             this.createSelectedFilterValue(resolvedTermLabel, this.encodeRefinementToken(`GPP|#${termGuid}`), checked),
             this.createSelectedFilterValue(resolvedTermLabel, this.encodeRefinementToken(`GP0|#${termGuid}`), checked),
@@ -446,7 +430,6 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
             : undefined;
 
         const filterValues = [
-            ...valuesToClear,
             ...this.dedupeFilterValues([
                 ...(matchingValue ? [matchingValue] : []),
                 ...baseParentValues
@@ -481,11 +464,7 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
             })();
 
         if (checked && this.props.domElement) {
-            const valuesToClear = this.createSingleSelectClearValues(currentFilterValues);
-            this.dispatchFilterUpdate([
-                ...valuesToClear,
-                filterValue
-            ]);
+            this.dispatchFilterUpdate([filterValue]);
             return;
         }
 
@@ -506,17 +485,6 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
             const filterLabels = this.extractLabelsFromFilter(filterValue);
             return normalizedTermLabel.length > 0 && filterLabels.includes(normalizedTermLabel);
         });
-    }
-
-    private createSingleSelectClearValues(currentFilterValues: any[]): IDataFilterValueInfo[] {
-        return currentFilterValues
-            .filter((value: any) => value?.selected)
-            .map((value: any) => ({
-                name: value.name,
-                value: value.value,
-                operator: value.operator || FilterComparisonOperator.Eq,
-                selected: false
-            }));
     }
 
     private createSelectedFilterValue(

--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -4,6 +4,7 @@ import * as ReactDOM from 'react-dom';
 import styles from './FilterHierarchicalComponent.module.scss';
 import { Checkbox } from '@fluentui/react/lib/Checkbox';
 import { Icon } from '@fluentui/react/lib/Icon';
+import { IconButton } from '@fluentui/react/lib/Button';
 import * as strings from 'CommonStrings';
 import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
 
@@ -44,6 +45,12 @@ export interface IFilterHierarchicalState {
     expandedTerms: { [key: string]: boolean };
     selectedTerms: { [key: string]: boolean };
     searchText: string;
+}
+
+interface ISelectedHierarchyTerm {
+    id: string;
+    label: string;
+    term: any;
 }
 
 export class FilterHierarchicalComponent extends React.Component<IFilterHierarchicalProps, IFilterHierarchicalState> {
@@ -395,7 +402,14 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
     private updateSelectedTermsState(termId: string, checked: boolean): void {
         this.scheduleStateUpdate(() => {
             this.setState(prevState => {
-                const nextSelectedTerms = { ...prevState.selectedTerms };
+                const isSingleSelectMode = !this.props.filter?.isMulti;
+                const nextSelectedTerms = isSingleSelectMode && checked
+                    ? Object.keys(prevState.selectedTerms).reduce((acc, key) => {
+                        acc[key] = false;
+                        return acc;
+                    }, {} as { [key: string]: boolean })
+                    : { ...prevState.selectedTerms };
+
                 nextSelectedTerms[termId] = checked;
 
                 return {
@@ -683,6 +697,29 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
         }
     }
 
+    private readonly getSelectedHierarchyTerms = (terms: any[]): ISelectedHierarchyTerm[] => {
+        const selectedTerms: ISelectedHierarchyTerm[] = [];
+
+        const collectSelectedTerms = (items: any[]): void => {
+            items.forEach((item: any) => {
+                if (this.state.selectedTerms[item.id]) {
+                    selectedTerms.push({
+                        id: item.id,
+                        label: this.getResolvedLabel(item.label),
+                        term: item
+                    });
+                }
+
+                if (item.children?.length > 0) {
+                    collectSelectedTerms(item.children);
+                }
+            });
+        };
+
+        collectSelectedTerms(terms || []);
+        return selectedTerms;
+    }
+
     private readonly renderTerm = (term: any, level: number = 0, resultGuids: Set<string> = new Set(), resultLabels: Set<string> = new Set(), lowerSearchText: string = '', hasResultSignals: boolean = true): JSX.Element | null => {
         const hasChildren = term.children?.length > 0;
         const isExpanded = this.state.expandedTerms[term.id];
@@ -763,6 +800,7 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
         const enabledResultGuidSet = resultGuidSet;
         
         const lowerSearchText = this.state.searchText.toLowerCase();
+        const selectedHierarchyTerms = this.props.filter?.isMulti ? this.getSelectedHierarchyTerms(hierarchicalTerms) : [];
 
         return (
             <div
@@ -779,6 +817,22 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
                         className={styles.searchInput}
                     />
                 </div>
+                {selectedHierarchyTerms.length > 0 && (
+                    <div className={styles.selectedTermsContainer}>
+                        {selectedHierarchyTerms.map(selectedTerm => (
+                            <div key={selectedTerm.id} className={styles.selectedTermPill}>
+                                <span className={styles.selectedTermLabel}>{selectedTerm.label}</span>
+                                <IconButton
+                                    iconProps={{ iconName: 'Cancel' }}
+                                    title={`${strings.Filters.ClearAllFiltersButtonLabel} ${selectedTerm.label}`}
+                                    ariaLabel={`${strings.Filters.ClearAllFiltersButtonLabel} ${selectedTerm.label}`}
+                                    className={styles.removeSelectedTermButton}
+                                    onClick={() => this.onTermCheckboxChange(selectedTerm.term, false)}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                )}
                 {hierarchicalTerms.map((term: any) => this.renderTerm(term, 0, enabledResultGuidSet, resultLabelSet, lowerSearchText, hasResultSignals)).filter(x => x !== null)}
             </div>
         );

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -118,13 +118,13 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
                         renderFilterValues = <span className={styles.operator} style={{ marginLeft: 5, marginRight: 5 }}>{`${operator}`}</span>;
                     }
 
-                    return <>
+                    return <React.Fragment key={`${filter.filterName}-${entry.displayValue}-${j}`}>
                         {filterString}
                         {renderFilterValues}
-                    </>;
+                    </React.Fragment>;
                 });
 
-                return <>
+                return <React.Fragment key={`${filter.filterName}-${i}`}>
                     <div className={styles.filterRow}>
                         <Label theme={(this.props.themeVariant as ITheme) || getTheme()}>
                             <Icon iconName='ClearFilter'
@@ -146,7 +146,7 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
                         </div>
                         : null
                     }
-                </>;
+                </React.Fragment>;
             });
 
             renderSelectedFilterValues = <div className={styles.selectedFilters}>

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -64,91 +64,89 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
 
         let renderSelectedFilterValues: JSX.Element = null;
         const filters = this.props.filters;
+        const renderableFilters = filters.filter(filter => filter.values.length > 0);
 
-        if (filters.length > 0) {
+        if (renderableFilters.length > 0) {
 
-            // Display only filter with values
-            const renderFilters = filters.map((filter: IDataFilter, i) => {
-                if (filter.values.length > 0) {
+            // Display only filters with values.
+            const renderFilters = renderableFilters.map((filter: IDataFilter, i) => {
+                let renderValues: JSX.Element[] = null;
+                const operator = this.getConditionOperatorString(filter.operator);
 
-                    let renderValues: JSX.Element[] = null;
-                    let operator = this.getConditionOperatorString(filter.operator);
+                // Get display name of the filter if specified 
+                let filterName = filter.filterName;
+                const currentFilterConfig = this.props.filtersConfiguration.filter(filterConfig => filterConfig.filterName === filter.filterName);
+                if (currentFilterConfig.length === 1) {
+                    filterName = currentFilterConfig[0].displayValue ? currentFilterConfig[0].displayValue : filterName;
+                }
 
-                    // Get display name of the filter if specified 
-                    let filterName = filter.filterName;
-                    const currentFilterConfig = this.props.filtersConfiguration.filter(filterConfig => filterConfig.filterName === filter.filterName);
-                    if (currentFilterConfig.length === 1) {
-                        filterName = currentFilterConfig[0].displayValue ? currentFilterConfig[0].displayValue : filterName;
+                const uniqueDisplayValues: Array<{ displayValue: string; operator: FilterComparisonOperator }> = [];
+                const seenDisplayValues = new Set<string>();
+
+                filter.values.forEach(value => {
+                    let displayValue = this.props.dayjs && this.props.dayjs(value.value).isValid() ? this.props.dayjs(value.value).format('LL') : value.name;
+
+                    // For taxonomy filters (GPP/GP0 tokens), extract the label if name is not set
+                    if (!displayValue || displayValue.indexOf("GPP|#") === 0 || displayValue.indexOf("GP0|#") === 0) {
+                        // Try to extract label from the token value field
+                        const labelFromToken = this.extractLabelFromToken(value.value);
+                        if (labelFromToken) {
+                            displayValue = labelFromToken;
+                        }
                     }
 
-                    const uniqueDisplayValues: Array<{ displayValue: string; operator: FilterComparisonOperator }> = [];
-                    const seenDisplayValues = new Set<string>();
+                    if (displayValue && displayValue.indexOf("i:0#") > -1) {
+                        //displayValue = displayValue.split("|")[1] + " (" + displayValue.split("|")[0] +")";  //like [PeopleCheckBox=" Lee Gu (LeeG@tcwlv.onmicrosoft.com )"]
+                        displayValue = displayValue.split("|")[1];  //like [PeopleCheckBox=" Lee Gu"]
+                    }
 
-                    filter.values.forEach(value => {
-                        let displayValue = this.props.dayjs && this.props.dayjs(value.value).isValid() ? this.props.dayjs(value.value).format('LL') : value.name;
+                    const normalizedDisplayValue = displayValue ? displayValue.trim().toLocaleLowerCase() : '';
+                    if (normalizedDisplayValue.length > 0 && !seenDisplayValues.has(normalizedDisplayValue)) {
+                        seenDisplayValues.add(normalizedDisplayValue);
+                        uniqueDisplayValues.push({
+                            displayValue,
+                            operator: value.operator
+                        });
+                    }
+                });
 
-                        // For taxonomy filters (GPP/GP0 tokens), extract the label if name is not set
-                        if (!displayValue || displayValue.indexOf("GPP|#") === 0 || displayValue.indexOf("GP0|#") === 0) {
-                            // Try to extract label from the token value field
-                            const labelFromToken = this.extractLabelFromToken(value.value);
-                            if (labelFromToken) {
-                                displayValue = labelFromToken;
-                            }
-                        }
+                renderValues = uniqueDisplayValues.map((entry, j) => {
+                    const filterString = `${filterName}${this.getComparisonOperatorString(entry.operator)}"${entry.displayValue}"`;
+                    let renderFilterValues = null;
 
-                        if (displayValue && displayValue.indexOf("i:0#") > -1) {
-                            //displayValue = displayValue.split("|")[1] + " (" + displayValue.split("|")[0] +")";  //like [PeopleCheckBox=" Lee Gu (LeeG@tcwlv.onmicrosoft.com )"]
-                            displayValue = displayValue.split("|")[1];  //like [PeopleCheckBox=" Lee Gu"]
-                        }
-
-                        const normalizedDisplayValue = displayValue ? displayValue.trim().toLocaleLowerCase() : '';
-                        if (normalizedDisplayValue.length > 0 && !seenDisplayValues.has(normalizedDisplayValue)) {
-                            seenDisplayValues.add(normalizedDisplayValue);
-                            uniqueDisplayValues.push({
-                                displayValue,
-                                operator: value.operator
-                            });
-                        }
-                    });
-
-                    renderValues = uniqueDisplayValues.map((entry, j) => {
-                        const filterString = `${filterName}${this.getComparisonOperatorString(entry.operator)}"${entry.displayValue}"`;
-                        let renderFilterValues = null;
-
-                        if (j < uniqueDisplayValues.length - 1) {
-                            renderFilterValues = <span className={styles.operator} style={{ marginLeft: 5, marginRight: 5 }}>{`${operator}`}</span>;
-                        }
-
-                        return <>
-                            {filterString}
-                            {renderFilterValues}
-                        </>;
-                    });
+                    if (j < uniqueDisplayValues.length - 1) {
+                        renderFilterValues = <span className={styles.operator} style={{ marginLeft: 5, marginRight: 5 }}>{`${operator}`}</span>;
+                    }
 
                     return <>
-                        <div className={styles.filterRow}>
-                            <Label theme={(this.props.themeVariant as ITheme) || getTheme()}>
-                                <Icon iconName='ClearFilter'
-                                    data-ui-test-id={TestConstants.SelectedFiltersClearFilter}
-                                    theme={(this.props.themeVariant as ITheme) || getTheme()}
-                                    onClick={() => {
-                                        // Remove all the values for that filter
-                                        this._onRemovefilter(filter.filterName, filter.values, this.props.instanceId);
-                                    }}>
-                                </Icon>
-                            </Label>
-                            <Label className={styles.filterRowValues} style={{ minWidth: 0 }} theme={(this.props.themeVariant as ITheme) || getTheme()}>
-                                <div className={styles.ellipsis}>[{renderValues}]</div>
-                            </Label>
-                        </div>
-                        {i < filters.length - 1 && filter.values.length > 0 ?
-                            <div className={styles.filterRow}>
-                                <Label className={styles.operator} theme={(this.props.themeVariant as ITheme) || getTheme()}>{`${this.getConditionOperatorString(this.props.operator as FilterConditionOperator)}`}</Label>
-                            </div>
-                            : null
-                        }
+                        {filterString}
+                        {renderFilterValues}
                     </>;
-                }
+                });
+
+                return <>
+                    <div className={styles.filterRow}>
+                        <Label theme={(this.props.themeVariant as ITheme) || getTheme()}>
+                            <Icon iconName='ClearFilter'
+                                data-ui-test-id={TestConstants.SelectedFiltersClearFilter}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
+                                onClick={() => {
+                                    // Remove all the values for that filter
+                                    this._onRemovefilter(filter.filterName, filter.values, this.props.instanceId);
+                                }}>
+                            </Icon>
+                        </Label>
+                        <Label className={styles.filterRowValues} style={{ minWidth: 0 }} theme={(this.props.themeVariant as ITheme) || getTheme()}>
+                            <div className={styles.ellipsis}>[{renderValues}]</div>
+                        </Label>
+                    </div>
+                    {i < renderableFilters.length - 1 ?
+                        <div className={styles.filterRow}>
+                            <Label className={styles.operator} theme={(this.props.themeVariant as ITheme) || getTheme()}>{`${this.getConditionOperatorString(this.props.operator as FilterConditionOperator)}`}</Label>
+                        </div>
+                        : null
+                    }
+                </>;
             });
 
             renderSelectedFilterValues = <div className={styles.selectedFilters}>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -249,6 +249,16 @@
 										{{else}}
 											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 												<div class="filter--value-hierarchical">
+													{{#if filter.isMulti}}
+														<div class="filter--option">
+															<pnp-filteroperator 
+																data-instance-id="{{@root.instanceId}}"
+																data-filter-name="{{filter.filterName}}" 
+																data-operator="{{filter.operator}}" 
+																data-theme-variant="{{JSONstringify @root.theme}}"
+															></pnp-filteroperator>
+														</div>
+													{{/if}}
 													<pnp-filterhierarchical 
 														data-instance-id="{{@root.instanceId}}" 
 														data-filter="{{JSONstringify filter 2}}"
@@ -267,12 +277,7 @@
 
 						<template id="collapsible-footer">
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
-								{{#isnt filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-								{{#eq filter.values.length 0}}
-									<div class="filter--message">
-										{{@root.strings.FilterNoValuesMessage}}
-									</div>
-								{{else}}
+								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 									{{#if filter.isMulti}}
 										<pnp-filtermultiselect 
 											data-instance-id="{{@root.instanceId}}" 
@@ -283,9 +288,24 @@
 										>
 										</pnp-filtermultiselect>
 									{{/if}}
+								{{else}}
+									{{#eq filter.values.length 0}}
+										<div class="filter--message">
+											{{@root.strings.FilterNoValuesMessage}}
+										</div>
+									{{else}}
+										{{#if filter.isMulti}}
+											<pnp-filtermultiselect 
+												data-instance-id="{{@root.instanceId}}" 
+												data-filter-name="{{filter.filterName}}" 
+												data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
+												data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
+												data-theme-variant="{{JSONstringify @root.theme}}"
+											>
+											</pnp-filtermultiselect>
+										{{/if}}
+									{{/eq}}
 								{{/eq}}
-								{{/isnt}}
-							{{/isnt}}
 						</template>
 
 					</pnp-collapsible>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -288,6 +288,7 @@
 										{{/if}}
 									{{/eq}}
 								{{/eq}}
+							{{/isnt}}
 						</template>
 
 					</pnp-collapsible>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -249,16 +249,7 @@
 										{{else}}
 											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 												<div class="filter--value-hierarchical">
-													{{#if filter.isMulti}}
-														<div class="filter--option">
-															<pnp-filteroperator 
-																data-instance-id="{{@root.instanceId}}"
-																data-filter-name="{{filter.filterName}}" 
-																data-operator="{{filter.operator}}" 
-																data-theme-variant="{{JSONstringify @root.theme}}"
-															></pnp-filteroperator>
-														</div>
-													{{/if}}
+													{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
 													<pnp-filterhierarchical 
 														data-instance-id="{{@root.instanceId}}" 
 														data-filter="{{JSONstringify filter 2}}"
@@ -278,16 +269,7 @@
 						<template id="collapsible-footer">
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
 								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-									{{#if filter.isMulti}}
-										<pnp-filtermultiselect 
-											data-instance-id="{{@root.instanceId}}" 
-											data-filter-name="{{filter.filterName}}" 
-											data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
-											data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
-											data-theme-variant="{{JSONstringify @root.theme}}"
-										>
-										</pnp-filtermultiselect>
-									{{/if}}
+									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
 								{{else}}
 									{{#eq filter.values.length 0}}
 										<div class="filter--message">

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -3,7 +3,7 @@
     <style>
 
         .filter {
-			margin-bottom: 10px;
+            margin-bottom: 10px;
 		}
     
 		.filter--value {
@@ -270,6 +270,16 @@
                                                         {{else}}
                                                             {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
                                                                 <div class="filter--value-hierarchical">
+                                                                    {{#if filter.isMulti}}
+                                                                        <div class="filter--option">
+                                                                            <pnp-filteroperator 
+                                                                                data-instance-id="{{@root.instanceId}}"
+                                                                                data-filter-name="{{filter.filterName}}" 
+                                                                                data-operator="{{filter.operator}}" 
+                                                                                data-theme-variant="{{JSONstringify @root.theme}}"
+                                                                            ></pnp-filteroperator>
+                                                                        </div>
+                                                                    {{/if}}
                                                                     <pnp-filterhierarchical 
                                                                         data-instance-id="{{@root.instanceId}}" 
                                                                         data-filter="{{JSONstringify filter 2}}"
@@ -288,27 +298,39 @@
                 
                                         <template id="collapsible-footer">
                                             {{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
-												{{#isnt filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-                                                {{#isnt filter.selectedTemplate 'TaxonomyPickerFilterTemplate'}}
-                                                    {{#eq filter.values.length 0}}
-                                                        <div class="filter--message">
-                                                            {{@root.strings.FilterNoValuesMessage}}
-                                                        </div>
-                                                    {{else}}
-                                                        {{#if filter.isMulti}}
-                                                            <pnp-filtermultiselect 
-                                                                data-instance-id="{{@root.instanceId}}" 
-                                                                data-filter-name="{{filter.filterName}}" 
-                                                                data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
-                                                                data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
-                                                                data-theme-variant="{{JSONstringify @root.theme}}"
-                                                            >
-                                                            </pnp-filtermultiselect>
-                                                        {{/if}}
-                                                    {{/eq}}
-                                                {{/isnt}}
-												{{/isnt}}
+                                                {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
+                                                    {{#if filter.isMulti}}
+                                                        <pnp-filtermultiselect 
+                                                            data-instance-id="{{@root.instanceId}}" 
+                                                            data-filter-name="{{filter.filterName}}" 
+                                                            data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
+                                                            data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
+                                                            data-theme-variant="{{JSONstringify @root.theme}}"
+                                                        >
+                                                        </pnp-filtermultiselect>
+                                                    {{/if}}
+                                                {{else}}
+                                                    {{#isnt filter.selectedTemplate 'TaxonomyPickerFilterTemplate'}}
+                                                        {{#eq filter.values.length 0}}
+                                                            <div class="filter--message">
+                                                                {{@root.strings.FilterNoValuesMessage}}
+                                                            </div>
+                                                        {{else}}
+                                                            {{#if filter.isMulti}}
+                                                                <pnp-filtermultiselect 
+                                                                    data-instance-id="{{@root.instanceId}}" 
+                                                                    data-filter-name="{{filter.filterName}}" 
+                                                                    data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
+                                                                    data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
+                                                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                                                >
+                                                                </pnp-filtermultiselect>
+                                                            {{/if}}
+                                                        {{/eq}}
+                                                    {{/isnt}}
+                                                {{/eq}}
                                             {{/isnt}}
+                                                {{/eq}}
                                         </template>
                 
                                     </pnp-collapsible>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -312,7 +312,6 @@
                                                     {{/isnt}}
                                                 {{/eq}}
                                             {{/isnt}}
-                                                {{/eq}}
                                         </template>
                 
                                     </pnp-collapsible>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -270,16 +270,7 @@
                                                         {{else}}
                                                             {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
                                                                 <div class="filter--value-hierarchical">
-                                                                    {{#if filter.isMulti}}
-                                                                        <div class="filter--option">
-                                                                            <pnp-filteroperator 
-                                                                                data-instance-id="{{@root.instanceId}}"
-                                                                                data-filter-name="{{filter.filterName}}" 
-                                                                                data-operator="{{filter.operator}}" 
-                                                                                data-theme-variant="{{JSONstringify @root.theme}}"
-                                                                            ></pnp-filteroperator>
-                                                                        </div>
-                                                                    {{/if}}
+                                                                    {{{hierarchicalOperator filter @root.instanceId @root.theme}}}
                                                                     <pnp-filterhierarchical 
                                                                         data-instance-id="{{@root.instanceId}}" 
                                                                         data-filter="{{JSONstringify filter 2}}"
@@ -299,16 +290,7 @@
                                         <template id="collapsible-footer">
                                             {{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
                                                 {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-                                                    {{#if filter.isMulti}}
-                                                        <pnp-filtermultiselect 
-                                                            data-instance-id="{{@root.instanceId}}" 
-                                                            data-filter-name="{{filter.filterName}}" 
-                                                            data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
-                                                            data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}"
-                                                            data-theme-variant="{{JSONstringify @root.theme}}"
-                                                        >
-                                                        </pnp-filtermultiselect>
-                                                    {{/if}}
+                                                    {{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
                                                 {{else}}
                                                     {{#isnt filter.selectedTemplate 'TaxonomyPickerFilterTemplate'}}
                                                         {{#eq filter.values.length 0}}

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -14,6 +14,15 @@
 			align-items: center;
 		}
 
+		.filter--value-hierarchical {
+			width: 100%;
+		}
+
+		.filter--value-hierarchical pnp-filterhierarchical {
+			display: block;
+			width: 100%;
+		}
+
 		.filter--values-list {
 			overflow: auto;
 			max-height: 400px;
@@ -226,7 +235,17 @@
 											</div>
 										{{else}}
 											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-												<div class="filter--value">
+												<div class="filter--value-hierarchical">
+													{{#if filter.isMulti}}
+														<div class="filter--option">
+															<pnp-filteroperator 
+																data-instance-id="{{@root.instanceId}}"
+																data-filter-name="{{filter.filterName}}" 
+																data-operator="{{filter.operator}}" 
+																data-theme-variant="{{JSONstringify @root.theme}}"
+															></pnp-filteroperator>
+														</div>
+													{{/if}}
 													<pnp-filterhierarchical 
 														data-instance-id="{{@root.instanceId}}" 
 														data-filter="{{JSONstringify filter 2}}"
@@ -245,12 +264,31 @@
 
 						<template id="collapsible-footer">
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
-								{{#isnt filter.selectedTemplate 'HierarchicalFilterTemplate'}}
+								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
+									{{#if filter.isMulti}}
+										<pnp-filtermultiselect 
+											data-instance-id="{{@root.instanceId}}" 
+											data-filter-name="{{filter.filterName}}" 
+											data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
+											data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}">
+										</pnp-filtermultiselect>
+									{{/if}}
+								{{else}}
 									{{#eq filter.values.length 0}}
 										<div class="filter--message">
 											{{@root.strings.FilterNoValuesMessage}}
 										</div>
 									{{else}}
+										{{#if filter.isMulti}}
+											<div class="filter--option">
+												<pnp-filteroperator 
+													data-instance-id="{{@root.instanceId}}"
+													data-filter-name="{{filter.filterName}}" 
+													data-operator="{{filter.operator}}" 
+													data-theme-variant="{{JSONstringify @root.theme}}"
+												></pnp-filteroperator>
+											</div>
+										{{/if}}
 										{{#if filter.isMulti}}
 											<pnp-filtermultiselect 
 												data-instance-id="{{@root.instanceId}}" 
@@ -260,7 +298,7 @@
 											</pnp-filtermultiselect>
 										{{/if}}
 									{{/eq}}
-								{{/isnt}}
+								{{/eq}}
 							{{/isnt}}
 						</template>
 

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -236,16 +236,7 @@
 										{{else}}
 											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 												<div class="filter--value-hierarchical">
-													{{#if filter.isMulti}}
-														<div class="filter--option">
-															<pnp-filteroperator 
-																data-instance-id="{{@root.instanceId}}"
-																data-filter-name="{{filter.filterName}}" 
-																data-operator="{{filter.operator}}" 
-																data-theme-variant="{{JSONstringify @root.theme}}"
-															></pnp-filteroperator>
-														</div>
-													{{/if}}
+													{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
 													<pnp-filterhierarchical 
 														data-instance-id="{{@root.instanceId}}" 
 														data-filter="{{JSONstringify filter 2}}"
@@ -265,14 +256,7 @@
 						<template id="collapsible-footer">
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
 								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-									{{#if filter.isMulti}}
-										<pnp-filtermultiselect 
-											data-instance-id="{{@root.instanceId}}" 
-											data-filter-name="{{filter.filterName}}" 
-											data-apply-disabled="{{#if filter.canApply}}false{{else}}true{{/if}}" 
-											data-clear-disabled="{{#if filter.canClear}}false{{else}}true{{/if}}">
-										</pnp-filtermultiselect>
-									{{/if}}
+									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
 								{{else}}
 									{{#eq filter.values.length 0}}
 										<div class="filter--message">

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -1194,6 +1194,43 @@ export class TemplateService implements ITemplateService {
                 return Math.abs(dayCount);
             }
         );
+
+        const hb: any = this._handlebars;
+        const escapeFn = hb.Utils?.escapeExpression ?? String;
+
+        this.Handlebars.registerHelper("hierarchicalOperator", (filter: any, instanceId: string, theme: any) => {
+            if (!filter?.isMulti) {
+                return "";
+            }
+
+            return new hb.SafeString(`
+                <div class="filter--option">
+                    <pnp-filteroperator
+                        data-instance-id="${escapeFn(instanceId)}"
+                        data-filter-name="${escapeFn(filter.filterName)}"
+                        data-operator="${escapeFn(filter.operator)}"
+                        data-theme-variant="${escapeFn(JSON.stringify(theme))}"
+                    ></pnp-filteroperator>
+                </div>
+            `);
+        });
+
+        this.Handlebars.registerHelper("hierarchicalMultiselect", (filter: any, instanceId: string, theme: any) => {
+            if (!filter?.isMulti) {
+                return "";
+            }
+
+            return new hb.SafeString(`
+                <pnp-filtermultiselect
+                    data-instance-id="${escapeFn(instanceId)}"
+                    data-filter-name="${escapeFn(filter.filterName)}"
+                    data-apply-disabled="${filter.canApply ? 'false' : 'true'}"
+                    data-clear-disabled="${filter.canClear ? 'false' : 'true'}"
+                    data-theme-variant="${escapeFn(JSON.stringify(theme))}"
+                >
+                </pnp-filtermultiselect>
+            `);
+        });
     }
 
     private async _initAdaptiveCardsResources(): Promise<void> {

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -951,7 +951,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return {
             displayName: filterConfiguration.displayValue?.trim() ? filterConfiguration.displayValue : availableFilter.filterName,
             filterName: availableFilter.filterName,
-            isMulti: !!filterConfiguration.isMulti,
+            isMulti: this.isMultiValueFilter(filterConfiguration),
             showCount: !!filterConfiguration.showCount,
             expandByDefault: !!filterConfiguration.expandByDefault,
             showWarningMarker,
@@ -1134,7 +1134,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             filterName: filterInfo.filterName,
             hasSelectedValues: filterInfo.filterValues.some(value => value.selected),
             selectedOnce: true,
-            isMulti: !!filterConfiguration.isMulti,
+            isMulti: this.isMultiValueFilter(filterConfiguration),
             showCount: !!filterConfiguration.showCount,
             expandByDefault: !!filterConfiguration.expandByDefault,
             values: filterValuesInternal,
@@ -1152,7 +1152,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { operator: { $set: filterInfo.operator } } });
         }
 
-        if (!filterConfiguration.isMulti) {
+        if (!this.isMultiValueFilter(filterConfiguration)) {
             updatedUiFilters[filterIdx].values = updatedUiFilters[filterIdx].values.map(value => ({
                 ...value,
                 selected: false
@@ -1477,11 +1477,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         if (debugContext) {
             this.logUpdateStep(debugContext, 'onFilterValuesUpdated:uiMerged', {
                 filterExistsInUi: filterIdx !== -1,
-                isMulti: !!filterConfiguration.isMulti
+                isMulti: this.isMultiValueFilter(filterConfiguration)
             });
         }
 
-        if (filterConfiguration.isMulti && !filterInfo.forceUpdate) {
+        if (this.isMultiValueFilter(filterConfiguration) && !filterInfo.forceUpdate) {
             this.updatePendingMultiFilterState(currentUiFilters, filterInfo.filterName);
             this.commitPendingMultiFilterState(currentUiFilters, debugContext);
             return;
@@ -1604,6 +1604,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         return this.encodeTaxonomyRefinementToken(`${tokenMatch[1]}${extractedGuid}`);
+    }
+
+    private isMultiValueFilter(filterConfiguration: IDataFilterConfiguration | IHierarchicalFilterConfiguration): boolean {
+        return !!filterConfiguration.isMulti;
     }
 
     private encodeTaxonomyRefinementToken(token: string): string {
@@ -1879,7 +1883,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                         displayName: filterConfiguration.displayValue?.trim() ? filterConfiguration.displayValue : filter.filterName,
                         expandByDefault: filterConfiguration.expandByDefault,
                         filterName: filter.filterName,
-                        isMulti: filterConfiguration.isMulti,
+                        isMulti: this.isMultiValueFilter(filterConfiguration),
                         selectedTemplate: filterConfiguration.selectedTemplate,
                         showCount: filterConfiguration.showCount,
                         showWarningMarker: false,


### PR DESCRIPTION
## Summary
- Added support for multi selection in the hierarchical refiner 
- Restore hierarchical refiner single-select behavior when multiselect is disabled
- Keep AND/OR and Apply/Clear controls limited to multiselect mode
- Hide empty selected-filters output in results layouts
- Centralize hierarchical control rendering in shared Handlebars helpers to reduce duplication

## Validation
- heft build