### PR TITLE
chore(release): bump version to 4.23.2

### DIFF
--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "PnP Modern Search - Search Web Parts - v4",
         "id": "59903278-dd5d-4e9e-bef6-562aae716b8b",
-        "version": "4.23.1.0",
+        "version": "4.23.2.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": true,
         "isDomainIsolated": false,

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.0",
+    "version": "4.23.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pnp/modern-search-web-parts",
-            "version": "4.23.0",
+            "version": "4.23.2",
             "dependencies": {
                 "@fluentui/font-icons-mdl2": "^8.5.67",
                 "@fluentui/react": "8.125.4",
@@ -10320,32 +10320,6 @@
             "license": "MIT",
             "dependencies": {
                 "loader-utils": "1.4.2"
-            }
-        },
-        "node_modules/@rushstack/loader-raw-script/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/@rushstack/loader-raw-script/node_modules/loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-            "license": "MIT",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/@rushstack/localization-utilities": {

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.1",
+    "version": "4.23.2",
     "private": true,
     "engines": {
         "node": ">=22.14.0 < 23.0.0"


### PR DESCRIPTION
Bumps the solution version 4.23.1 → 4.23.2 (`package.json` + `package-solution.json`) and refreshes `package-lock.json`.

Split out to a PR because the new `develop` ruleset requires changes to go through a pull request.