### PR TITLE
Fix #4854: Static person template works in both single and multi select mode

### DIFF
--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "heft test --clean --production && heft package-solution --production",
         "clean": "heft clean",
-        "start": "heft start --clean",
+        "start": "heft start",
         "eject-webpack": "heft eject-webpack"
     },
     "dependencies": {

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "heft test --clean --production && heft package-solution --production",
         "clean": "heft clean",
-        "start": "heft start",
+        "start": "heft start --clean",
         "eject-webpack": "heft eject-webpack"
     },
     "dependencies": {

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -816,15 +816,17 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const isMultiMode = this.isMultiSelectionMode();
         const selectedPeople = this.state.pickerSelectedPeople || [];
         const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
-        const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText)
-            .filter(person => isMultiMode || !selectedUserKeys.has(this.getIdentityKey(person)));
+        const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText);
+        const selectableUsers = isMultiMode
+            ? filteredUsers.filter(person => !selectedUserKeys.has(this.getIdentityKey(person)))
+            : filteredUsers;
         const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
         const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
         const selectedPillBackgroundColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
         const selectedPillBorderColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
         const selectedPillTextColor = this.props.themeVariant?.semanticColors?.primaryButtonText ?? '#ffffff';
-        const singleSelectOptions = isMultiMode ? [] : this.getSingleSelectOptions(filteredUsers, textColor);
-        const selectedSingleUserKey = isMultiMode ? undefined : this.getSelectedSingleStaticUserKey(filteredUsers, selectedUserKeys, selectedDisplayNames);
+        const singleSelectOptions = isMultiMode ? [] : this.getSingleSelectOptions(selectableUsers, textColor);
+        const selectedSingleUserKey = isMultiMode ? undefined : this.getSelectedSingleStaticUserKey(selectableUsers, selectedUserKeys, selectedDisplayNames);
 
         return <div>
             {selectedPeople.length > 0 && (
@@ -888,7 +890,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         {noUsersFoundMessage}
                     </div>
                 )}
-                {filteredUsers.map(user => {
+                {selectableUsers.map(user => {
                     const userKey = this.getIdentityKey(user);
                     const checked = this.isStaticUserChecked(user, selectedUserKeys, selectedDisplayNames);
 
@@ -948,7 +950,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         }}
                         options={singleSelectOptions}
                         onChange={(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption) => {
-                            const selectedUser = filteredUsers.find(user => this.getIdentityKey(user) === option?.key);
+                            const selectedUser = selectableUsers.find(user => this.getIdentityKey(user) === option?.key);
                             if (!selectedUser) {
                                 return;
                             }

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -741,18 +741,21 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                                 key={personKey}
                                 type="button"
                                 onClick={() => this.toggleStaticUserSelection(person, false)}
+                                disabled={this.props.disabled}
                                 style={{
                                     alignItems: 'center',
                                     backgroundColor: '#106ebe',
                                     border: '1px solid #106ebe',
                                     borderRadius: 16,
                                     color: '#ffffff',
-                                    cursor: 'pointer',
+                                    cursor: this.props.disabled ? 'not-allowed' : 'pointer',
                                     display: 'inline-flex',
                                     gap: 8,
+                                    opacity: this.props.disabled ? 0.6 : 1,
                                     padding: '4px 12px'
                                 }}
                                 title={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
+                                aria-label={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
                             >
                                 <span style={{ lineHeight: 1 }}>{person.text}</span>
                                 <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>×</span>
@@ -764,7 +767,13 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                     <input
                         type="text"
                         value={this.state.pickerSearchText}
+                        disabled={this.props.disabled}
+                        aria-label={searchUsersPlaceholder}
                         onChange={(event) => {
+                            if (this.props.disabled) {
+                                return;
+                            }
+
                             const nextSearchText = event.currentTarget.value;
 
                             if (this.pickerSearchDebounceTimer !== null) {
@@ -826,6 +835,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                                     }}
                                     theme={(this.props.themeVariant as ITheme) || getTheme()}
                                     checked={checked}
+                                    disabled={this.props.disabled}
                                     label={user.text}
                                     onChange={(ev, isChecked) => {
                                         this.toggleStaticUserSelection(user, !!isChecked);

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -490,8 +490,11 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const seedQueries = ['a', 'e', 'i', 'o', 'u'];
         const uniqueUsers = new Map<string, IPersonaProps>();
 
-        for (const query of seedQueries) {
-            const people = await this.searchTenantUsersFromPeoplePicker(query, 200);
+        const peopleResults = await Promise.all(seedQueries.map(query => {
+            return this.searchTenantUsersFromPeoplePicker(query, 200);
+        }));
+
+        for (const people of peopleResults) {
             people.forEach(person => {
                 const key = `${person.optionalText || person.secondaryText || person.text}`;
                 if (key && !uniqueUsers.has(key)) {
@@ -547,6 +550,32 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const rightDisplayNameKey = this.getDisplayNameKey(right);
 
         return !!leftDisplayNameKey && leftDisplayNameKey === rightDisplayNameKey;
+    }
+
+    private readonly isStaticUserChecked = (user: IPersonaProps, selectedUserKeys: Set<string>, selectedDisplayNames: Set<string>): boolean => {
+        const userKey = this.getIdentityKey(user);
+        const normalizedDisplayName = `${user?.text || ''}`.trim().toLowerCase();
+        return selectedUserKeys.has(userKey) || selectedDisplayNames.has(normalizedDisplayName);
+    }
+
+    private readonly getSingleSelectOptions = (filteredUsers: IPersonaProps[], textColor: string): IChoiceGroupOption[] => {
+        return filteredUsers.map(user => {
+            return {
+                key: this.getIdentityKey(user),
+                text: user.text,
+                disabled: this.props.disabled,
+                styles: {
+                    field: {
+                        color: textColor
+                    }
+                }
+            };
+        });
+    }
+
+    private readonly getSelectedSingleStaticUserKey = (filteredUsers: IPersonaProps[], selectedUserKeys: Set<string>, selectedDisplayNames: Set<string>): string | undefined => {
+        const selectedUser = filteredUsers.find(user => this.isStaticUserChecked(user, selectedUserKeys, selectedDisplayNames));
+        return selectedUser ? this.getIdentityKey(selectedUser) : undefined;
     }
 
     private readonly toggleStaticUserSelection = (person: IPersonaProps, checked: boolean): void => {
@@ -758,178 +787,184 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         return `${person?.optionalText || person?.secondaryText || person?.text || ''}`.trim();
     }
 
-    public render() {
+    private readonly onStaticPickerSearchTextChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        if (this.props.disabled) {
+            return;
+        }
 
-        if (this.isStaticPickerMode()) {
-            const staticPeoplePickerStrings = webPartStrings?.General?.StaticPeoplePicker;
-            const removeSelectedUserTitleTemplate = staticPeoplePickerStrings?.RemoveSelectedUserTitle || 'Remove {0}';
-            const searchUsersPlaceholder = staticPeoplePickerStrings?.SearchUsersPlaceholder || 'Search users';
-            const loadingTenantUsersLabel = staticPeoplePickerStrings?.LoadingTenantUsersLabel || 'Loading tenant users...';
-            const noUsersFoundMessage = staticPeoplePickerStrings?.NoUsersFoundMessage || 'No users found.';
-            const isMultiMode = this.isMultiSelectionMode();
-            const selectedPeople = this.state.pickerSelectedPeople || [];
-            const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
-            const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText)
-                .filter(person => isMultiMode || !selectedUserKeys.has(this.getIdentityKey(person)));
+        const nextSearchText = event.currentTarget.value;
 
-            const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
-            const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
-            const selectedPillBackgroundColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
-            const selectedPillBorderColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
-            const selectedPillTextColor = this.props.themeVariant?.palette?.white ?? '#ffffff';
+        if (this.pickerSearchDebounceTimer !== null) {
+            clearTimeout(this.pickerSearchDebounceTimer);
+            this.pickerSearchDebounceTimer = null;
+        }
 
-            return <div>
-                {selectedPeople.length > 0 && (
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
-                        {selectedPeople.map(person => {
-                            const personKey = this.getIdentityKey(person);
+        this.setState({ pickerSearchText: nextSearchText });
 
-                            return <button
-                                key={personKey}
-                                type="button"
-                                onClick={() => this.toggleStaticUserSelection(person, false)}
-                                disabled={this.props.disabled}
-                                style={{
-                                    alignItems: 'center',
-                                    backgroundColor: selectedPillBackgroundColor,
-                                    border: `1px solid ${selectedPillBorderColor}`,
-                                    borderRadius: 16,
-                                    color: selectedPillTextColor,
-                                    cursor: this.props.disabled ? 'not-allowed' : 'pointer',
-                                    display: 'inline-flex',
-                                    gap: 8,
-                                    opacity: this.props.disabled ? 0.6 : 1,
-                                    padding: '4px 12px'
-                                }}
-                                title={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
-                                aria-label={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
-                            >
-                                <span style={{ lineHeight: 1 }}>{person.text}</span>
-                                <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>×</span>
-                            </button>;
-                        })}
+        this.pickerSearchDebounceTimer = setTimeout(() => {
+            this.pickerSearchDebounceTimer = null;
+            this.setState({ pickerSearchFilterText: nextSearchText });
+        }, 120);
+    }
+
+    private renderStaticPeoplePicker(): JSX.Element {
+        const staticPeoplePickerStrings = webPartStrings?.General?.StaticPeoplePicker;
+        const removeSelectedUserTitleTemplate = staticPeoplePickerStrings?.RemoveSelectedUserTitle || 'Remove {0}';
+        const searchUsersPlaceholder = staticPeoplePickerStrings?.SearchUsersPlaceholder || 'Search users';
+        const loadingTenantUsersLabel = staticPeoplePickerStrings?.LoadingTenantUsersLabel || 'Loading tenant users...';
+        const noUsersFoundMessage = staticPeoplePickerStrings?.NoUsersFoundMessage || 'No users found.';
+        const isMultiMode = this.isMultiSelectionMode();
+        const selectedPeople = this.state.pickerSelectedPeople || [];
+        const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
+        const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText)
+            .filter(person => isMultiMode || !selectedUserKeys.has(this.getIdentityKey(person)));
+        const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
+        const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
+        const selectedPillBackgroundColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
+        const selectedPillBorderColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
+        const selectedPillTextColor = this.props.themeVariant?.palette?.white ?? '#ffffff';
+        const singleSelectOptions = isMultiMode ? [] : this.getSingleSelectOptions(filteredUsers, textColor);
+        const selectedSingleUserKey = isMultiMode ? undefined : this.getSelectedSingleStaticUserKey(filteredUsers, selectedUserKeys, selectedDisplayNames);
+
+        return <div>
+            {selectedPeople.length > 0 && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+                    {selectedPeople.map(person => {
+                        const personKey = this.getIdentityKey(person);
+
+                        return <button
+                            key={personKey}
+                            type="button"
+                            onClick={() => this.toggleStaticUserSelection(person, false)}
+                            disabled={this.props.disabled}
+                            style={{
+                                alignItems: 'center',
+                                backgroundColor: selectedPillBackgroundColor,
+                                border: `1px solid ${selectedPillBorderColor}`,
+                                borderRadius: 16,
+                                color: selectedPillTextColor,
+                                cursor: this.props.disabled ? 'not-allowed' : 'pointer',
+                                display: 'inline-flex',
+                                gap: 8,
+                                opacity: this.props.disabled ? 0.6 : 1,
+                                padding: '4px 12px'
+                            }}
+                            title={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
+                            aria-label={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
+                        >
+                            <span style={{ lineHeight: 1 }}>{person.text}</span>
+                            <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>x</span>
+                        </button>;
+                    })}
+                </div>
+            )}
+            <div style={{ marginBottom: 8 }}>
+                <input
+                    type="text"
+                    value={this.state.pickerSearchText}
+                    disabled={this.props.disabled}
+                    aria-label={searchUsersPlaceholder}
+                    onChange={this.onStaticPickerSearchTextChanged}
+                    placeholder={searchUsersPlaceholder}
+                    style={{ width: '100%', boxSizing: 'border-box', padding: '6px 8px' }}
+                />
+            </div>
+            <div style={{ maxHeight: 260, minHeight: 260, overflowY: 'auto', position: 'relative' }}>
+                {this.state.isPickerLoading && (
+                    <div style={{
+                        position: 'absolute',
+                        inset: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        backgroundColor: 'rgba(255,255,255,0.45)',
+                        zIndex: 1
+                    }}>
+                        <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />
                     </div>
                 )}
-                <div style={{ marginBottom: 8 }}>
-                    <input
-                        type="text"
-                        value={this.state.pickerSearchText}
-                        disabled={this.props.disabled}
-                        aria-label={searchUsersPlaceholder}
-                        onChange={(event) => {
-                            if (this.props.disabled) {
+                {!this.state.isPickerLoading && selectedPeople.length === 0 && filteredUsers.length === 0 && (
+                    <div style={{ color: '#605e5c', fontSize: 12 }}>
+                        {noUsersFoundMessage}
+                    </div>
+                )}
+                {filteredUsers.map(user => {
+                    const userKey = this.getIdentityKey(user);
+                    const checked = this.isStaticUserChecked(user, selectedUserKeys, selectedDisplayNames);
+
+                    if (isMultiMode) {
+                        return <div key={userKey} style={{ marginBottom: 6 }}>
+                            <Checkbox
+                                styles={{
+                                    root: {
+                                        paddingRight: 10,
+                                        paddingLeft: 10,
+                                        paddingBottom: 7,
+                                        paddingTop: 7
+                                    },
+                                    label: {
+                                        width: '100%',
+                                    },
+                                    text: {
+                                        color: textColor
+                                    }
+                                }}
+                                theme={(this.props.themeVariant as ITheme) || getTheme()}
+                                checked={checked}
+                                disabled={this.props.disabled}
+                                label={user.text}
+                                onChange={(ev, isChecked) => {
+                                    this.toggleStaticUserSelection(user, !!isChecked);
+                                }}
+                                title={user.text}
+                                onRenderLabel={this._renderCheckboxLabel}
+                            />
+                        </div>;
+                    }
+
+                    return null;
+                })}
+                {!isMultiMode && singleSelectOptions.length > 0 && (
+                    <ChoiceGroup
+                        selectedKey={selectedSingleUserKey}
+                        styles={{
+                            root: {
+                                position: 'relative',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                selectors: {
+                                    '.ms-ChoiceFieldGroup': {
+                                        width: '100%'
+                                    },
+                                    '.ms-ChoiceField': {
+                                        marginTop: 0,
+                                        paddingRight: 10,
+                                        paddingLeft: 10,
+                                        paddingBottom: 7,
+                                        paddingTop: 7
+                                    }
+                                }
+                            }
+                        }}
+                        options={singleSelectOptions}
+                        onChange={(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption) => {
+                            const selectedUser = filteredUsers.find(user => this.getIdentityKey(user) === option?.key);
+                            if (!selectedUser) {
                                 return;
                             }
 
-                            const nextSearchText = event.currentTarget.value;
-
-                            if (this.pickerSearchDebounceTimer !== null) {
-                                clearTimeout(this.pickerSearchDebounceTimer);
-                                this.pickerSearchDebounceTimer = null;
-                            }
-
-                            this.setState({ pickerSearchText: nextSearchText });
-
-                            this.pickerSearchDebounceTimer = setTimeout(() => {
-                                this.pickerSearchDebounceTimer = null;
-                                this.setState({ pickerSearchFilterText: nextSearchText });
-                            }, 120);
+                            this.toggleStaticUserSelection(selectedUser, true);
                         }}
-                        placeholder={searchUsersPlaceholder}
-                        style={{ width: '100%', boxSizing: 'border-box', padding: '6px 8px' }}
                     />
-                </div>
-                <div style={{ maxHeight: 260, minHeight: 260, overflowY: 'auto', position: 'relative' }}>
-                    {this.state.isPickerLoading && (
-                        <div style={{
-                            position: 'absolute',
-                            inset: 0,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            backgroundColor: 'rgba(255,255,255,0.45)',
-                            zIndex: 1
-                        }}>
-                            <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />
-                        </div>
-                    )}
-                    {!this.state.isPickerLoading && selectedPeople.length === 0 && filteredUsers.length === 0 && (
-                        <div style={{ color: '#605e5c', fontSize: 12 }}>
-                            {noUsersFoundMessage}
-                        </div>
-                    )}
-                    {filteredUsers.map(user => {
-                        const userKey = this.getIdentityKey(user);
-                        const normalizedDisplayName = `${user?.text || ''}`.trim().toLowerCase();
-                        const checked = selectedUserKeys.has(userKey) || selectedDisplayNames.has(normalizedDisplayName);
+                )}
+            </div>
+        </div>;
+    }
 
-                        if (isMultiMode) {
-                            return <div key={userKey} style={{ marginBottom: 6 }}>
-                                <Checkbox
-                                    styles={{
-                                        root: {
-                                            paddingRight: 10,
-                                            paddingLeft: 10,
-                                            paddingBottom: 7,
-                                            paddingTop: 7
-                                        },
-                                        label: {
-                                            width: '100%',
-                                        },
-                                        text: {
-                                            color: textColor
-                                        }
-                                    }}
-                                    theme={(this.props.themeVariant as ITheme) || getTheme()}
-                                    checked={checked}
-                                    disabled={this.props.disabled}
-                                    label={user.text}
-                                    onChange={(ev, isChecked) => {
-                                        this.toggleStaticUserSelection(user, !!isChecked);
-                                    }}
-                                    title={user.text}
-                                    onRenderLabel={this._renderCheckboxLabel}
-                                />
-                            </div>;
-                        }
+    public render() {
 
-                        return <ChoiceGroup
-                            key={userKey}
-                            selectedKey={checked ? userKey : undefined}
-                            styles={{
-                                root: {
-                                    position: 'relative',
-                                    display: 'flex',
-                                    paddingRight: 10,
-                                    paddingLeft: 10,
-                                    paddingBottom: 7,
-                                    paddingTop: 7,
-                                    selectors: {
-                                        '.ms-ChoiceField': {
-                                            marginTop: 0
-                                        }
-                                    }
-                                }
-                            }}
-                            options={[
-                                {
-                                    key: userKey,
-                                    text: user.text,
-                                    disabled: this.props.disabled,
-                                    styles: {
-                                        field: {
-                                            color: textColor
-                                        }
-                                    }
-                                }
-                            ]}
-                            onChange={() => {
-                                this.toggleStaticUserSelection(user, true);
-                            }}
-                        />;
-                    })}
-                </div>
-            </div>;
+        if (this.isStaticPickerMode()) {
+            return this.renderStaticPeoplePicker();
         }
 
         let filterValue: IDataFilterValueInfo = {

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -528,15 +528,32 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         return `${person?.optionalText || person?.secondaryText || person?.text || ''}`.trim().toLowerCase();
     }
 
+    private readonly getDisplayNameKey = (person: IPersonaProps): string => {
+        return `${person?.text || ''}`.trim().toLowerCase();
+    }
+
+    private readonly isSameStaticPerson = (left: IPersonaProps, right: IPersonaProps): boolean => {
+        const leftIdentityKey = this.getIdentityKey(left);
+        const rightIdentityKey = this.getIdentityKey(right);
+
+        if (leftIdentityKey && rightIdentityKey && leftIdentityKey === rightIdentityKey) {
+            return true;
+        }
+
+        const leftDisplayNameKey = this.getDisplayNameKey(left);
+        const rightDisplayNameKey = this.getDisplayNameKey(right);
+
+        return !!leftDisplayNameKey && leftDisplayNameKey === rightDisplayNameKey;
+    }
+
     private readonly toggleStaticUserSelection = (person: IPersonaProps, checked: boolean): void => {
-        const personKey = this.getIdentityKey(person);
         const currentSelection = this.state.pickerSelectedPeople || [];
         let nextSelection: IPersonaProps[];
         const isMultiMode = this.isMultiSelectionMode();
 
         if (checked) {
             if (isMultiMode) {
-                if (currentSelection.some(item => this.getIdentityKey(item) === personKey)) {
+                if (currentSelection.some(item => this.isSameStaticPerson(item, person))) {
                     nextSelection = currentSelection;
                 } else {
                     nextSelection = [...currentSelection, person];
@@ -545,7 +562,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                 nextSelection = [person];
             }
         } else {
-            nextSelection = currentSelection.filter(item => this.getIdentityKey(item) !== personKey);
+            nextSelection = currentSelection.filter(item => !this.isSameStaticPerson(item, person));
         }
 
         this.emitPickerSelection(nextSelection);

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -915,7 +915,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                     </div>
                 )}
                 {!this.state.isPickerLoading && selectableUsers.length === 0 && (
-                    <div style={{ color: '#605e5c', fontSize: 12 }}>
+                    <div style={{ color: textColor, fontSize: 12 }}>
                         {noUsersFoundMessage}
                     </div>
                 )}

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -87,6 +87,7 @@ export interface IFilterPeopleTemplateState {
     pickerSelectedPeople: IPersonaProps[];
     pickerSuggestedPeople: IPersonaProps[];
     isPickerLoading: boolean;
+    hasLoadedInitialPickerSuggestions: boolean;
     pickerSearchText: string;
     pickerSearchFilterText: string;
 }
@@ -170,6 +171,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             pickerSelectedPeople: selectedPeople,
             pickerSuggestedPeople: [],
             isPickerLoading: false,
+            hasLoadedInitialPickerSuggestions: false,
             pickerSearchText: '',
             pickerSearchFilterText: ''
         };
@@ -178,12 +180,6 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     public componentDidMount(): void {
         this._isMounted = true;
         this.restoreSelectionFeedback();
-
-        if (this.isStaticPickerMode()) {
-            this.loadInitialPickerSuggestions().catch(() => {
-                // Ignore initial suggestion lookup failures
-            });
-        }
     }
 
     public componentDidUpdate(prevProps: IFilterPeopleTemplateProps): void {
@@ -633,7 +629,8 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             if (this._isMounted) {
                 this.setState({
                     pickerSuggestedPeople: FilterPeopleTemplateComponent.tenantUsersCache,
-                    isPickerLoading: false
+                    isPickerLoading: false,
+                    hasLoadedInitialPickerSuggestions: true
                 });
             }
 
@@ -655,18 +652,36 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             if (this._isMounted) {
                 this.setState({
                     pickerSuggestedPeople,
-                    isPickerLoading: false
+                    isPickerLoading: false,
+                    hasLoadedInitialPickerSuggestions: true
                 });
             }
         } catch {
             if (this._isMounted) {
-                this.setState({ isPickerLoading: false });
+                this.setState({
+                    isPickerLoading: false,
+                    hasLoadedInitialPickerSuggestions: true
+                });
             }
         } finally {
             if (FilterPeopleTemplateComponent.tenantUsersLoadingPromise === loadingPromise) {
                 FilterPeopleTemplateComponent.setTenantUsersLoadingPromise(null);
             }
         }
+    }
+
+    private readonly ensureInitialPickerSuggestionsLoaded = (): void => {
+        if (!this.isStaticPickerMode()) {
+            return;
+        }
+
+        if (this.state.isPickerLoading || this.state.hasLoadedInitialPickerSuggestions) {
+            return;
+        }
+
+        this.loadInitialPickerSuggestions().catch(() => {
+            // Ignore initial suggestion lookup failures
+        });
     }
 
     private readonly getInitialTenantUsers = async (): Promise<IPersonaProps[]> => {
@@ -842,11 +857,10 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     }
 
     private renderStaticPeoplePicker(): JSX.Element {
-        const staticPeoplePickerStrings = webPartStrings?.General?.StaticPeoplePicker;
-        const removeSelectedUserTitleTemplate = staticPeoplePickerStrings?.RemoveSelectedUserTitle || 'Remove {0}';
-        const searchUsersPlaceholder = staticPeoplePickerStrings?.SearchUsersPlaceholder || 'Search users';
-        const loadingTenantUsersLabel = staticPeoplePickerStrings?.LoadingTenantUsersLabel || 'Loading tenant users...';
-        const noUsersFoundMessage = staticPeoplePickerStrings?.NoUsersFoundMessage || 'No users found.';
+        const { RemoveSelectedUserTitle: removeSelectedUserTitleTemplate,
+            SearchUsersPlaceholder: searchUsersPlaceholder,
+            LoadingTenantUsersLabel: loadingTenantUsersLabel,
+            NoUsersFoundMessage: noUsersFoundMessage } = webPartStrings.General.StaticPeoplePicker;
         const isMultiMode = this.isMultiSelectionMode();
         const selectedPeople = this.state.pickerSelectedPeople || [];
         const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
@@ -898,6 +912,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                     value={this.state.pickerSearchText}
                     disabled={this.props.disabled}
                     aria-label={searchUsersPlaceholder}
+                    onFocus={this.ensureInitialPickerSuggestionsLoaded}
                     onChange={this.onStaticPickerSearchTextChanged}
                     placeholder={searchUsersPlaceholder}
                     style={{ width: '100%', boxSizing: 'border-box', padding: '6px 8px' }}
@@ -917,7 +932,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />
                     </div>
                 )}
-                {!this.state.isPickerLoading && selectableUsers.length === 0 && (
+                {!this.state.isPickerLoading && this.state.hasLoadedInitialPickerSuggestions && selectableUsers.length === 0 && (
                     <div style={{ color: textColor, fontSize: 12 }}>
                         {noUsersFoundMessage}
                     </div>

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -111,6 +111,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     private static readonly SELECTION_FEEDBACK_DURATION_MS = 2500;
     private static readonly GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
     private static readonly MAX_INITIAL_GRAPH_USERS = 2000;
+    private static readonly MAX_VISIBLE_STATIC_USERS = 200;
     private static readonly GRAPH_PAGE_SIZE = 200;
     private static tenantUsersCache: IPersonaProps[] | null = null;
     private static tenantUsersLoadingPromise: Promise<IPersonaProps[]> | null = null;
@@ -585,7 +586,9 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     private readonly getSelectableStaticUsers = (filteredUsers: IPersonaProps[], selectedPeople: IPersonaProps[], isMultiMode: boolean): IPersonaProps[] => {
         if (isMultiMode) {
             const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
-            return filteredUsers.filter(person => !selectedUserKeys.has(this.getIdentityKey(person)));
+            return filteredUsers
+                .filter(person => !selectedUserKeys.has(this.getIdentityKey(person)))
+                .slice(0, FilterPeopleTemplateComponent.MAX_VISIBLE_STATIC_USERS);
         }
 
         const visibleUsers = [...selectedPeople, ...filteredUsers];
@@ -597,7 +600,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             }
         });
 
-        return uniqueUsers;
+        return uniqueUsers.slice(0, FilterPeopleTemplateComponent.MAX_VISIBLE_STATIC_USERS);
     }
 
     private readonly toggleStaticUserSelection = (person: IPersonaProps, checked: boolean): void => {

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -180,6 +180,8 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     public componentDidMount(): void {
         this._isMounted = true;
         this.restoreSelectionFeedback();
+
+        this.ensureInitialPickerSuggestionsLoaded();
     }
 
     public componentDidUpdate(prevProps: IFilterPeopleTemplateProps): void {

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -411,7 +411,10 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         }
 
         const json = await response.json();
-        const digest = json?.d?.GetContextWebInformation?.FormDigestValue;
+        const digest = `${json?.d?.GetContextWebInformation?.FormDigestValue ?? ''}`.trim();
+        if (!digest) {
+            throw new Error('Failed to retrieve request digest: missing FormDigestValue.');
+        }
         const timeoutSeconds = Number(json?.d?.GetContextWebInformation?.FormDigestTimeoutSeconds ?? 1800);
 
         this.requestDigestToken = digest;

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -820,9 +820,9 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             .filter(person => isMultiMode || !selectedUserKeys.has(this.getIdentityKey(person)));
         const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
         const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
-        const selectedPillBackgroundColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
-        const selectedPillBorderColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
-        const selectedPillTextColor = this.props.themeVariant?.palette?.white ?? '#ffffff';
+        const selectedPillBackgroundColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
+        const selectedPillBorderColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
+        const selectedPillTextColor = this.props.themeVariant?.semanticColors?.primaryButtonText ?? '#ffffff';
         const singleSelectOptions = isMultiMode ? [] : this.getSingleSelectOptions(filteredUsers, textColor);
         const selectedSingleUserKey = isMultiMode ? undefined : this.getSelectedSingleStaticUserKey(filteredUsers, selectedUserKeys, selectedDisplayNames);
 

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { BaseWebComponent, IDataFilterInfo, IDataFilterValueInfo, ExtensibilityConstants } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
 import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Spinner, SpinnerSize, Text, getTheme } from '@fluentui/react';
+import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import { MSGraphClientFactory } from '@microsoft/sp-http';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
+import * as webPartStrings from 'SearchFiltersWebPartStrings';
 import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
 
 export interface IFilterPeopleTemplateProps {
@@ -53,19 +56,68 @@ export interface IFilterPeopleTemplateProps {
     themeVariant?: IReadonlyTheme;
 
     /**
+     * Enables static people picker mode (tenant users suggestions)
+     */
+    staticPicker?: boolean | string;
+
+    /**
+     * Serialized selected values for static people picker mode
+     */
+    selectedValues?: string | Array<{ name?: string; value?: string; selected?: boolean }>;
+
+    /**
+     * Graph client factory for tenant-wide user suggestions
+     */
+    msGraphClientFactory?: MSGraphClientFactory;
+
+    /**
      * Handler when a filter value is selected
      */
-    onChecked: (filterName: string, filterValue: IDataFilterValueInfo) => void;
+    onChecked: (filterName: string, filterValue: IDataFilterValueInfo | IDataFilterValueInfo[]) => void;
 }
 
 export interface IFilterPeopleTemplateState {
     isSelectionInProgress: boolean;
+    pickerSelectedPeople: IPersonaProps[];
+    pickerSuggestedPeople: IPersonaProps[];
+    isPickerLoading: boolean;
+    pickerSearchText: string;
+    pickerSearchFilterText: string;
+}
+
+interface IPeoplePickerPrincipalEntity {
+    Key?: string;
+    DisplayText?: string;
+    EntityData?: {
+        Email?: string;
+        AccountName?: string;
+    };
+}
+
+interface IGraphUserEntity {
+    id?: string;
+    displayName?: string;
+    mail?: string;
+    userPrincipalName?: string;
 }
 
 export class FilterPeopleTemplateComponent extends React.Component<IFilterPeopleTemplateProps, IFilterPeopleTemplateState> {
     private static readonly SELECTION_FEEDBACK_DURATION_MS = 2500;
     private static readonly GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
+    private static tenantUsersCache: IPersonaProps[] | null = null;
+    private static tenantUsersLoadingPromise: Promise<IPersonaProps[]> | null = null;
     private selectionFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
+    private pickerSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    private requestDigestToken: string = null;
+    private requestDigestExpiration: number = 0;
+
+    private static setTenantUsersCache(users: IPersonaProps[]): void {
+        FilterPeopleTemplateComponent.tenantUsersCache = users;
+    }
+
+    private static setTenantUsersLoadingPromise(promise: Promise<IPersonaProps[]> | null): void {
+        FilterPeopleTemplateComponent.tenantUsersLoadingPromise = promise;
+    }
 
     private _setImmediateProgressCursor(): void {
         if (!globalThis.document) {
@@ -97,19 +149,56 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     public constructor(props: IFilterPeopleTemplateProps) {
         super(props);
 
+        let selectedPeople: IPersonaProps[] = [];
+
+        if (this.isStaticPickerMode()) {
+            selectedPeople = this.parseSelectedPeopleFromProps();
+        }
+
         this.state = {
-            isSelectionInProgress: false
+            isSelectionInProgress: false,
+            pickerSelectedPeople: selectedPeople,
+            pickerSuggestedPeople: [],
+            isPickerLoading: false,
+            pickerSearchText: '',
+            pickerSearchFilterText: ''
         };
     }
 
     public componentDidMount(): void {
         this.restoreSelectionFeedback();
+
+        if (this.isStaticPickerMode()) {
+            this.loadInitialPickerSuggestions().catch(() => {
+                // Ignore initial suggestion lookup failures
+            });
+        }
+    }
+
+    public componentDidUpdate(prevProps: IFilterPeopleTemplateProps): void {
+        if (!this.isStaticPickerMode()) {
+            return;
+        }
+
+        if (prevProps.selectedValues === this.props.selectedValues) {
+            return;
+        }
+
+        const nextSelectedPeople = this.parseSelectedPeopleFromProps();
+        this.setState({
+            pickerSelectedPeople: nextSelectedPeople
+        });
     }
 
     public componentWillUnmount(): void {
         if (this.selectionFeedbackTimer !== null) {
             clearTimeout(this.selectionFeedbackTimer);
             this.selectionFeedbackTimer = null;
+        }
+
+        if (this.pickerSearchDebounceTimer !== null) {
+            clearTimeout(this.pickerSearchDebounceTimer);
+            this.pickerSearchDebounceTimer = null;
         }
     }
 
@@ -188,6 +277,379 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         }, FilterPeopleTemplateComponent.SELECTION_FEEDBACK_DURATION_MS);
     }
 
+    private isStaticPickerMode(): boolean {
+        return `${this.props.staticPicker ?? ''}`.toLowerCase() === 'true';
+    }
+
+    private isMultiSelectionMode(): boolean {
+        const rawValue = this.props.isMulti as unknown as boolean | string | undefined;
+
+        if (typeof rawValue === 'string') {
+            return rawValue.toLowerCase() === 'true';
+        }
+
+        return !!rawValue;
+    }
+
+    private parseSelectedPeopleFromProps(): IPersonaProps[] {
+        if (!this.props.selectedValues) {
+            return this.parseSelectedPeopleFromDeepLink();
+        }
+
+        try {
+            let selectedValues: Array<{ name?: string; value?: string; selected?: boolean }> = [];
+            const rawSelectedValues = this.props.selectedValues;
+
+            if (Array.isArray(rawSelectedValues)) {
+                selectedValues = rawSelectedValues;
+            } else if (typeof rawSelectedValues === 'string') {
+                try {
+                    selectedValues = JSON.parse(rawSelectedValues) as Array<{ name?: string; value?: string; selected?: boolean }>;
+                } catch {
+                    // Handle HTML-escaped JSON payloads coming from template attributes.
+                    const decodedPayload = rawSelectedValues
+                        .replaceAll('&quot;', '"')
+                        .replaceAll('&#34;', '"')
+                        .replaceAll('&apos;', "'")
+                        .replaceAll('&#39;', "'")
+                        .replaceAll('&amp;', '&');
+                    selectedValues = JSON.parse(decodedPayload) as Array<{ name?: string; value?: string; selected?: boolean }>;
+                }
+            }
+
+            if (!Array.isArray(selectedValues)) {
+                return this.parseSelectedPeopleFromDeepLink();
+            }
+
+            const selectedPeople = selectedValues
+                .filter(value => value?.selected === true || `${value?.selected ?? ''}`.toLowerCase() === 'true')
+                .map(value => {
+                    const displayName = this._resolveDisplayLabel(value.name, value.value);
+                    return {
+                        text: displayName,
+                        secondaryText: value.value,
+                        optionalText: value.value
+                    };
+                });
+
+            // If selectedValues is provided, trust it as the source of truth even when empty.
+            // Falling back to deep link here can resurrect stale selections after deselection.
+            return selectedPeople;
+        } catch {
+            return this.parseSelectedPeopleFromDeepLink();
+        }
+    }
+
+    private parseSelectedPeopleFromDeepLink(): IPersonaProps[] {
+        try {
+            const instanceId = `${this.props.instanceId ?? ''}`.trim();
+            const filterName = `${this.props.filterName ?? ''}`.trim();
+
+            if (!instanceId || !filterName || !globalThis?.location?.search) {
+                return [];
+            }
+
+            const queryParamName = `f_${instanceId}`;
+            const queryValue = new URLSearchParams(globalThis.location.search).get(queryParamName);
+            if (!queryValue) {
+                return [];
+            }
+
+            let parsedFilters: Array<{ filterName?: string; values?: Array<{ name?: string; value?: string }> }> = [];
+            try {
+                parsedFilters = JSON.parse(queryValue);
+            } catch {
+                parsedFilters = JSON.parse(decodeURIComponent(queryValue));
+            }
+
+            if (!Array.isArray(parsedFilters)) {
+                return [];
+            }
+
+            const matchingFilter = parsedFilters.find(filter => `${filter?.filterName ?? ''}` === filterName);
+            const values = matchingFilter?.values || [];
+
+            return values
+                .filter(value => !!`${value?.name ?? value?.value ?? ''}`.trim())
+                .map(value => {
+                    const displayName = this._resolveDisplayLabel(value?.name, value?.value);
+                    return {
+                        text: displayName,
+                        secondaryText: `${value?.value ?? ''}`,
+                        optionalText: `${value?.value ?? ''}`
+                    };
+                });
+        } catch {
+            return [];
+        }
+    }
+
+    private async getRequestDigest(): Promise<string> {
+        const now = Date.now();
+        if (this.requestDigestToken && now < this.requestDigestExpiration) {
+            return this.requestDigestToken;
+        }
+
+        const response = await fetch(`${globalThis.location.origin}/_api/contextinfo`, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json;odata=verbose'
+            },
+            credentials: 'same-origin'
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to retrieve request digest. Status: ${response.status}`);
+        }
+
+        const json = await response.json();
+        const digest = json?.d?.GetContextWebInformation?.FormDigestValue;
+        const timeoutSeconds = Number(json?.d?.GetContextWebInformation?.FormDigestTimeoutSeconds ?? 1800);
+
+        this.requestDigestToken = digest;
+        this.requestDigestExpiration = Date.now() + Math.max(60, timeoutSeconds - 30) * 1000;
+
+        return digest;
+    }
+
+    private async searchTenantUsersFromPeoplePicker(queryText: string, maxSuggestions: number = 20): Promise<IPersonaProps[]> {
+        const normalizedQuery = `${queryText ?? ''}`.trim();
+        if (!normalizedQuery) {
+            return [];
+        }
+
+        const digest = await this.getRequestDigest();
+        const response = await fetch(`${globalThis.location.origin}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json;odata=verbose',
+                'Content-Type': 'application/json;odata=verbose',
+                'X-RequestDigest': digest
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify({
+                queryParams: {
+                    QueryString: normalizedQuery,
+                    MaximumEntitySuggestions: maxSuggestions,
+                    PrincipalType: 1,
+                    PrincipalSource: 15,
+                    AllowEmailAddresses: true,
+                    AllowMultipleEntities: true,
+                    AllUrlZones: false
+                }
+            })
+        });
+
+        if (!response.ok) {
+            return [];
+        }
+
+        const json = await response.json();
+        const rawResult = json?.d?.ClientPeoplePickerSearchUser;
+        const entities = rawResult ? JSON.parse(rawResult) as IPeoplePickerPrincipalEntity[] : [];
+
+        return this.mapPrincipalEntitiesToPersonas(entities);
+    }
+
+    private mapPrincipalEntitiesToPersonas(entities: IPeoplePickerPrincipalEntity[]): IPersonaProps[] {
+        return (entities || []).map(entity => {
+            const email = entity?.EntityData?.Email;
+            const accountName = entity?.EntityData?.AccountName || entity?.Key;
+            const text = entity?.DisplayText || email || accountName || '';
+
+            return {
+                text,
+                secondaryText: email || accountName,
+                optionalText: accountName
+            };
+        }).filter(persona => !!persona.text);
+    }
+
+    private readonly getSeededTenantUsers = async (): Promise<IPersonaProps[]> => {
+        const seedQueries = ['a', 'e', 'i', 'o', 'u'];
+        const uniqueUsers = new Map<string, IPersonaProps>();
+
+        for (const query of seedQueries) {
+            const people = await this.searchTenantUsersFromPeoplePicker(query, 200);
+            people.forEach(person => {
+                const key = `${person.optionalText || person.secondaryText || person.text}`;
+                if (key && !uniqueUsers.has(key)) {
+                    uniqueUsers.set(key, person);
+                }
+            });
+
+            if (uniqueUsers.size >= 500) {
+                break;
+            }
+        }
+
+        return Array.from(uniqueUsers.values()).sort((left, right) => {
+            return `${left.text ?? ''}`.localeCompare(`${right.text ?? ''}`);
+        });
+    }
+
+    private readonly filterAllPreloadedUsers = (searchText: string): IPersonaProps[] => {
+        const normalizedSearchText = `${searchText ?? ''}`.trim().toLocaleLowerCase();
+        const source = this.state.pickerSuggestedPeople || [];
+
+        if (!normalizedSearchText) {
+            return source;
+        }
+
+        return source.filter(persona => {
+            const displayName = `${persona?.text ?? ''}`.toLocaleLowerCase();
+            const mail = `${persona?.secondaryText ?? ''}`.toLocaleLowerCase();
+            const principalName = `${persona?.optionalText ?? ''}`.toLocaleLowerCase();
+            return displayName.includes(normalizedSearchText)
+                || mail.includes(normalizedSearchText)
+                || principalName.includes(normalizedSearchText);
+        });
+    }
+
+    private readonly getIdentityKey = (person: IPersonaProps): string => {
+        return `${person?.optionalText || person?.secondaryText || person?.text || ''}`.trim().toLowerCase();
+    }
+
+    private readonly toggleStaticUserSelection = (person: IPersonaProps, checked: boolean): void => {
+        const personKey = this.getIdentityKey(person);
+        const currentSelection = this.state.pickerSelectedPeople || [];
+        let nextSelection: IPersonaProps[];
+        const isMultiMode = this.isMultiSelectionMode();
+
+        if (checked) {
+            if (isMultiMode) {
+                if (currentSelection.some(item => this.getIdentityKey(item) === personKey)) {
+                    nextSelection = currentSelection;
+                } else {
+                    nextSelection = [...currentSelection, person];
+                }
+            } else {
+                nextSelection = [person];
+            }
+        } else {
+            nextSelection = currentSelection.filter(item => this.getIdentityKey(item) !== personKey);
+        }
+
+        this.emitPickerSelection(nextSelection);
+        this.setState({
+            pickerSelectedPeople: nextSelection
+        });
+    }
+
+    private readonly loadInitialPickerSuggestions = async (): Promise<void> => {
+        if (Array.isArray(FilterPeopleTemplateComponent.tenantUsersCache)) {
+            this.setState({
+                pickerSuggestedPeople: FilterPeopleTemplateComponent.tenantUsersCache,
+                isPickerLoading: false
+            });
+            return;
+        }
+
+        this.setState({ isPickerLoading: true });
+
+        const existingLoadingPromise = FilterPeopleTemplateComponent.tenantUsersLoadingPromise;
+        const loadingPromise = existingLoadingPromise ?? this.getInitialTenantUsers();
+        FilterPeopleTemplateComponent.setTenantUsersLoadingPromise(loadingPromise);
+
+        try {
+            const pickerSuggestedPeople = await loadingPromise;
+            FilterPeopleTemplateComponent.setTenantUsersCache(pickerSuggestedPeople);
+
+            this.setState({
+                pickerSuggestedPeople,
+                isPickerLoading: false
+            });
+        } catch {
+            this.setState({ isPickerLoading: false });
+        } finally {
+            if (FilterPeopleTemplateComponent.tenantUsersLoadingPromise === loadingPromise) {
+                FilterPeopleTemplateComponent.setTenantUsersLoadingPromise(null);
+            }
+        }
+    }
+
+    private readonly getInitialTenantUsers = async (): Promise<IPersonaProps[]> => {
+        if (!this.props.msGraphClientFactory) {
+            return [];
+        }
+
+        try {
+            const client = await this.props.msGraphClientFactory.getClient('3');
+            let users: IGraphUserEntity[] = [];
+            let response = await client
+                .api('/users')
+                .version('v1.0')
+                .select('id,displayName,mail,userPrincipalName')
+                .top(999)
+                .get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
+
+            users = users.concat(Array.isArray(response?.value) ? response.value : []);
+
+            let nextLink = response?.['@odata.nextLink'];
+            let pageCount = 1;
+
+            while (nextLink && pageCount < 100) {
+                response = await client.api(nextLink).get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
+                users = users.concat(Array.isArray(response?.value) ? response.value : []);
+                nextLink = response?.['@odata.nextLink'];
+                pageCount++;
+            }
+
+            const uniqueUsers = new Map<string, IPersonaProps>();
+            users.forEach(user => {
+                const text = `${user.displayName || user.mail || user.userPrincipalName || ''}`.trim();
+                const secondaryText = `${user.mail || user.userPrincipalName || ''}`.trim();
+                const optionalText = `${user.userPrincipalName || ''}`.trim();
+                const key = `${optionalText || secondaryText || text}`;
+
+                if (text && !uniqueUsers.has(key)) {
+                    uniqueUsers.set(key, {
+                        text,
+                        secondaryText,
+                        optionalText
+                    });
+                }
+            });
+
+            return Array.from(uniqueUsers.values()).sort((left, right) => {
+                return `${left.text ?? ''}`.localeCompare(`${right.text ?? ''}`);
+            });
+        } catch {
+            try {
+                return await this.getSeededTenantUsers();
+            } catch {
+                return [];
+            }
+        }
+    }
+
+    private readonly emitPickerSelection = (selectedPeople: IPersonaProps[]): void => {
+        const previouslySelected = this.state.pickerSelectedPeople || [];
+        const selectedFilterValues: IDataFilterValueInfo[] = selectedPeople.map(person => {
+            const fallbackIdentity = this.getStaticPersonIdentityValue(person);
+            const displayName = `${person?.text || fallbackIdentity}`.trim();
+            return {
+                name: displayName,
+                value: fallbackIdentity,
+                selected: true
+            };
+        });
+
+        previouslySelected.forEach(previousPerson => {
+            const previousIdentity = this.getStaticPersonIdentityValue(previousPerson);
+            if (!selectedFilterValues.some(value => value.value === previousIdentity)) {
+                const previousDisplayName = `${previousPerson?.text || previousIdentity}`.trim();
+                selectedFilterValues.push({
+                    name: previousDisplayName,
+                    value: previousIdentity,
+                    selected: false
+                });
+            }
+        });
+
+        this.props.onChecked(this.props.filterName, selectedFilterValues);
+    }
+
     private _extractReadableLabel(value: string): string {
         const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
         if (!cleanedValue) {
@@ -248,7 +710,170 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         return rawLabel;
     }
 
+    private getStaticPersonIdentityValue(person: IPersonaProps): string {
+        return `${person?.optionalText || person?.secondaryText || person?.text || ''}`.trim();
+    }
+
     public render() {
+
+        if (this.isStaticPickerMode()) {
+            const staticPeoplePickerStrings = webPartStrings?.General?.StaticPeoplePicker;
+            const removeSelectedUserTitleTemplate = staticPeoplePickerStrings?.RemoveSelectedUserTitle || 'Remove {0}';
+            const searchUsersPlaceholder = staticPeoplePickerStrings?.SearchUsersPlaceholder || 'Search users';
+            const loadingTenantUsersLabel = staticPeoplePickerStrings?.LoadingTenantUsersLabel || 'Loading tenant users...';
+            const noUsersFoundMessage = staticPeoplePickerStrings?.NoUsersFoundMessage || 'No users found.';
+            const isMultiMode = this.isMultiSelectionMode();
+            const selectedPeople = this.state.pickerSelectedPeople || [];
+            const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
+            const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText)
+                .filter(person => isMultiMode || !selectedUserKeys.has(this.getIdentityKey(person)));
+
+            const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
+            const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
+
+            return <div>
+                {selectedPeople.length > 0 && (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+                        {selectedPeople.map(person => {
+                            const personKey = this.getIdentityKey(person);
+
+                            return <button
+                                key={personKey}
+                                type="button"
+                                onClick={() => this.toggleStaticUserSelection(person, false)}
+                                style={{
+                                    alignItems: 'center',
+                                    backgroundColor: '#106ebe',
+                                    border: '1px solid #106ebe',
+                                    borderRadius: 16,
+                                    color: '#ffffff',
+                                    cursor: 'pointer',
+                                    display: 'inline-flex',
+                                    gap: 8,
+                                    padding: '4px 12px'
+                                }}
+                                title={removeSelectedUserTitleTemplate.replace('{0}', `${person.text ?? ''}`)}
+                            >
+                                <span style={{ lineHeight: 1 }}>{person.text}</span>
+                                <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>×</span>
+                            </button>;
+                        })}
+                    </div>
+                )}
+                <div style={{ marginBottom: 8 }}>
+                    <input
+                        type="text"
+                        value={this.state.pickerSearchText}
+                        onChange={(event) => {
+                            const nextSearchText = event.currentTarget.value;
+
+                            if (this.pickerSearchDebounceTimer !== null) {
+                                clearTimeout(this.pickerSearchDebounceTimer);
+                                this.pickerSearchDebounceTimer = null;
+                            }
+
+                            this.setState({ pickerSearchText: nextSearchText });
+
+                            this.pickerSearchDebounceTimer = setTimeout(() => {
+                                this.pickerSearchDebounceTimer = null;
+                                this.setState({ pickerSearchFilterText: nextSearchText });
+                            }, 120);
+                        }}
+                        placeholder={searchUsersPlaceholder}
+                        style={{ width: '100%', boxSizing: 'border-box', padding: '6px 8px' }}
+                    />
+                </div>
+                <div style={{ maxHeight: 260, minHeight: 260, overflowY: 'auto', position: 'relative' }}>
+                    {this.state.isPickerLoading && (
+                        <div style={{
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            backgroundColor: 'rgba(255,255,255,0.45)',
+                            zIndex: 1
+                        }}>
+                            <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />
+                        </div>
+                    )}
+                    {!this.state.isPickerLoading && selectedPeople.length === 0 && filteredUsers.length === 0 && (
+                        <div style={{ color: '#605e5c', fontSize: 12 }}>
+                            {noUsersFoundMessage}
+                        </div>
+                    )}
+                    {filteredUsers.map(user => {
+                        const userKey = this.getIdentityKey(user);
+                        const normalizedDisplayName = `${user?.text || ''}`.trim().toLowerCase();
+                        const checked = selectedUserKeys.has(userKey) || selectedDisplayNames.has(normalizedDisplayName);
+
+                        if (isMultiMode) {
+                            return <div key={userKey} style={{ marginBottom: 6 }}>
+                                <Checkbox
+                                    styles={{
+                                        root: {
+                                            paddingRight: 10,
+                                            paddingLeft: 10,
+                                            paddingBottom: 7,
+                                            paddingTop: 7
+                                        },
+                                        label: {
+                                            width: '100%',
+                                        },
+                                        text: {
+                                            color: textColor
+                                        }
+                                    }}
+                                    theme={(this.props.themeVariant as ITheme) || getTheme()}
+                                    checked={checked}
+                                    label={user.text}
+                                    onChange={(ev, isChecked) => {
+                                        this.toggleStaticUserSelection(user, !!isChecked);
+                                    }}
+                                    title={user.text}
+                                    onRenderLabel={this._renderCheckboxLabel}
+                                />
+                            </div>;
+                        }
+
+                        return <ChoiceGroup
+                            key={userKey}
+                            selectedKey={checked ? userKey : undefined}
+                            styles={{
+                                root: {
+                                    position: 'relative',
+                                    display: 'flex',
+                                    paddingRight: 10,
+                                    paddingLeft: 10,
+                                    paddingBottom: 7,
+                                    paddingTop: 7,
+                                    selectors: {
+                                        '.ms-ChoiceField': {
+                                            marginTop: 0
+                                        }
+                                    }
+                                }
+                            }}
+                            options={[
+                                {
+                                    key: userKey,
+                                    text: user.text,
+                                    disabled: this.props.disabled,
+                                    styles: {
+                                        field: {
+                                            color: textColor
+                                        }
+                                    }
+                                }
+                            ]}
+                            onChange={() => {
+                                this.toggleStaticUserSelection(user, true);
+                            }}
+                        />;
+                    })}
+                </div>
+            </div>;
+        }
 
         let filterValue: IDataFilterValueInfo = {
             name: this.props.name,
@@ -262,7 +887,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         let textColor: string = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
         const labelValue = this._resolveDisplayLabel(filterValue.name, filterValue.value);
 
-        if (this.props.isMulti) {
+        if (this.isMultiSelectionMode()) {
             renderInput = <Checkbox
                 styles={{
                     root: {
@@ -352,18 +977,51 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
 
 export class FilterPeopleCheckBoxWebComponent extends BaseWebComponent {
 
+    public static get observedAttributes(): string[] {
+        return [
+            'data-instance-id',
+            'data-filter-name',
+            'data-is-multi',
+            'data-static-picker',
+            'data-selected-values',
+            'data-theme-variant',
+            'data-name',
+            'data-value',
+            'data-selected',
+            'data-disabled',
+            'data-count'
+        ];
+    }
+
     public constructor() {
         super();
     }
 
+    public attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+        if (oldValue === newValue || !this.isConnected) {
+            return;
+        }
+
+        this.renderComponent();
+    }
+
     public connectedCallback() {
 
-        let props = this.resolveAttributes();
-        const checkBox = <FilterPeopleTemplateComponent {...props} onChecked={(filterName: string, filterValue: IDataFilterValueInfo) => {
+        this.renderComponent();
+    }
+
+    private renderComponent(): void {
+
+        let props = this.resolveAttributes() as IFilterPeopleTemplateProps;
+        props.msGraphClientFactory = this._serviceScope.consume(MSGraphClientFactory.serviceKey);
+
+        const checkBox = <FilterPeopleTemplateComponent {...props} onChecked={(filterName: string, filterValue: IDataFilterValueInfo | IDataFilterValueInfo[]) => {
+            const selectedFilterValues = Array.isArray(filterValue) ? filterValue : [filterValue];
+
             // Bubble event through the DOM
             const detail: IDataFilterInfo = {
                 filterName: filterName,
-                filterValues: [filterValue],
+                filterValues: selectedFilterValues,
                 instanceId: props.instanceId
             };
             this.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_UPDATED, {

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -321,11 +321,11 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                 } catch {
                     // Handle HTML-escaped JSON payloads coming from template attributes.
                     const decodedPayload = rawSelectedValues
+                        .replaceAll('&amp;', '&')
                         .replaceAll('&quot;', '"')
                         .replaceAll('&#34;', '"')
                         .replaceAll('&apos;', "'")
-                        .replaceAll('&#39;', "'")
-                        .replaceAll('&amp;', '&');
+                        .replaceAll('&#39;', "'");
                     selectedValues = JSON.parse(decodedPayload) as Array<{ name?: string; value?: string; selected?: boolean }>;
                 }
             }
@@ -547,8 +547,8 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const leftIdentityKey = this.getIdentityKey(left);
         const rightIdentityKey = this.getIdentityKey(right);
 
-        if (leftIdentityKey && rightIdentityKey && leftIdentityKey === rightIdentityKey) {
-            return true;
+        if (leftIdentityKey && rightIdentityKey) {
+            return leftIdentityKey === rightIdentityKey;
         }
 
         const leftDisplayNameKey = this.getDisplayNameKey(left);

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -871,6 +871,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const selectedPillBackgroundColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
         const selectedPillBorderColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
         const selectedPillTextColor = this.props.themeVariant?.semanticColors?.primaryButtonText ?? '#ffffff';
+        const loadingOverlayBackgroundColor = this.props.themeVariant?.isInverted ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.45)';
         const singleSelectOptions = isMultiMode ? [] : this.getSingleSelectOptions(selectableUsers, textColor);
         const selectedSingleUserKey = isMultiMode ? undefined : this.getSelectedSingleStaticUserKey(selectableUsers, selectedUserKeys, selectedDisplayNames);
 
@@ -926,7 +927,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
-                        backgroundColor: 'rgba(255,255,255,0.45)',
+                        backgroundColor: loadingOverlayBackgroundColor,
                         zIndex: 1
                     }}>
                         <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -118,6 +118,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     private pickerSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     private requestDigestToken: string = null;
     private requestDigestExpiration: number = 0;
+    private _isMounted: boolean = false;
 
     private static setTenantUsersCache(users: IPersonaProps[]): void {
         FilterPeopleTemplateComponent.tenantUsersCache = users;
@@ -174,6 +175,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     }
 
     public componentDidMount(): void {
+        this._isMounted = true;
         this.restoreSelectionFeedback();
 
         if (this.isStaticPickerMode()) {
@@ -199,6 +201,8 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     }
 
     public componentWillUnmount(): void {
+        this._isMounted = false;
+
         if (this.selectionFeedbackTimer !== null) {
             clearTimeout(this.selectionFeedbackTimer);
             this.selectionFeedbackTimer = null;
@@ -623,14 +627,19 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
 
     private readonly loadInitialPickerSuggestions = async (): Promise<void> => {
         if (Array.isArray(FilterPeopleTemplateComponent.tenantUsersCache)) {
-            this.setState({
-                pickerSuggestedPeople: FilterPeopleTemplateComponent.tenantUsersCache,
-                isPickerLoading: false
-            });
+            if (this._isMounted) {
+                this.setState({
+                    pickerSuggestedPeople: FilterPeopleTemplateComponent.tenantUsersCache,
+                    isPickerLoading: false
+                });
+            }
+
             return;
         }
 
-        this.setState({ isPickerLoading: true });
+        if (this._isMounted) {
+            this.setState({ isPickerLoading: true });
+        }
 
         const existingLoadingPromise = FilterPeopleTemplateComponent.tenantUsersLoadingPromise;
         const loadingPromise = existingLoadingPromise ?? this.getInitialTenantUsers();
@@ -640,12 +649,16 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             const pickerSuggestedPeople = await loadingPromise;
             FilterPeopleTemplateComponent.setTenantUsersCache(pickerSuggestedPeople);
 
-            this.setState({
-                pickerSuggestedPeople,
-                isPickerLoading: false
-            });
+            if (this._isMounted) {
+                this.setState({
+                    pickerSuggestedPeople,
+                    isPickerLoading: false
+                });
+            }
         } catch {
-            this.setState({ isPickerLoading: false });
+            if (this._isMounted) {
+                this.setState({ isPickerLoading: false });
+            }
         } finally {
             if (FilterPeopleTemplateComponent.tenantUsersLoadingPromise === loadingPromise) {
                 FilterPeopleTemplateComponent.setTenantUsersLoadingPromise(null);

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -5,6 +5,7 @@ import { Checkbox, ChoiceGroup, ICheckboxProps, IChoiceGroupOption, ITheme, Spin
 import { IPersonaProps } from '@fluentui/react/lib/Persona';
 import { MSGraphClientFactory } from '@microsoft/sp-http';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
+import { PageContext } from '@microsoft/sp-page-context';
 import * as webPartStrings from 'SearchFiltersWebPartStrings';
 import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
 
@@ -71,6 +72,11 @@ export interface IFilterPeopleTemplateProps {
     msGraphClientFactory?: MSGraphClientFactory;
 
     /**
+     * Current web absolute URL (for SharePoint REST endpoints)
+     */
+    webAbsoluteUrl?: string;
+
+    /**
      * Handler when a filter value is selected
      */
     onChecked: (filterName: string, filterValue: IDataFilterValueInfo | IDataFilterValueInfo[]) => void;
@@ -104,6 +110,8 @@ interface IGraphUserEntity {
 export class FilterPeopleTemplateComponent extends React.Component<IFilterPeopleTemplateProps, IFilterPeopleTemplateState> {
     private static readonly SELECTION_FEEDBACK_DURATION_MS = 2500;
     private static readonly GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
+    private static readonly MAX_INITIAL_GRAPH_USERS = 2000;
+    private static readonly GRAPH_PAGE_SIZE = 200;
     private static tenantUsersCache: IPersonaProps[] | null = null;
     private static tenantUsersLoadingPromise: Promise<IPersonaProps[]> | null = null;
     private selectionFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
@@ -390,7 +398,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             return this.requestDigestToken;
         }
 
-        const response = await fetch(`${globalThis.location.origin}/_api/contextinfo`, {
+        const response = await fetch(`${this.getCurrentWebAbsoluteUrl()}/_api/contextinfo`, {
             method: 'POST',
             headers: {
                 'Accept': 'application/json;odata=verbose'
@@ -419,7 +427,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         }
 
         const digest = await this.getRequestDigest();
-        const response = await fetch(`${globalThis.location.origin}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`, {
+        const response = await fetch(`${this.getCurrentWebAbsoluteUrl()}/_api/SP.UI.ApplicationPages.ClientPeoplePickerWebServiceInterface.clientPeoplePickerSearchUser`, {
             method: 'POST',
             headers: {
                 'Accept': 'application/json;odata=verbose',
@@ -463,6 +471,16 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                 optionalText: accountName
             };
         }).filter(persona => !!persona.text);
+    }
+
+    private getCurrentWebAbsoluteUrl(): string {
+        const configuredWebAbsoluteUrl = `${this.props.webAbsoluteUrl ?? ''}`.trim();
+        if (configuredWebAbsoluteUrl) {
+            return configuredWebAbsoluteUrl.replace(/\/$/, '');
+        }
+
+        const globalOrigin = `${globalThis?.location?.origin ?? ''}`.trim();
+        return globalOrigin;
     }
 
     private readonly getSeededTenantUsers = async (): Promise<IPersonaProps[]> => {
@@ -580,17 +598,23 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                 .api('/users')
                 .version('v1.0')
                 .select('id,displayName,mail,userPrincipalName')
-                .top(999)
+                .top(FilterPeopleTemplateComponent.GRAPH_PAGE_SIZE)
                 .get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
 
             users = users.concat(Array.isArray(response?.value) ? response.value : []);
+            if (users.length > FilterPeopleTemplateComponent.MAX_INITIAL_GRAPH_USERS) {
+                users = users.slice(0, FilterPeopleTemplateComponent.MAX_INITIAL_GRAPH_USERS);
+            }
 
             let nextLink = response?.['@odata.nextLink'];
             let pageCount = 1;
 
-            while (nextLink && pageCount < 100) {
+            while (nextLink && pageCount < 100 && users.length < FilterPeopleTemplateComponent.MAX_INITIAL_GRAPH_USERS) {
                 response = await client.api(nextLink).get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
                 users = users.concat(Array.isArray(response?.value) ? response.value : []);
+                if (users.length > FilterPeopleTemplateComponent.MAX_INITIAL_GRAPH_USERS) {
+                    users = users.slice(0, FilterPeopleTemplateComponent.MAX_INITIAL_GRAPH_USERS);
+                }
                 nextLink = response?.['@odata.nextLink'];
                 pageCount++;
             }
@@ -730,6 +754,9 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
 
             const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
             const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
+            const selectedPillBackgroundColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
+            const selectedPillBorderColor = this.props.themeVariant?.palette?.themePrimary ?? '#106ebe';
+            const selectedPillTextColor = this.props.themeVariant?.palette?.white ?? '#ffffff';
 
             return <div>
                 {selectedPeople.length > 0 && (
@@ -744,10 +771,10 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                                 disabled={this.props.disabled}
                                 style={{
                                     alignItems: 'center',
-                                    backgroundColor: '#106ebe',
-                                    border: '1px solid #106ebe',
+                                    backgroundColor: selectedPillBackgroundColor,
+                                    border: `1px solid ${selectedPillBorderColor}`,
                                     borderRadius: 16,
-                                    color: '#ffffff',
+                                    color: selectedPillTextColor,
                                     cursor: this.props.disabled ? 'not-allowed' : 'pointer',
                                     display: 'inline-flex',
                                     gap: 8,
@@ -1024,6 +1051,7 @@ export class FilterPeopleCheckBoxWebComponent extends BaseWebComponent {
 
         let props = this.resolveAttributes() as IFilterPeopleTemplateProps;
         props.msGraphClientFactory = this._serviceScope.consume(MSGraphClientFactory.serviceKey);
+        props.webAbsoluteUrl = this._serviceScope.consume(PageContext.serviceKey)?.web?.absoluteUrl;
 
         const checkBox = <FilterPeopleTemplateComponent {...props} onChecked={(filterName: string, filterValue: IDataFilterValueInfo | IDataFilterValueInfo[]) => {
             const selectedFilterValues = Array.isArray(filterValue) ? filterValue : [filterValue];

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -578,6 +578,24 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         return selectedUser ? this.getIdentityKey(selectedUser) : undefined;
     }
 
+    private readonly getSelectableStaticUsers = (filteredUsers: IPersonaProps[], selectedPeople: IPersonaProps[], isMultiMode: boolean): IPersonaProps[] => {
+        if (isMultiMode) {
+            const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
+            return filteredUsers.filter(person => !selectedUserKeys.has(this.getIdentityKey(person)));
+        }
+
+        const visibleUsers = [...selectedPeople, ...filteredUsers];
+        const uniqueUsers: IPersonaProps[] = [];
+
+        visibleUsers.forEach(person => {
+            if (!uniqueUsers.some(existingPerson => this.isSameStaticPerson(existingPerson, person))) {
+                uniqueUsers.push(person);
+            }
+        });
+
+        return uniqueUsers;
+    }
+
     private readonly toggleStaticUserSelection = (person: IPersonaProps, checked: boolean): void => {
         const currentSelection = this.state.pickerSelectedPeople || [];
         let nextSelection: IPersonaProps[];
@@ -817,9 +835,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
         const selectedPeople = this.state.pickerSelectedPeople || [];
         const selectedUserKeys = new Set(selectedPeople.map(person => this.getIdentityKey(person)));
         const filteredUsers = this.filterAllPreloadedUsers(this.state.pickerSearchFilterText);
-        const selectableUsers = isMultiMode
-            ? filteredUsers.filter(person => !selectedUserKeys.has(this.getIdentityKey(person)))
-            : filteredUsers;
+        const selectableUsers = this.getSelectableStaticUsers(filteredUsers, selectedPeople, isMultiMode);
         const selectedDisplayNames = new Set(selectedPeople.map(person => `${person?.text || ''}`.trim().toLowerCase()).filter(Boolean));
         const textColor = this.props.themeVariant?.isInverted ? this.props.themeVariant?.semanticColors?.bodyText ?? '#323130' : this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
         const selectedPillBackgroundColor = this.props.themeVariant?.semanticColors?.primaryButtonBackground ?? '#106ebe';
@@ -885,7 +901,7 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
                         <Spinner size={SpinnerSize.small} label={loadingTenantUsersLabel} />
                     </div>
                 )}
-                {!this.state.isPickerLoading && selectedPeople.length === 0 && filteredUsers.length === 0 && (
+                {!this.state.isPickerLoading && selectableUsers.length === 0 && (
                     <div style={{ color: '#605e5c', fontSize: 12 }}>
                         {noUsersFoundMessage}
                     </div>

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -23,6 +23,7 @@ import { BuiltinDataSourceProviderKeys } from "./AvailableDataSources";
 import { AutoCalculatedDataSourceFields, SortableFields } from "../common/Constants";
 import LocalizationHelper from "../helpers/LocalizationHelper";
 import { ObjectHelper } from "../helpers/ObjectHelper";
+import { BuiltinFilterTemplates } from "../layouts/AvailableTemplates";
 
 export enum EntityType {
     Message = 'message',
@@ -1202,7 +1203,9 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private buildAggregations(dataContext: IDataContext): ISearchRequestAggregation[] {
-        return dataContext.filters.filtersConfiguration.map(filterConfig => {
+        return dataContext.filters.filtersConfiguration.filter(filterConfig => {
+            return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople;
+        }).map(filterConfig => {
             const aggregation: ISearchRequestAggregation = {
                 field: filterConfig.filterName,
                 bucketDefinition: {

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -40,6 +40,7 @@ import { BuiltinDataSourceProviderKeys } from './AvailableDataSources';
 import { StringHelper } from '../helpers/StringHelper';
 import { AutoCalculatedDataSourceFields, SortableFields } from '../common/Constants';
 import { ObjectHelper } from '../helpers/ObjectHelper';
+import { BuiltinFilterTemplates } from '../layouts/AvailableTemplates';
 import commonStyles from '../styles/Common.module.scss';
 import { PnPClientStorage } from "@pnp/common/storage";
 
@@ -1004,7 +1005,9 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
         if (!isEmpty(dataContext.filters)) {
 
             // Set list of refiners to retrieve
-            searchQuery.Refiners = dataContext.filters.filtersConfiguration.map(filterConfig => {
+            searchQuery.Refiners = dataContext.filters.filtersConfiguration.filter(filterConfig => {
+                return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople;
+            }).map(filterConfig => {
 
                 // Special case with Date managed properties
                 const regexExpr = "(RefinableDate\\d+)(?=,|$)|" +

--- a/search-parts/src/helpers/DataFilterHelper.ts
+++ b/search-parts/src/helpers/DataFilterHelper.ts
@@ -209,7 +209,7 @@ export class DataFilterHelper {
                     }
 
                     // Enclose the expression with quotes if the value contains spaces, or number only
-                    if ((/\s/.test(value) && value.indexOf('range') === -1) || (filter.filterName.indexOf("RefinableString") && /^\d+$/.test(value))) {
+                    if ((/\s/.test(value) && value.indexOf('range') === -1) || (filter.filterName.includes("RefinableString") && /^\d+$/.test(value))) {
                         value = DataFilterHelper.quoteStringRefinementValue(value);
                     }
 

--- a/search-parts/src/helpers/DataFilterHelper.ts
+++ b/search-parts/src/helpers/DataFilterHelper.ts
@@ -18,6 +18,18 @@ export class DataFilterHelper {
     }
 
     /**
+     * Escapes a string value so it can be safely wrapped in double quotes for KQL/FQL refinements.
+     */
+    private static quoteStringRefinementValue(value: string): string {
+        const normalizedValue = `${value ?? ''}`;
+        const escapedValue = normalizedValue
+            .replaceAll('\\', String.raw`\\`)
+            .replaceAll('"', String.raw`\"`);
+
+        return `"${escapedValue}"`;
+    }
+
+    /**
      * Returns the configuration for a specific filter
      * @param filter the filter
      * @param filtersConfiguration the filtes configuraton 
@@ -121,7 +133,7 @@ export class DataFilterHelper {
                             }
                         }
                         else {
-                            return `${filterName}:"${refinement.name}"`;
+                            return `${filterName}:${DataFilterHelper.quoteStringRefinementValue(refinement.name)}`;
                         }
                     }).filter(c => c);
 
@@ -198,7 +210,7 @@ export class DataFilterHelper {
 
                     // Enclose the expression with quotes if the value contains spaces, or number only
                     if ((/\s/.test(value) && value.indexOf('range') === -1) || (filter.filterName.indexOf("RefinableString") && /^\d+$/.test(value))) {
-                        value = `"${value}"`;
+                        value = DataFilterHelper.quoteStringRefinementValue(value);
                     }
 
                     return /ǂǂ/.test(value) && encodeTokens ? encodeURIComponent(value) : value;
@@ -257,7 +269,7 @@ export class DataFilterHelper {
 
                     // Enclose the expression with quotes if the value contains spaces
                     if (/\s/.test(refinementToken) && refinementToken.indexOf('range') === -1) {
-                        refinementToken = `"${refinementToken}"`;
+                        refinementToken = DataFilterHelper.quoteStringRefinementValue(refinementToken);
                     }
 
                     refinementQueryConditions.push(`${filter.filterName}:${refinementToken}`);

--- a/search-parts/src/layouts/AvailableTemplates.ts
+++ b/search-parts/src/layouts/AvailableTemplates.ts
@@ -5,6 +5,7 @@ export enum BuiltinFilterTemplates {
     DateRange = 'DateRangeFilterTemplate',
     ComboBox = 'ComboBoxFilterTemplate',
     People = 'PeopleTemplate',
+    StaticPeople = 'StaticPeopleTemplate',
     DateInterval = 'DateIntervalFilterTemplate',
     TaxonomyPicker = 'TaxonomyPickerFilterTemplate',
     Hierarchical = 'HierarchicalFilterTemplate'
@@ -19,6 +20,7 @@ export const BuiltinFilterTypes = {
     [BuiltinFilterTemplates.ComboBox]: FilterType.Refiner,
     [BuiltinFilterTemplates.People]: FilterType.Refiner,
     [BuiltinFilterTemplates.Hierarchical]: FilterType.Refiner,
+    [BuiltinFilterTemplates.StaticPeople]: FilterType.StaticFilter,
     [BuiltinFilterTemplates.DateRange]: FilterType.StaticFilter,
     [BuiltinFilterTemplates.TaxonomyPicker]: FilterType.StaticFilter
 };

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -236,6 +236,28 @@
 										{{/each}}
 									</div>				
 									{{else}}
+											{{#eq filter.selectedTemplate 'StaticPeopleTemplate'}}
+												{{#if filter.isMulti}}
+													<div class="filter--option">
+														<pnp-filteroperator 
+															data-instance-id="{{@root.instanceId}}"
+															data-filter-name="{{filter.filterName}}" 
+															data-operator="{{filter.operator}}" 
+															data-theme-variant="{{JSONstringify @root.theme}}"
+														></pnp-filteroperator>
+													</div>
+												{{/if}}
+												<div class="filter--option">
+													<pnp-peoplefilter
+														data-instance-id="{{@root.instanceId}}"
+														data-filter-name="{{filter.filterName}}"
+														data-is-multi="{{filter.isMulti}}"
+														data-static-picker="true"
+														data-selected-values="{{JSONstringify filter.values 2}}"
+														data-theme-variant="{{JSONstringify @root.theme}}"
+													></pnp-peoplefilter>
+												</div>
+											{{else}}
 
 										{{#eq filter.selectedTemplate 'DateIntervalFilterTemplate'}}
 											<div class="filter--value">
@@ -260,6 +282,7 @@
 												</div>
 											{{/eq}}
 										{{/eq}}	
+										{{/eq}}
 									{{/eq}}	
 								{{/eq}}
 							{{/eq}}
@@ -272,9 +295,11 @@
 									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
 								{{else}}
 									{{#eq filter.values.length 0}}
-										<div class="filter--message">
-											{{@root.strings.FilterNoValuesMessage}}
-										</div>
+										{{#isnt filter.selectedTemplate 'StaticPeopleTemplate'}}
+											<div class="filter--message">
+												{{@root.strings.FilterNoValuesMessage}}
+											</div>
+										{{/isnt}}
 									{{else}}
 										{{#if filter.isMulti}}
 											<pnp-filtermultiselect 

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -258,6 +258,28 @@
                                                             {{/each}}
                                                         </div>
                                                     {{else}}
+                                                        {{#eq filter.selectedTemplate 'StaticPeopleTemplate'}}
+                                                            {{#if filter.isMulti}}
+                                                                <div class="filter--option">
+                                                                    <pnp-filteroperator 
+                                                                        data-instance-id="{{@root.instanceId}}"
+                                                                        data-filter-name="{{filter.filterName}}" 
+                                                                        data-operator="{{filter.operator}}" 
+                                                                        data-theme-variant="{{JSONstringify @root.theme}}"
+                                                                    ></pnp-filteroperator>
+                                                                </div>
+                                                            {{/if}}
+                                                            <div class="filter--option">
+                                                                <pnp-peoplefilter
+                                                                    data-instance-id="{{@root.instanceId}}"
+                                                                    data-filter-name="{{filter.filterName}}"
+                                                                    data-is-multi="{{filter.isMulti}}"
+                                                                    data-static-picker="true"
+                                                                    data-selected-values="{{JSONstringify filter.values 2}}"
+                                                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                                                ></pnp-peoplefilter>
+                                                            </div>
+                                                        {{else}}
                                                         {{#eq filter.selectedTemplate 'DateIntervalFilterTemplate'}}
                                                             <div class="filter--value">
                                                                 <pnp-filterdateinterval 
@@ -281,6 +303,7 @@
                                                                 </div>
                                                             {{/eq}}
                                                         {{/eq}}
+														{{/eq}}
                                                     {{/eq}}
                                                 {{/eq}}
                                             {{/eq}}
@@ -294,9 +317,11 @@
                                                 {{else}}
                                                     {{#isnt filter.selectedTemplate 'TaxonomyPickerFilterTemplate'}}
                                                         {{#eq filter.values.length 0}}
-                                                            <div class="filter--message">
-                                                                {{@root.strings.FilterNoValuesMessage}}
-                                                            </div>
+															{{#isnt filter.selectedTemplate 'StaticPeopleTemplate'}}
+																<div class="filter--message">
+																	{{@root.strings.FilterNoValuesMessage}}
+																</div>
+															{{/isnt}}
                                                         {{else}}
                                                             {{#if filter.isMulti}}
                                                                 <pnp-filtermultiselect 

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -224,29 +224,52 @@
 											{{/each}}
 										</div>
 									{{else}}
-										{{#eq filter.selectedTemplate 'DateIntervalFilterTemplate'}}
-											<div class="filter--value">
-												<pnp-filterdateinterval 
-													data-instance-id="{{@root.instanceId}}" 
-													data-filter="{{JSONstringify filter 2}}"
+										{{#eq filter.selectedTemplate 'StaticPeopleTemplate'}}
+											{{#if filter.isMulti}}
+												<div class="filter--option">
+													<pnp-filteroperator 
+														data-instance-id="{{@root.instanceId}}"
+														data-filter-name="{{filter.filterName}}" 
+														data-operator="{{filter.operator}}" 
+														data-theme-variant="{{JSONstringify @root.theme}}"
+													></pnp-filteroperator>
+												</div>
+											{{/if}}
+											<div class="filter--option">
+												<pnp-peoplefilter
+													data-instance-id="{{@root.instanceId}}"
+													data-filter-name="{{filter.filterName}}"
+													data-is-multi="{{filter.isMulti}}"
+													data-static-picker="true"
+													data-selected-values="{{JSONstringify filter.values 2}}"
 													data-theme-variant="{{JSONstringify @root.theme}}"
-												>
-											</pnp-filterdateinterval>
+												></pnp-peoplefilter>
 											</div>
 										{{else}}
-											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
-												<div class="filter--value-hierarchical">
-													{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
-													<pnp-filterhierarchical 
+											{{#eq filter.selectedTemplate 'DateIntervalFilterTemplate'}}
+												<div class="filter--value">
+													<pnp-filterdateinterval 
 														data-instance-id="{{@root.instanceId}}" 
 														data-filter="{{JSONstringify filter 2}}"
-														data-selected-filters="{{JSONstringify @root.selectedFilters 2}}"
 														data-theme-variant="{{JSONstringify @root.theme}}"
 													>
-													</pnp-filterhierarchical>
+													</pnp-filterdateinterval>
 												</div>
-											{{/eq}}
-										{{/eq}}	
+											{{else}}
+												{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
+													<div class="filter--value-hierarchical">
+														{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
+														<pnp-filterhierarchical 
+															data-instance-id="{{@root.instanceId}}" 
+															data-filter="{{JSONstringify filter 2}}"
+															data-selected-filters="{{JSONstringify @root.selectedFilters 2}}"
+															data-theme-variant="{{JSONstringify @root.theme}}"
+														>
+														</pnp-filterhierarchical>
+													</div>
+												{{/eq}}
+											{{/eq}}	
+										{{/eq}}
 									{{/eq}}
 								{{/eq}}
 							{{/eq}}
@@ -259,11 +282,14 @@
 									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
 								{{else}}
 									{{#eq filter.values.length 0}}
-										<div class="filter--message">
-											{{@root.strings.FilterNoValuesMessage}}
-										</div>
+										{{#isnt filter.selectedTemplate 'StaticPeopleTemplate'}}
+											<div class="filter--message">
+												{{@root.strings.FilterNoValuesMessage}}
+											</div>
+										{{/isnt}}
 									{{else}}
 										{{#if filter.isMulti}}
+											{{#isnt filter.selectedTemplate 'StaticPeopleTemplate'}}
 											<div class="filter--option">
 												<pnp-filteroperator 
 													data-instance-id="{{@root.instanceId}}"
@@ -272,6 +298,7 @@
 													data-theme-variant="{{JSONstringify @root.theme}}"
 												></pnp-filteroperator>
 											</div>
+											{{/isnt}}
 										{{/if}}
 										{{#if filter.isMulti}}
 											<pnp-filtermultiselect 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -570,6 +570,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     configuration.operator = FilterConditionOperator.AND;
                 }
 
+                if (configuration.selectedTemplate === BuiltinFilterTemplates.StaticPeople) {
+                    configuration.maxBuckets = undefined;
+                    configuration.showLimitExceededWarning = false;
+                }
+
                 // Preserve hierarchical settings set through custom fields.
                 const correspondingNewConfig = nextConfigurations.find(c => c.filterName === configuration.filterName);
                 if (correspondingNewConfig) {
@@ -928,6 +933,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                                 key: `${field.id}-${itemId}`,
                                 type: 'number',
                                 value: value ? value.toString() : '',
+                                disabled: item.selectedTemplate === BuiltinFilterTemplates.StaticPeople,
                                 errorMessage: errorMessage,
                                 onChange: (ev, newValue) => {
                                     const parsedValue = newValue && newValue.trim() !== '' ? parseInt(newValue, 10) : undefined;
@@ -945,7 +951,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                             return React.createElement("div", { key: `${field.id}-${itemId}` },
                                 React.createElement(Checkbox, {
                                     defaultChecked: item.showLimitExceededWarning ?? false,
-                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval,
+                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval || item.selectedTemplate === BuiltinFilterTemplates.StaticPeople,
                                     onChange: (ev, checked: boolean) => {
                                         onUpdate(field.id, checked);
                                     }
@@ -974,6 +980,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                             {
                                 key: BuiltinFilterTemplates.People,
                                 text: webPartStrings.PropertyPane.DataFilterCollection.Templates.PeopleTemplate
+                            },
+                            {
+                                key: BuiltinFilterTemplates.StaticPeople,
+                                text: webPartStrings.PropertyPane.DataFilterCollection.Templates.StaticPeopleTemplate
                             },
                             {
                                 key: BuiltinFilterTemplates.ComboBox,

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -94,12 +94,14 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private _busyHideTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyPrimeTimer: ReturnType<typeof setTimeout> | null = null;
+    private _busyCursorAutoHideTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyStartedAt: number = 0;
     private _latestDeferredSubmittedFilters: IDataFilter[] | null = null;
     private static readonly _DISPLAY_NAME_CACHE_LIMIT = 5000;
     private static readonly _HIERARCHY_CACHE_LIMIT = 64;
     private static readonly _PRUNED_HIERARCHY_CACHE_LIMIT = 256;
     private static readonly _MIN_BUSY_VISIBLE_MS = 2000;
+    private static readonly _STATIC_PEOPLE_BUSY_VISIBLE_MS = 3000;
     private static readonly _MAX_BUSY_DURATION_MS = 10000;
     private static readonly _BUSY_PRIME_TIMEOUT_MS = 1500;
     private static readonly _GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
@@ -298,6 +300,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             this._busyHideTimer = null;
         }
 
+        if (this._busyCursorAutoHideTimer) {
+            clearTimeout(this._busyCursorAutoHideTimer);
+            this._busyCursorAutoHideTimer = null;
+        }
+
         if (this._busyWatchdogTimer) {
             clearTimeout(this._busyWatchdogTimer);
             this._busyWatchdogTimer = null;
@@ -318,6 +325,16 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 this.endResultsUpdate();
             }
         }, SearchFiltersContainer._MAX_BUSY_DURATION_MS);
+
+        if (this.isStaticPeopleFilter(sourceFilterName)) {
+            this._busyCursorAutoHideTimer = setTimeout(() => {
+                this._busyCursorAutoHideTimer = null;
+
+                if (this.state.isUpdatingResults) {
+                    this.setBusyCursor(false);
+                }
+            }, SearchFiltersContainer._STATIC_PEOPLE_BUSY_VISIBLE_MS);
+        }
 
         this.setState(prevState => ({
             isUpdatingResults: true,
@@ -420,6 +437,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private endResultsUpdate(): void {
         const elapsed = performance.now() - this._busyStartedAt;
         const remaining = SearchFiltersContainer._MIN_BUSY_VISIBLE_MS - elapsed;
+
+        if (this._busyCursorAutoHideTimer) {
+            clearTimeout(this._busyCursorAutoHideTimer);
+            this._busyCursorAutoHideTimer = null;
+        }
 
         if (this._busyHideTimer) {
             clearTimeout(this._busyHideTimer);
@@ -734,7 +756,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return false;
     }
 
-    private shouldShowPeopleTemplateMappingWarning(availableFilter: IDataFilterResult): boolean {
+    private shouldShowPeopleTemplateMappingWarning(availableFilter: IDataFilterResult, selectedTemplate?: string): boolean {
+        if (selectedTemplate === BuiltinFilterTemplates.StaticPeople) {
+            return false;
+        }
+
         const values = availableFilter?.values ?? [];
         if (values.length === 0) {
             return false;
@@ -820,7 +846,25 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return selectedFilterValues.findIndex(value => this.areFilterValuesEquivalent(`${value.value ?? ''}`, availableRawValue));
     }
 
-    private mergeAvailableValueWithSelection(availableValue: IDataFilterResultValue, selectedFilterValues: IDataFilterValueInternal[], selectedValueIndexByRaw: Map<string, number>): IDataFilterValueInternal {
+    private getMatchingStaticPeopleSelectedValueIndex(availableValue: IDataFilterResultValue, selectedFilterValues: IDataFilterValueInternal[]): number {
+        const availableLabel = this.resolveFilterDisplayName(`${availableValue?.name ?? ''}`, `${availableValue?.value ?? ''}`)
+            .trim()
+            .toLowerCase();
+
+        if (!availableLabel) {
+            return -1;
+        }
+
+        return selectedFilterValues.findIndex(selectedValue => {
+            const selectedLabel = this.resolveFilterDisplayName(`${selectedValue?.name ?? ''}`, `${selectedValue?.value ?? ''}`)
+                .trim()
+                .toLowerCase();
+
+            return selectedLabel === availableLabel;
+        });
+    }
+
+    private mergeAvailableValueWithSelection(availableValue: IDataFilterResultValue, selectedFilterValues: IDataFilterValueInternal[], selectedValueIndexByRaw: Map<string, number>, selectedTemplate?: string): IDataFilterValueInternal {
         const filterValueInternal: IDataFilterValueInternal = {
             name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`),
             selected: false,
@@ -830,7 +874,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             count: availableValue.count
         };
 
-        const valueIdx = this.getMatchingSelectedValueIndex(`${availableValue.value}`, selectedValueIndexByRaw, selectedFilterValues);
+        let valueIdx = this.getMatchingSelectedValueIndex(`${availableValue.value}`, selectedValueIndexByRaw, selectedFilterValues);
+        if (valueIdx === -1 && selectedTemplate === BuiltinFilterTemplates.StaticPeople) {
+            valueIdx = this.getMatchingStaticPeopleSelectedValueIndex(availableValue, selectedFilterValues);
+        }
+
         if (valueIdx === -1) {
             return filterValueInternal;
         }
@@ -870,7 +918,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 };
             }
 
-            return this.mergeAvailableValueWithSelection(availableValue, selectedFilterValues, selectedValueIndexByRaw);
+            return this.mergeAvailableValueWithSelection(availableValue, selectedFilterValues, selectedValueIndexByRaw, filterConfiguration.selectedTemplate);
         });
     }
 
@@ -940,7 +988,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             : undefined;
         const showPeopleTemplateMappingWarning = this.props.webPartTitleProps?.displayMode === DisplayMode.Edit
             && filterConfiguration.selectedTemplate === BuiltinFilterTemplates.People
-            && this.shouldShowPeopleTemplateMappingWarning(availableFilter);
+            && this.shouldShowPeopleTemplateMappingWarning(availableFilter, filterConfiguration.selectedTemplate);
         const peopleTemplateMappingWarningText = showPeopleTemplateMappingWarning
             ? (webPartStrings.PropertyPane.DataFilterCollection.PeopleTemplateQUserMappingWarning
                 || 'People template warning: values do not look like user identities. This property may not be mapped to a Q_USER crawled property.')
@@ -1322,8 +1370,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             backgroundColor: this.props.filterBackgroundColor || undefined,
             borderStyle: this.props.filterBorderColor || this.props.filterBorderThickness ? 'solid' : undefined,
             borderColor: this.props.filterBorderColor || undefined,
-            borderWidth: this.props.filterBorderThickness === undefined ? undefined : `${this.props.filterBorderThickness}px`,
-            cursor: this.state.isUpdatingResults ? 'progress' : 'default'
+            borderWidth: this.props.filterBorderThickness === undefined ? undefined : `${this.props.filterBorderThickness}px`
         };
 
         return <div ref={this.componentRef} data-instance-id={this.props.instanceId} style={containerStyles} onPointerDownCapture={this.primeBusyCursorFromInteraction}>
@@ -1347,11 +1394,15 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         // Use case when the opeartor control is used directly in the Handlebars template. Otherwise, for nested component usage (ex: combo box), the operator value will be changed through the IDataFilterInfo interface direcrtly and not trought a JavaScript event.
         this.bindFilterValueOperatorUpdated();
 
-        // Initial state
-        this.getFiltersToDisplay(this.props.availableFilters, [], this.props.filtersConfiguration);
+        const hasDeepLink = !!UrlHelper.getQueryStringParam(this.deeplinkQueryStringParam, globalThis.location.href);
 
-        // Process deep links
-        this.getFiltersDeepLink();
+        // Process deep links first so restored selections are not overwritten by an empty initial UI refresh.
+        if (hasDeepLink) {
+            this.getFiltersDeepLink();
+        } else {
+            // Initial state
+            this.getFiltersToDisplay(this.props.availableFilters, [], this.props.filtersConfiguration);
+        }
 
         this._handleQueryStringChange();
     }
@@ -1516,6 +1567,14 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         this._latestDeferredSubmittedFilters = null;
     }
 
+    private isStaticPeopleFilter(filterName?: string): boolean {
+        if (!filterName) {
+            return false;
+        }
+
+        return this.props.filtersConfiguration.some(filter => filter.filterName === filterName && filter.selectedTemplate === BuiltinFilterTemplates.StaticPeople);
+    }
+
     /**
      * Gets only the selected filters from the UI and convert them to format sent to the data source
      * @param currentUiFilters the current UI filters (selected or not)
@@ -1537,6 +1596,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             });
 
             if (values.length > 0) {
+                const isStaticPeopleFilter = selectedFilter.selectedTemplate === BuiltinFilterTemplates.StaticPeople;
 
                 newSelectedFilter.values = values.map(value => {
 
@@ -1550,9 +1610,16 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                     // 'Equals' by default
                     if (!newValue.operator) newValue.operator = FilterComparisonOperator.Eq;
 
-                    // Guard rail: normalize malformed taxonomy tokens before submitting to query/URL.
-                    // This prevents trailing garbage characters in GP0/GPP/L0 GUID payloads.
-                    newValue.value = this.sanitizeTaxonomyRefinementValue(`${newValue.value ?? ''}`);
+                    if (isStaticPeopleFilter) {
+                        const displayNameValue = `${newValue.name ?? newValue.value ?? ''}`.trim();
+                        newValue.value = displayNameValue;
+                        newValue.name = displayNameValue;
+                        newValue.operator = FilterComparisonOperator.Eq;
+                    } else {
+                        // Guard rail: normalize malformed taxonomy tokens before submitting to query/URL.
+                        // This prevents trailing garbage characters in GP0/GPP/L0 GUID payloads.
+                        newValue.value = this.sanitizeTaxonomyRefinementValue(`${newValue.value ?? ''}`);
+                    }
 
                     return newValue;
                 });
@@ -1921,6 +1988,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                     currentUiFilters: currentUiFilters,
                     submittedFilters: dataFilters
                 }, () => {
+                    // Rebuild available values using restored deep-link selection state.
+                    // This ensures static people selection remains marked after reload.
+                    this.getFiltersToDisplay(this.props.availableFilters, currentUiFilters, this.props.filtersConfiguration);
+
                     // Update the connected data source only after UI state has been restored.
                     // This prevents a stale getFiltersToDisplay() pass from overwriting deep-link selections on refresh.
                     this.props.onUpdateFilters(dataFilters);

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -95,6 +95,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private _busyWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyPrimeTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyCursorAutoHideTimer: ReturnType<typeof setTimeout> | null = null;
+    private _isMounted: boolean = false;
     private _busyStartedAt: number = 0;
     private _latestDeferredSubmittedFilters: IDataFilter[] | null = null;
     private static readonly _DISPLAY_NAME_CACHE_LIMIT = 5000;
@@ -330,7 +331,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             this._busyCursorAutoHideTimer = setTimeout(() => {
                 this._busyCursorAutoHideTimer = null;
 
-                if (this.state.isUpdatingResults) {
+                if (this._isMounted && this.state.isUpdatingResults) {
                     this.setBusyCursor(false);
                 }
             }, SearchFiltersContainer._STATIC_PEOPLE_BUSY_VISIBLE_MS);
@@ -1380,6 +1381,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     public componentDidMount() {
+        this._isMounted = true;
 
         // Bind events when filter values are selected
         this.bindFilterEvents();
@@ -1542,6 +1544,8 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     public componentWillUnmount(): void {
+        this._isMounted = false;
+
         if (this._deferredSubmittedUpdateTimer) {
             clearTimeout(this._deferredSubmittedUpdateTimer);
             this._deferredSubmittedUpdateTimer = null;
@@ -1560,6 +1564,11 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         if (this._busyHideTimer) {
             clearTimeout(this._busyHideTimer);
             this._busyHideTimer = null;
+        }
+
+        if (this._busyCursorAutoHideTimer) {
+            clearTimeout(this._busyCursorAutoHideTimer);
+            this._busyCursorAutoHideTimer = null;
         }
 
         this.setBusyCursor(false);

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -407,7 +407,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return false;
         }
 
-        return !!target.closest('pnp-filtercheckbox, pnp-filtercombobox, pnp-filtersearchbox, pnp-filtermultiselect, pnp-filteroperator, pnp-filterdaterange, pnp-filterdateinterval, pnp-filterhierarchical');
+        return !!target.closest('pnp-filtercheckbox, pnp-filtercombobox, pnp-filtersearchbox, pnp-filtermultiselect, pnp-filteroperator, pnp-filterdaterange, pnp-filterdateinterval, pnp-filterhierarchical, pnp-peoplefilter');
     }
 
     private readonly primeBusyCursorFromInteraction = (event: React.PointerEvent<HTMLDivElement>): void => {

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -1998,6 +1998,16 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 });
 
             } catch {
+                this._lastProcessedDeepLink = '';
+
+                this.setState(prevState => ({
+                    currentUiFilters: this.resetSelectedFilterValues(prevState.currentUiFilters),
+                    submittedFilters: []
+                }), () => {
+                    this.getFiltersToDisplay(this.props.availableFilters, [], this.props.filtersConfiguration);
+                    this.props.onUpdateFilters([]);
+                });
+
                 Log.verbose(`[SearchFiltersContainer.getFiltersDeepLink]`, `Filters format in the query string is invalid.`);
             }
         }

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfigurovat"
             },
             NoAvailableFilterMessage: "Žádné dostupné filtry k zobrazení.",
-            WebPartDefaultTitle: "Webový díl filtrů vyhledávání"
+            WebPartDefaultTitle: "Webový díl filtrů vyhledávání",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Odebrat {0}",
+                SearchUsersPlaceholder: "Hledat uživatele",
+                LoadingTenantUsersLabel: "Načítání uživatelů tenanta...",
+                NoUsersFoundMessage: "Nebyli nalezeni žádní uživatelé."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Upravit šablonu filtrů"
             }
         },
-            WebPartDefaultTitle: "Webový díl filtrů vyhledávání",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "Odebrat {0}",
-                SearchUsersPlaceholder: "Hledat uživatele",
-                LoadingTenantUsersLabel: "Načítání uživatelů tenanta...",
-                NoUsersFoundMessage: "Nebyli nalezeni žádní uživatelé."
-            }
+        Styling: {
             StylingOptionsGroupName: "Možnosti stylu",
             FilterBackgroundColorLabel: "Barva pozadí filtru",
             FilterBorderColorLabel: "Barva okraje filtru",

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Rozbalovací nabídka",
                     DateIntervalTemplate: "Časový interval",
                     PeopleTemplate: "Šablona pro osoby",
+                    StaticPeopleTemplate: "Statická šablona osoby",
                     TaxonomyPickerTemplate: "Výběr taxonomie",
                     HierarchicalFilterTemplate: "Hierarchický filtr"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Upravit šablonu filtrů"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Webový díl filtrů vyhledávání",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Odebrat {0}",
+                SearchUsersPlaceholder: "Hledat uživatele",
+                LoadingTenantUsersLabel: "Načítání uživatelů tenanta...",
+                NoUsersFoundMessage: "Nebyli nalezeni žádní uživatelé."
+            }
             StylingOptionsGroupName: "Možnosti stylu",
             FilterBackgroundColorLabel: "Barva pozadí filtru",
             FilterBorderColorLabel: "Barva okraje filtru",

--- a/search-parts/src/webparts/searchFilters/loc/da-dk.js
+++ b/search-parts/src/webparts/searchFilters/loc/da-dk.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfigurér"
             },
             NoAvailableFilterMessage: "Ingen tilgængelige filtre at vise.",
-            WebPartDefaultTitle: "Søgefiltre-webpart"
+            WebPartDefaultTitle: "Søgefiltre-webpart",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Fjern {0}",
+                SearchUsersPlaceholder: "Søg efter brugere",
+                LoadingTenantUsersLabel: "Indlæser brugere...",
+                NoUsersFoundMessage: "Ingen brugere fundet."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -54,6 +60,7 @@ define([], function () {
                     ComboBoxTemplate: "Combo-boks",
                     DateIntervalTemplate: "Datointerval",
                     PeopleTemplate: "Personskabelon",
+                    StaticPeopleTemplate: "Statisk personskabelon",
                     TaxonomyPickerTemplate: "Taksonomivælger",
                     HierarchicalFilterTemplate: "Hierarkisk filter"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Combobox",
                     DateIntervalTemplate: "Datums Interval",
                     PeopleTemplate: "Personenvorlage",
+                    StaticPeopleTemplate: "Statische Personenvorlage",
                     TaxonomyPickerTemplate: "Taxonomy Picker",
                     HierarchicalFilterTemplate: "Hierarchischer Filter"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Filter Vorlage bearbeiten"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Suchfilter Web Part",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "{0} entfernen",
+                SearchUsersPlaceholder: "Benutzer suchen",
+                LoadingTenantUsersLabel: "Mandantenbenutzer werden geladen...",
+                NoUsersFoundMessage: "Keine Benutzer gefunden."
+            }
             StylingOptionsGroupName: "Stiloptionen",
             FilterBackgroundColorLabel: "Filter-Hintergrundfarbe",
             FilterBorderColorLabel: "Filter-Rahmenfarbe",

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfigurieren"
             },
             NoAvailableFilterMessage: "Keine Filter zum Anzeigen verfügbar.",
-            WebPartDefaultTitle: "Suchfilter Web Part"
+            WebPartDefaultTitle: "Suchfilter Web Part",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "{0} entfernen",
+                SearchUsersPlaceholder: "Benutzer suchen",
+                LoadingTenantUsersLabel: "Mandantenbenutzer werden geladen...",
+                NoUsersFoundMessage: "Keine Benutzer gefunden."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Filter Vorlage bearbeiten"
             }
         },
-            WebPartDefaultTitle: "Suchfilter Web Part",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "{0} entfernen",
-                SearchUsersPlaceholder: "Benutzer suchen",
-                LoadingTenantUsersLabel: "Mandantenbenutzer werden geladen...",
-                NoUsersFoundMessage: "Keine Benutzer gefunden."
-            }
+        Styling: {
             StylingOptionsGroupName: "Stiloptionen",
             FilterBackgroundColorLabel: "Filter-Hintergrundfarbe",
             FilterBorderColorLabel: "Filter-Rahmenfarbe",

--- a/search-parts/src/webparts/searchFilters/loc/en-us.js
+++ b/search-parts/src/webparts/searchFilters/loc/en-us.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configure"
             },
             NoAvailableFilterMessage: "No available filter to display.",
-            WebPartDefaultTitle: "Search Filters Web Part"
+            WebPartDefaultTitle: "Search Filters Web Part",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Remove {0}",
+                SearchUsersPlaceholder: "Search users",
+                LoadingTenantUsersLabel: "Loading tenant users...",
+                NoUsersFoundMessage: "No users found."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -56,6 +62,7 @@ define([], function () {
                     ComboBoxTemplate: "Combo box",
                     DateIntervalTemplate: "Date interval",
                     PeopleTemplate: "People Template",
+                    StaticPeopleTemplate: "Static Person Template",
                     TaxonomyPickerTemplate: "Taxonomy picker",
                     HierarchicalFilterTemplate: "Hierarchical filter"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Caja combo",
                     DateIntervalTemplate: "Intervalo de fechas",
                     PeopleTemplate: "Plantilla de persona",
+                    StaticPeopleTemplate: "Plantilla de persona estática",
                     TaxonomyPickerTemplate: "Selector de taxonomía",
                     HierarchicalFilterTemplate: "Filtro jerárquico"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Editar plantilla de filtros"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Web Part de filtros de búsqueda",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Quitar {0}",
+                SearchUsersPlaceholder: "Buscar usuarios",
+                LoadingTenantUsersLabel: "Cargando usuarios del inquilino...",
+                NoUsersFoundMessage: "No se encontraron usuarios."
+            }
             StylingOptionsGroupName: "Opciones de estilo",
             FilterBackgroundColorLabel: "Color de fondo del filtro",
             FilterBorderColorLabel: "Color de borde del filtro",

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configurar"
             },
             NoAvailableFilterMessage: "No hay ningún filtro disponible para mostrar.",
-            WebPartDefaultTitle: "Web Part de filtros de búsqueda"
+            WebPartDefaultTitle: "Web Part de filtros de búsqueda",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Quitar {0}",
+                SearchUsersPlaceholder: "Buscar usuarios",
+                LoadingTenantUsersLabel: "Cargando usuarios del inquilino...",
+                NoUsersFoundMessage: "No se encontraron usuarios."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Editar plantilla de filtros"
             }
         },
-            WebPartDefaultTitle: "Web Part de filtros de búsqueda",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "Quitar {0}",
-                SearchUsersPlaceholder: "Buscar usuarios",
-                LoadingTenantUsersLabel: "Cargando usuarios del inquilino...",
-                NoUsersFoundMessage: "No se encontraron usuarios."
-            }
+        Styling: {
             StylingOptionsGroupName: "Opciones de estilo",
             FilterBackgroundColorLabel: "Color de fondo del filtro",
             FilterBorderColorLabel: "Color de borde del filtro",

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfiguroi"
             },
             NoAvailableFilterMessage: "Ei suodattimia näytettäväksi.",
-            WebPartDefaultTitle: "Haun suodattimet webosa"
+            WebPartDefaultTitle: "Haun suodattimet webosa",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Poista {0}",
+                SearchUsersPlaceholder: "Hae käyttäjiä",
+                LoadingTenantUsersLabel: "Ladataan vuokraajan käyttäjiä...",
+                NoUsersFoundMessage: "Käyttäjiä ei löytynyt."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Muokkaa suodatintemplaattia"
             }
         },
-            WebPartDefaultTitle: "Haun suodattimet webosa",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "Poista {0}",
-                SearchUsersPlaceholder: "Hae käyttäjiä",
-                LoadingTenantUsersLabel: "Ladataan vuokraajan käyttäjiä...",
-                NoUsersFoundMessage: "Käyttäjiä ei löytynyt."
-            }
+        Styling: {
             StylingOptionsGroupName: "Tyyliasetukset",
             FilterBackgroundColorLabel: "Suodattimen taustav\u00e4ri",
             FilterBorderColorLabel: "Suodattimen reunav\u00e4ri",

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Yhdistelmävalinta",
                     DateIntervalTemplate: "Ajankohtarajaus (esim. viime kuussa)",
                     PeopleTemplate: "Henkilö malli",
+                    StaticPeopleTemplate: "Staattinen henkilömalli",
                     TaxonomyPickerTemplate: "Taksonomiavalinta",
                     HierarchicalFilterTemplate: "Hierarkkinen suodatin"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Muokkaa suodatintemplaattia"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Haun suodattimet webosa",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Poista {0}",
+                SearchUsersPlaceholder: "Hae käyttäjiä",
+                LoadingTenantUsersLabel: "Ladataan vuokraajan käyttäjiä...",
+                NoUsersFoundMessage: "Käyttäjiä ei löytynyt."
+            }
             StylingOptionsGroupName: "Tyyliasetukset",
             FilterBackgroundColorLabel: "Suodattimen taustav\u00e4ri",
             FilterBorderColorLabel: "Suodattimen reunav\u00e4ri",

--- a/search-parts/src/webparts/searchFilters/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchFilters/loc/fr-fr.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configurer"
             },
             NoAvailableFilterMessage: "Aucun filtre disponible à afficher.",
-            WebPartDefaultTitle: "Composant Web des filtres de recherche"
+            WebPartDefaultTitle: "Composant Web des filtres de recherche",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Retirer {0}",
+                SearchUsersPlaceholder: "Rechercher des utilisateurs",
+                LoadingTenantUsersLabel: "Chargement des utilisateurs du locataire...",
+                NoUsersFoundMessage: "Aucun utilisateur trouvé."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -56,6 +62,7 @@ define([], function () {
                     ComboBoxTemplate: "Zone de liste modifiable",
                     DateIntervalTemplate: "Intervalle de dates",
                     PeopleTemplate: "Modèle de personne",
+                    StaticPeopleTemplate: "Modèle de personne statique",
                     TaxonomyPickerTemplate: "Sélecteur de taxonomie",
                     HierarchicalFilterTemplate: "Filtre hiérarchique"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/it-it.js
+++ b/search-parts/src/webparts/searchFilters/loc/it-it.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configura"
             },
             NoAvailableFilterMessage: "Nessun filtro disponibile da visualizzare.",
-            WebPartDefaultTitle: "Web Part dei Filtri di Ricerca"
+            WebPartDefaultTitle: "Web Part dei Filtri di Ricerca",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Rimuovi {0}",
+                SearchUsersPlaceholder: "Cerca utenti",
+                LoadingTenantUsersLabel: "Caricamento utenti del tenant...",
+                NoUsersFoundMessage: "Nessun utente trovato."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -54,6 +60,7 @@ define([], function () {
                     ComboBoxTemplate: "Casella combinata",
                     DateIntervalTemplate: "Intervallo di tempo",
                     PeopleTemplate: "Modello di persona",
+                    StaticPeopleTemplate: "Modello persona statico",
                     TaxonomyPickerTemplate: "Selettore di tassonomia",
                     HierarchicalFilterTemplate: "Filtro gerarchico"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
@@ -8,6 +8,12 @@ declare interface ISearchFiltersWebPartStrings {
         },
         NoAvailableFilterMessage: string;
         WebPartDefaultTitle: string;
+        StaticPeoplePicker: {
+            RemoveSelectedUserTitle: string;
+            SearchUsersPlaceholder: string;
+            LoadingTenantUsersLabel: string;
+            NoUsersFoundMessage: string;
+        };
     },
     PropertyPane: {
         ConnectionsPage: {
@@ -54,6 +60,7 @@ declare interface ISearchFiltersWebPartStrings {
                 DateRangeTemplate: string;
                 ComboBoxTemplate: string;
                 PeopleTemplate: string;
+                StaticPeopleTemplate: string;
                 DateIntervalTemplate: string;
                 TaxonomyPickerTemplate: string;
                 HierarchicalFilterTemplate: string;

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfigurer"
             },
             NoAvailableFilterMessage: "Det er ingen tilgjengelige filter.",
-            WebPartDefaultTitle: "Søkefilter"
+            WebPartDefaultTitle: "Søkefilter",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Fjern {0}",
+                SearchUsersPlaceholder: "Søk etter brukere",
+                LoadingTenantUsersLabel: "Laster inn leierbrukere...",
+                NoUsersFoundMessage: "Ingen brukere funnet."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Rediger filtermal"
             }
         },
-            WebPartDefaultTitle: "Søkefilter",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "Fjern {0}",
-                SearchUsersPlaceholder: "Søk etter brukere",
-                LoadingTenantUsersLabel: "Laster inn leierbrukere...",
-                NoUsersFoundMessage: "Ingen brukere funnet."
-            }
+        Styling: {
             StylingOptionsGroupName: "Stilalternativer",
             FilterBackgroundColorLabel: "Filter bakgrunnsfarge",
             FilterBorderColorLabel: "Filter kantfarge",

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Kombinasjonsboks",
                     DateIntervalTemplate: "Datointervall (faste intervaller)",
                     PeopleTemplate: "Person mal",
+                    StaticPeopleTemplate: "Statisk personmal",
                     TaxonomyPickerTemplate: "Taksonomivelger",
                     HierarchicalFilterTemplate: "Hierarkisk filter"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Rediger filtermal"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Søkefilter",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Fjern {0}",
+                SearchUsersPlaceholder: "Søk etter brukere",
+                LoadingTenantUsersLabel: "Laster inn leierbrukere...",
+                NoUsersFoundMessage: "Ingen brukere funnet."
+            }
             StylingOptionsGroupName: "Stilalternativer",
             FilterBackgroundColorLabel: "Filter bakgrunnsfarge",
             FilterBorderColorLabel: "Filter kantfarge",

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Keuzelijst",
                     DateIntervalTemplate: "Datum interval",
                     PeopleTemplate: "Persoon sjabloon",
+                    StaticPeopleTemplate: "Statisch persoonssjabloon",
                     TaxonomyPickerTemplate: "Taxonomie picker",
                     HierarchicalFilterTemplate: "Hiërarchisch filter"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Bewerk filters sjabloon"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Zoekfilters webonderdeel",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "{0} verwijderen",
+                SearchUsersPlaceholder: "Zoek gebruikers",
+                LoadingTenantUsersLabel: "Tenantgebruikers laden...",
+                NoUsersFoundMessage: "Geen gebruikers gevonden."
+            }
             StylingOptionsGroupName: "Stijlopties",
             FilterBackgroundColorLabel: "Filter achtergrondkleur",
             FilterBorderColorLabel: "Filter randkleur",

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configureer"
             },
             NoAvailableFilterMessage: "Er zijn geen beschikbare filters.",
-            WebPartDefaultTitle: "Zoekfilters webonderdeel"
+            WebPartDefaultTitle: "Zoekfilters webonderdeel",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "{0} verwijderen",
+                SearchUsersPlaceholder: "Zoek gebruikers",
+                LoadingTenantUsersLabel: "Tenantgebruikers laden...",
+                NoUsersFoundMessage: "Geen gebruikers gevonden."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Bewerk filters sjabloon"
             }
         },
-            WebPartDefaultTitle: "Zoekfilters webonderdeel",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "{0} verwijderen",
-                SearchUsersPlaceholder: "Zoek gebruikers",
-                LoadingTenantUsersLabel: "Tenantgebruikers laden...",
-                NoUsersFoundMessage: "Geen gebruikers gevonden."
-            }
+        Styling: {
             StylingOptionsGroupName: "Stijlopties",
             FilterBackgroundColorLabel: "Filter achtergrondkleur",
             FilterBorderColorLabel: "Filter randkleur",

--- a/search-parts/src/webparts/searchFilters/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchFilters/loc/pl-pl.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfiguruj"
             },
             NoAvailableFilterMessage: "Brak dostępnych filtrów do wyświetlenia.",
-            WebPartDefaultTitle: "Web Part Filtry Wyszukiwania"
+            WebPartDefaultTitle: "Web Part Filtry Wyszukiwania",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Usuń {0}",
+                SearchUsersPlaceholder: "Wyszukaj użytkowników",
+                LoadingTenantUsersLabel: "Ładowanie użytkowników dzierżawy...",
+                NoUsersFoundMessage: "Nie znaleziono użytkowników."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -54,6 +60,7 @@ define([], function () {
                     ComboBoxTemplate: "Pole rozwijalne",
                     DateIntervalTemplate: "Okres czasu",
                     PeopleTemplate: "Szablon osoby",
+                    StaticPeopleTemplate: "Statyczny szablon osoby",
                     TaxonomyPickerTemplate: "Wybór terminu",
                     HierarchicalFilterTemplate: "Filtr hierarchiczny"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/pt-br.js
+++ b/search-parts/src/webparts/searchFilters/loc/pt-br.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Configurar"
             },
             NoAvailableFilterMessage: "Nenhum filtro disponível para exibir.",
-            WebPartDefaultTitle: "Web Part de Filtro de Busca"
+            WebPartDefaultTitle: "Web Part de Filtro de Busca",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Remover {0}",
+                SearchUsersPlaceholder: "Pesquisar usuários",
+                LoadingTenantUsersLabel: "Carregando usuários do locatário...",
+                NoUsersFoundMessage: "Nenhum usuário encontrado."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -54,6 +60,7 @@ define([], function () {
                     ComboBoxTemplate: "Lista de seleção",
                     DateIntervalTemplate: "Intervalo de datas",
                     PeopleTemplate: "Modelo de pessoa",
+                    StaticPeopleTemplate: "Modelo de pessoa estático",
                     TaxonomyPickerTemplate: "Seletor de taxonomia",
                     HierarchicalFilterTemplate: "Filtro hierárquico"
                 },

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -54,6 +54,7 @@ define([], function () {
                     ComboBoxTemplate: "Kombinationsruta",
                     DateIntervalTemplate: "Datumintervall (fasta intervall)",
                     PeopleTemplate: "Person mall",
+                    StaticPeopleTemplate: "Statisk personmall",
                     TaxonomyPickerTemplate: "Taxonomiväljare",
                     HierarchicalFilterTemplate: "Hierarkiskt filter"
                 },
@@ -75,7 +76,13 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Redigera filtermall"
             }
         },
-        Styling: {
+            WebPartDefaultTitle: "Sökfilters webbdel",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Ta bort {0}",
+                SearchUsersPlaceholder: "Sök användare",
+                LoadingTenantUsersLabel: "Läser in klientanvändare...",
+                NoUsersFoundMessage: "Inga användare hittades."
+            }
             StylingOptionsGroupName: "Stilalternativ",
             FilterBackgroundColorLabel: "Filter bakgrundsfärg",
             FilterBorderColorLabel: "Filter kantfärg",

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -8,7 +8,13 @@ define([], function () {
                 ConfigureBtnLabel: "Konfigurera"
             },
             NoAvailableFilterMessage: "Inget tillgängligt filter att visa.",
-            WebPartDefaultTitle: "Sökfilters webbdel"
+            WebPartDefaultTitle: "Sökfilters webbdel",
+            StaticPeoplePicker: {
+                RemoveSelectedUserTitle: "Ta bort {0}",
+                SearchUsersPlaceholder: "Sök användare",
+                LoadingTenantUsersLabel: "Läser in klientanvändare...",
+                NoUsersFoundMessage: "Inga användare hittades."
+            }
         },
         PropertyPane: {
             ConnectionsPage: {
@@ -76,13 +82,7 @@ define([], function () {
                 FiltersTemplatePanelHeader: "Redigera filtermall"
             }
         },
-            WebPartDefaultTitle: "Sökfilters webbdel",
-            StaticPeoplePicker: {
-                RemoveSelectedUserTitle: "Ta bort {0}",
-                SearchUsersPlaceholder: "Sök användare",
-                LoadingTenantUsersLabel: "Läser in klientanvändare...",
-                NoUsersFoundMessage: "Inga användare hittades."
-            }
+        Styling: {
             StylingOptionsGroupName: "Stilalternativ",
             FilterBackgroundColorLabel: "Filter bakgrundsfärg",
             FilterBorderColorLabel: "Filter kantfärg",


### PR DESCRIPTION
## Summary
This PR completes the Static Person Template implementation and aligns behavior across single-select and multi-select modes.
It fixes selection sync issues, improves UX stability, and localizes new user-facing strings.

## What changed
- Added and wired Static Person Template support end-to-end in search filters.
- Implemented tenant user loading for static people picker with stable rendering behavior.
- Fixed selection synchronization issues between UI state and applied filters.
- Ensured selected user pills and selected values stay consistent after deselection.
- Added multi-select operator support using the same operator control placement/style as other templates.
- Reduced visual jitter by stabilizing list container behavior during loading and updates.
- Localized static people picker strings across all supported locales.
- Updated Danish translation for loading text to:
  Indlæser brugere...

## Validation
- Built successfully and generated the SPFx package.
- Verified static person template behavior in both single-select and multi-select modes.
- Confirmed operator behavior and placement matches existing templates.
- Confirmed no errors in updated TS/TSX and template files.

## Issue reference
Closes #4854