### PR TITLE
Fix formatting and HTML issues in documentation

### DIFF
--- a/docs/extensibility/templating.md
+++ b/docs/extensibility/templating.md
@@ -259,6 +259,24 @@ Supported output format tokens include all [dayjs format tokens](https://day.js.
 
 **Example** `{{hexToString '"ǂǂ4b656f6768e280997320437269737073"'}}` returns `Keogh’s Crisps`.
 
+#### Deep Link Example For Search Filters
+
+If you want a value rendered in a custom results template to open a page with a filter already selected, you can build the filter payload yourself.
+
+The deep-link query string parameter is `f_<Search Filters instance ID>`. The filter `value` must contain the UTF-8 hex form of the label, prefixed with `ǂǂ` and wrapped in escaped quotes.
+
+```handlebars
+{{!-- Example for a Search Filters web part whose instance ID is known --}}
+{{!-- Replace the GUID below with the instance ID of your Search Filters web part --}}
+<a
+    href="/sites/contoso/SitePages/Search.aspx?f_4b43307b-8891-42d5-9a62-7bfb83c11de9=%5B%7B%22filterName%22%3A%22RefinableString109%22%2C%22values%22%3A%5B%7B%22name%22%3A%22{{slot item @root.slots.Title}}%22%2C%22value%22%3A%22%5C%22%C7%82%C7%82{{stringToHex (slot item @root.slots.Title)}}%5C%22%22%2C%22operator%22%3A0%2C%22disabled%22%3Afalse%7D%5D%2C%22operator%22%3A%22or%22%7D%5D"
+>
+    {{slot item @root.slots.Title}}
+</a>
+```
+
+In practice, the safest approach is still to select a filter once in the UI, copy the generated URL, and then replace only the `name` and hex-encoded `value` parts in your template.
+
 #### formatSPFileSize
 
 **Syntax** `{{formatSPFileSize <value>}}`
@@ -296,24 +314,6 @@ Representative examples:
 | 1073741823 | `1.00 GB` |
 | 1073741824 | `1 GB` |
 | 44398312377 | `41.3 GB` |
-
-#### Deep Link Example For Search Filters
-
-If you want a value rendered in a custom results template to open a page with a filter already selected, you can build the filter payload yourself.
-
-The deep-link query string parameter is `f_<Search Filters instance ID>`. The filter `value` must contain the UTF-8 hex form of the label, prefixed with `ǂǂ` and wrapped in escaped quotes.
-
-```handlebars
-{{!-- Example for a Search Filters web part whose instance ID is known --}}
-{{!-- Replace the GUID below with the instance ID of your Search Filters web part --}}
-<a
-    href="/sites/contoso/SitePages/Search.aspx?f_4b43307b-8891-42d5-9a62-7bfb83c11de9=%5B%7B%22filterName%22%3A%22RefinableString109%22%2C%22values%22%3A%5B%7B%22name%22%3A%22{{slot item @root.slots.Title}}%22%2C%22value%22%3A%22%5C%22%C7%82%C7%82{{stringToHex (slot item @root.slots.Title)}}%5C%22%22%2C%22operator%22%3A0%2C%22disabled%22%3Afalse%7D%5D%2C%22operator%22%3A%22or%22%7D%5D"
->
-    {{slot item @root.slots.Title}}
-</a>
-```
-
-In practice, the safest approach is still to select a filter once in the UI, copy the generated URL, and then replace only the `name` and hex-encoded `value` parts in your template.
 
 #### #times
 

--- a/docs/extensibility/web_components_list.md
+++ b/docs/extensibility/web_components_list.md
@@ -117,7 +117,7 @@ Here are the list of all **reusable** web components you can use to customize yo
 - **Usage**
 ```html
 <pnp-panel
-    data-theme-variant='{{JSONstringify @root.theme}}'   
+    data-theme-variant="{{JSONstringify @root.theme}}"   
     data-is-open="false" 
     data-is-light-dismiss="true"
     data-is-blocking="true"

--- a/docs/extensibility/web_components_list.md
+++ b/docs/extensibility/web_components_list.md
@@ -117,7 +117,7 @@ Here are the list of all **reusable** web components you can use to customize yo
 - **Usage**
 ```html
 <pnp-panel
-    data-theme-variant="{{JSONstringify @root.theme}}"   
+    data-theme-variant="{{JSONstringify @root.theme}}"
     data-is-open="false" 
     data-is-light-dismiss="true"
     data-is-blocking="true"

--- a/docs/scenarios/clickable-column-filter-link.md
+++ b/docs/scenarios/clickable-column-filter-link.md
@@ -1,5 +1,5 @@
 !!! note
-The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
+    The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
 
 !!! warning
     This scenario requires **PnP Modern Search version 4.22.0 or later**. It uses the `stringToHex` Handlebars helper which was added in 4.22.0 and is not available in earlier versions. If you are on an older version the filter link column will not work correctly.

--- a/docs/scenarios/document-viewer-page.md
+++ b/docs/scenarios/document-viewer-page.md
@@ -1,5 +1,5 @@
 !!! note
-The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
+    The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
 
 This scenario builds a dedicated document viewer page in SharePoint that opens when a user clicks a view icon in a search results list. The viewer page displays the document in an embedded iframe alongside a metadata panel, giving users a rich in-context viewing experience without leaving SharePoint.
 

--- a/docs/scenarios/more-info-panel-with-pnp-panel.md
+++ b/docs/scenarios/more-info-panel-with-pnp-panel.md
@@ -50,7 +50,7 @@ Paste the following as the column value:
 
 ```html
 <pnp-panel
-    data-theme-variant='{{JSONstringify @root.theme}}' 
+    data-theme-variant="{{JSONstringify @root.theme}}"
     data-is-open="false" 
     data-is-light-dismiss="true"
     data-is-blocking="true"

--- a/docs/scenarios/more-info-panel-with-pnp-panel.md
+++ b/docs/scenarios/more-info-panel-with-pnp-panel.md
@@ -1,5 +1,5 @@
 !!! note
-The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
+    The PnP Modern Search Web Parts must be deployed to your App Catalog and activated on your site. See the [installation documentation](../installation.md) for details.
 
 Search results pages are always fighting for screen (width) real estate — you want to show useful metadata but you can't add endless columns. By adding a single small icon column to your results list, users can click it to open a right-hand flyout panel that displays as much metadata as you need, without cluttering the results view.
 
@@ -35,7 +35,7 @@ Under **Layouts → Slots**, add the following three slots:
 | `LastModifiedTimeForRetention` | `LastModifiedTimeForRetention` |
 
 !!! warning
-The slot names must match exactly as shown — they are referenced directly in the `<pnp-panel>` template in Step 4. A typo or different casing will result in those fields showing blank in the panel.
+    The slot names must match exactly as shown — they are referenced directly in the `<pnp-panel>` template in Step 4. A typo or different casing will result in those fields showing blank in the panel.
 
 ## Step 4: Add the info panel column
 
@@ -129,7 +129,7 @@ Paste the following as the column value:
 ```
 
 !!! tip
-The template above relies on the managed properties and slot names being exactly as specified in Steps 2 and 3. Once you have it working you can freely customise the panel to add, remove, or relabel any metadata fields.
+    The template above relies on the managed properties and slot names being exactly as specified in Steps 2 and 3. Once you have it working you can freely customise the panel to add, remove, or relabel any metadata fields.
 
 ## Step 5: Publish and test
 
@@ -138,5 +138,5 @@ Save and publish the page. Each result row will show the info icon on the right.
 ![The panel open showing metadata for a selected result](assets/more-info-panel-with-pnp-panel/more-info-panel-result.png)
 
 !!! tip
-If a field shows blank, check two things: (1) the managed property is included in the **Selected Properties** list in the Data sources panel, and (2) the slot mapping in the Layouts panel points to the correct managed property name.
+    If a field shows blank, check two things: (1) the managed property is included in the **Selected Properties** list in the Data sources panel, and (2) the slot mapping in the Layouts panel points to the correct managed property name.
 


### PR DESCRIPTION
This pull request makes a small update to the documentation, standardising the use of double quotes instead of single quotes for the `data-theme-variant` attribute in HTML code examples for <pnp-panel>. This helps ensure consistency across documentation.

It also adds my attempts at fixing the indents for 

`
!!! note
    The template
`

So my scenarios correctly displays in the rendered pages.