### PR TITLE
fix(templating): restore CSS nesting in template styles (#4851)

### DIFF
--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -313,13 +313,53 @@ export class TemplateService implements ITemplateService {
         await this._customElementHelperPromise;
     }
 
+    /**
+     * Re-parses raw CSS text through a throwaway, inert DOMParser document to
+     * obtain a populated CSSOM stylesheet. This is used when a style element is
+     * detached (e.g. created via Range.createContextualFragment) and therefore
+     * exposes a null `style.sheet`. Going through the browser's real CSS engine
+     * preserves modern features such as CSS nesting, which the regex fallback
+     * cannot handle. The document produced by DOMParser is inert (scripts never
+     * run) and the CSS text is assigned via textContent, so no markup breakout
+     * or code execution is possible.
+     */
+    private parseCssTextToSheet(cssText: string): CSSStyleSheet | null {
+        if (!cssText || !cssText.trim()) {
+            return null;
+        }
+
+        try {
+            const doc = new DOMParser().parseFromString("<style></style>", "text/html");
+            const styleEl = doc.getElementsByTagName("style")[0];
+
+            if (!styleEl) {
+                return null;
+            }
+
+            styleEl.textContent = cssText;
+            return (styleEl.sheet as CSSStyleSheet) ?? null;
+        } catch {
+            return null;
+        }
+    }
+
     public legacyStyleParser(
         style: HTMLStyleElement,
         elementPrefixId: string
     ): string {
         let prefixedStyles: string[] = [];
 
-        const sheet: any = style.sheet;
+        let sheet: any = style.sheet;
+
+        // When the style element is detached (e.g. created via
+        // Range.createContextualFragment), style.sheet is null and the CSSOM is
+        // unavailable. Re-parse the CSS text through a throwaway DOMParser
+        // document to obtain a populated sheet so the CSSOM path below can run.
+        // This preserves modern CSS features such as nesting, which the regex
+        // fallback further down cannot handle.
+        if (!(sheet as CSSStyleSheet)?.cssRules) {
+            sheet = this.parseCssTextToSheet(style.textContent || style.innerText || "");
+        }
 
         // Try to use CSSOM if available (for live DOM elements)
         if ((sheet as CSSStyleSheet)?.cssRules) {

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -314,6 +314,20 @@ export class TemplateService implements ITemplateService {
     }
 
     /**
+     * Safely reads the CSS rules from a stylesheet. Accessing `cssRules` can
+     * throw (e.g. a SecurityError for a cross-origin stylesheet), which would
+     * otherwise abort template rendering. Returns null when the rules cannot be
+     * read so callers can fall back to text-based parsing.
+     */
+    private safeGetCssRules(sheet: CSSStyleSheet | null | undefined): CSSRuleList | null {
+        try {
+            return sheet?.cssRules ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
      * Re-parses raw CSS text through a throwaway, inert DOMParser document to
      * obtain a populated CSSOM stylesheet. This is used when a style element is
      * detached (e.g. created via Range.createContextualFragment) and therefore
@@ -324,19 +338,23 @@ export class TemplateService implements ITemplateService {
      * or code execution is possible.
      */
     private parseCssTextToSheet(cssText: string): CSSStyleSheet | null {
-        if (!cssText || !cssText.trim()) {
+        if (!cssText?.trim()) {
             return null;
         }
 
         try {
-            const doc = new DOMParser().parseFromString("<style></style>", "text/html");
-            const styleEl = doc.getElementsByTagName("style")[0];
-
-            if (!styleEl) {
-                return null;
-            }
-
+            // Build the throwaway <style> inside an inert DOMParser document. It
+            // is never attached to the live document, so it triggers no
+            // @import/url() network fetches and does not affect the page.
+            // Appending it to that document's head is what populates its sheet.
+            const doc = new DOMParser().parseFromString(
+                "<!DOCTYPE html><html><head></head><body></body></html>",
+                "text/html"
+            );
+            const styleEl = doc.createElement("style");
             styleEl.textContent = cssText;
+            doc.head.appendChild(styleEl);
+
             return (styleEl.sheet as CSSStyleSheet) ?? null;
         } catch {
             return null;
@@ -349,7 +367,7 @@ export class TemplateService implements ITemplateService {
     ): string {
         let prefixedStyles: string[] = [];
 
-        let sheet: any = style.sheet;
+        let sheet: CSSStyleSheet | null = style.sheet as CSSStyleSheet;
 
         // When the style element is detached (e.g. created via
         // Range.createContextualFragment), style.sheet is null and the CSSOM is
@@ -357,14 +375,15 @@ export class TemplateService implements ITemplateService {
         // document to obtain a populated sheet so the CSSOM path below can run.
         // This preserves modern CSS features such as nesting, which the regex
         // fallback further down cannot handle.
-        if (!(sheet as CSSStyleSheet)?.cssRules) {
+        let cssRules = this.safeGetCssRules(sheet);
+
+        if (!cssRules) {
             sheet = this.parseCssTextToSheet(style.textContent || style.innerText || "");
+            cssRules = this.safeGetCssRules(sheet);
         }
 
         // Try to use CSSOM if available (for live DOM elements)
-        if ((sheet as CSSStyleSheet)?.cssRules) {
-            const cssRules = (sheet as CSSStyleSheet).cssRules;
-
+        if (cssRules) {
             for (let j = 0; j < cssRules.length; j++) {
                 const cssRule: CSSRule = cssRules.item(j);
 


### PR DESCRIPTION
## Fixes #4851 — CSS nesting broken in 4.23.1

### Problem
Nested CSS inside Handlebars template `<style>` blocks stopped being applied in 4.23.1 (rendered partially or dropped), unless `data-cssscope="layer"` was used for *all* styles.

### Root cause
PR #4840 (commit `beeb526f`, shipped in 4.23.1) refactored `TemplateRenderer` and switched the non-MGT template parse from `DOMParser.parseFromString` (full Document → `style.sheet` populated) to `Range.createContextualFragment` (DocumentFragment → `style.sheet === null`). With no `sheet`, `legacyStyleParser` fell through to its regex fallback, whose property matcher `[^{}]*` cannot span nested `{}`, so nested rules were dropped or flattened.

### Fix
When `style.sheet` is unavailable, re-parse the CSS text through a throwaway **inert** `DOMParser` document (CSS assigned via `textContent`, so no markup breakout and scripts never run) to obtain a populated CSSOM sheet. This restores the CSSOM prefixing path, which preserves CSS nesting and `@media` rules. The regex fallback remains only as a last resort.

### Verification
- Confirmed root cause in a real browser: `DOMParser` → `sheet` present + nesting preserved in `cssText`; `createContextualFragment` → `sheet === null`.
- Verified end-to-end on a live Search Results web part with the reporter's exact template: the injected `<style>` now emits `#pnp-template_… .mytest { … & pnp-icon { font-size: 26px … } & li { … } }` and computed styles confirm the nested rules apply (icon 26px/10px, li flex/8px, link 500/18px).
- Security: a `</style><img onerror>` injection test creates no element and does not execute.
- `heft build` passes (no TS/lint errors).