### PR TITLE
Fix taxonomy filter labels with umlauts

### DIFF
--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -151,44 +151,33 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
     }
 
     private _extractReadableLabel(value: string): string {
-        const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(value);
         if (!cleanedValue) {
             return '';
         }
 
-        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
-        if (taxonomyLabelMatch?.[1]?.trim()) {
-            return taxonomyLabelMatch[1].trim();
+        const taxonomyLabel = TaxonomyHelper.extractTaxonomyLabel(cleanedValue);
+        if (taxonomyLabel) {
+            return taxonomyLabel;
         }
 
-        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
-        if (genericGuidLabelMatch?.[1]?.trim()) {
-            return genericGuidLabelMatch[1].trim();
+        const claimsLabel = TaxonomyHelper.extractClaimsLabel(cleanedValue);
+        if (claimsLabel) {
+            return claimsLabel;
         }
 
-        const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
-        if (claimsLabelMatch?.[1]?.trim()) {
-            return claimsLabelMatch[1].trim();
-        }
-
-        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+        if (TaxonomyHelper.isReadablePlainLabel(cleanedValue)) {
             return cleanedValue;
         }
 
-        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
-        if (personLikeLabelMatch?.[1]?.trim()) {
-            return personLikeLabelMatch[1].trim();
+        const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
+        if (personLikeLabel) {
+            return personLikeLabel;
         }
 
-        const segments = cleanedValue.split('|').map(segment => segment.trim()).filter(Boolean);
-        if (segments.length > 0) {
-            for (const segment of segments) {
-                const isGuidLike = /^#?[-0-9a-fA-F]{32,36}$/.test(segment);
-                const isLongHexLike = segment.length > 16 && /^[0-9a-fA-F]+$/.test(segment);
-                if (!isGuidLike && !isLongHexLike) {
-                    return segment;
-                }
-            }
+        const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (firstReadablePipeSegment) {
+            return firstReadablePipeSegment;
         }
 
         return '';

--- a/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxComponent.tsx
@@ -171,6 +171,10 @@ export class FilterCheckBoxComponent extends React.Component<IFilterCheckBoxProp
             return claimsLabelMatch[1].trim();
         }
 
+        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+            return cleanedValue;
+        }
+
         const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
         if (personLikeLabelMatch?.[1]?.trim()) {
             return personLikeLabelMatch[1].trim();

--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -168,44 +168,38 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
         }
 
         const extractReadableLabel = (input: string): string => {
-            const cleanedValue = `${input || ''}`.trim().replace(/^"+|"+$/g, '');
+            const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(input);
             if (!cleanedValue) {
                 return '';
             }
 
-            const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
-            if (taxonomyLabelMatch?.[1]?.trim()) {
-                return taxonomyLabelMatch[1].trim();
+            const taxonomyLabel = TaxonomyHelper.extractTaxonomyLabel(cleanedValue);
+            if (taxonomyLabel) {
+                return taxonomyLabel;
             }
 
-            const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
-            if (genericGuidLabelMatch?.[1]?.trim()) {
-                return genericGuidLabelMatch[1].trim();
+            const claimsLabel = TaxonomyHelper.extractClaimsLabel(cleanedValue);
+            if (claimsLabel) {
+                return claimsLabel;
             }
 
-            const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
-            if (claimsLabelMatch?.[1]?.trim()) {
-                return claimsLabelMatch[1].trim();
-            }
-
-            if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+            if (TaxonomyHelper.isReadablePlainLabel(cleanedValue)) {
                 return cleanedValue;
             }
 
-            const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
-            if (personLikeLabelMatch?.[1]?.trim()) {
-                return personLikeLabelMatch[1].trim();
+            const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
+            if (personLikeLabel) {
+                return personLikeLabel;
             }
 
-            const emailMatch = /([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/.exec(cleanedValue);
-            if (emailMatch?.[1]) {
-                return emailMatch[1];
+            const emailLikeLabel = TaxonomyHelper.extractEmailLikeLabel(cleanedValue);
+            if (emailLikeLabel) {
+                return emailLikeLabel;
             }
 
-            const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
-            const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
-            if (firstReadablePart) {
-                return firstReadablePart;
+            const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+            if (firstReadablePipeSegment) {
+                return firstReadablePipeSegment;
             }
 
             return '';

--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -188,6 +188,10 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
                 return claimsLabelMatch[1].trim();
             }
 
+            if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+                return cleanedValue;
+            }
+
             const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
             if (personLikeLabelMatch?.[1]?.trim()) {
                 return personLikeLabelMatch[1].trim();

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -775,44 +775,33 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
     }
 
     private _extractReadableLabel(value: string): string {
-        const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(value);
         if (!cleanedValue) {
             return '';
         }
 
-        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
-        if (taxonomyLabelMatch?.[1]?.trim()) {
-            return taxonomyLabelMatch[1].trim();
+        const taxonomyLabel = TaxonomyHelper.extractTaxonomyLabel(cleanedValue);
+        if (taxonomyLabel) {
+            return taxonomyLabel;
         }
 
-        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
-        if (genericGuidLabelMatch?.[1]?.trim()) {
-            return genericGuidLabelMatch[1].trim();
+        const claimsLabel = TaxonomyHelper.extractClaimsLabel(cleanedValue);
+        if (claimsLabel) {
+            return claimsLabel;
         }
 
-        const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
-        if (claimsLabelMatch?.[1]?.trim()) {
-            return claimsLabelMatch[1].trim();
-        }
-
-        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+        if (TaxonomyHelper.isReadablePlainLabel(cleanedValue)) {
             return cleanedValue;
         }
 
-        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
-        if (personLikeLabelMatch?.[1]?.trim()) {
-            return personLikeLabelMatch[1].trim();
+        const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
+        if (personLikeLabel) {
+            return personLikeLabel;
         }
 
-        const segments = cleanedValue.split('|').map(segment => segment.trim()).filter(Boolean);
-        if (segments.length > 0) {
-            for (const segment of segments) {
-                const isGuidLike = /^#?[-0-9a-fA-F]{32,36}$/.test(segment);
-                const isLongHexLike = segment.length > 16 && /^[0-9a-fA-F]+$/.test(segment);
-                if (!isGuidLike && !isLongHexLike) {
-                    return segment;
-                }
-            }
+        const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (firstReadablePipeSegment) {
+            return firstReadablePipeSegment;
         }
 
         return '';

--- a/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
@@ -795,6 +795,10 @@ export class FilterPeopleTemplateComponent extends React.Component<IFilterPeople
             return claimsLabelMatch[1].trim();
         }
 
+        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+            return cleanedValue;
+        }
+
         const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
         if (personLikeLabelMatch?.[1]?.trim()) {
             return personLikeLabelMatch[1].trim();

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -287,6 +287,10 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
                 return claimsLabelMatch[1].trim();
             }
 
+            if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+                return cleanedValue;
+            }
+
             const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
             if (personLikeLabelMatch?.[1]?.trim()) {
                 return personLikeLabelMatch[1].trim();

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -277,34 +277,33 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
         }
 
         const extractReadableLabel = (value: string): string => {
-            const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+            const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(value);
             if (!cleanedValue) {
                 return '';
             }
 
-            const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
-            if (claimsLabelMatch?.[1]?.trim()) {
-                return claimsLabelMatch[1].trim();
+            const claimsLabel = TaxonomyHelper.extractClaimsLabel(cleanedValue);
+            if (claimsLabel) {
+                return claimsLabel;
             }
 
-            if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+            if (TaxonomyHelper.isReadablePlainLabel(cleanedValue)) {
                 return cleanedValue;
             }
 
-            const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
-            if (personLikeLabelMatch?.[1]?.trim()) {
-                return personLikeLabelMatch[1].trim();
+            const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
+            if (personLikeLabel) {
+                return personLikeLabel;
             }
 
-            const emailMatch = /([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/.exec(cleanedValue);
-            if (emailMatch?.[1]) {
-                return emailMatch[1];
+            const emailLikeLabel = TaxonomyHelper.extractEmailLikeLabel(cleanedValue);
+            if (emailLikeLabel) {
+                return emailLikeLabel;
             }
 
-            const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
-            const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
-            if (firstReadablePart) {
-                return firstReadablePart;
+            const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+            if (firstReadablePipeSegment) {
+                return firstReadablePipeSegment;
             }
 
             return '';

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -34,14 +34,29 @@ export class TaxonomyHelper {
             return '';
         }
 
+        const getSafeExtractedLabel = (candidate?: string): string => {
+            const normalizedCandidate = this.normalizeReadableLabelCandidate(candidate || '');
+            if (!normalizedCandidate) {
+                return '';
+            }
+
+            if (this.containsEncodedTokenMarker(normalizedCandidate) || this.isGuidLikeToken(normalizedCandidate)) {
+                return '';
+            }
+
+            return normalizedCandidate;
+        };
+
         const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#(?:0|0?[0-9a-f-]{32,36})\|(.+)$/i.exec(cleanedValue);
-        if (taxonomyLabelMatch?.[1]?.trim()) {
-            return taxonomyLabelMatch[1].trim();
+        const taxonomyLabel = getSafeExtractedLabel(taxonomyLabelMatch?.[1]);
+        if (taxonomyLabel) {
+            return taxonomyLabel;
         }
 
         const genericGuidLabelMatch = /\|#(?:0|0?[0-9a-f-]{32,36})\|([^|]+)$/i.exec(cleanedValue);
-        if (genericGuidLabelMatch?.[1]?.trim()) {
-            return genericGuidLabelMatch[1].trim();
+        const genericGuidLabel = getSafeExtractedLabel(genericGuidLabelMatch?.[1]);
+        if (genericGuidLabel) {
+            return genericGuidLabel;
         }
 
         return '';

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -5,11 +5,15 @@ export class TaxonomyHelper {
     }
 
     private static isGuidLikeToken(value: string): boolean {
-        return /^#?(?:[0-9a-fA-F]{24,}|[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.test(value);
+        return /^#?(?:[0-9a-fA-F]{17,}|[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.test(value);
     }
 
     private static isTaxonomyTokenPrefix(value: string): boolean {
         return /^(?:L0|GP0|GPP)$/i.test(value);
+    }
+
+    private static containsReadableLetter(value: string): boolean {
+        return Array.from(value).some(char => char.toLocaleLowerCase() !== char.toLocaleUpperCase());
     }
 
     public static normalizeReadableLabelCandidate(value: string): string {
@@ -80,7 +84,7 @@ export class TaxonomyHelper {
         }
 
         const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
-        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part)
+        const firstReadablePart = parts.find(part => this.containsReadableLetter(part)
             && !this.containsEncodedTokenMarker(part)
             && !this.isTaxonomyTokenPrefix(part)
             && !this.isGuidLikeToken(part));

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -1,5 +1,74 @@
 export class TaxonomyHelper {
 
+    public static normalizeReadableLabelCandidate(value: string): string {
+        return `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+    }
+
+    public static isReadablePlainLabel(value: string): boolean {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        return !!cleanedValue && !cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue);
+    }
+
+    public static extractTaxonomyLabel(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
+        if (taxonomyLabelMatch?.[1]?.trim()) {
+            return taxonomyLabelMatch[1].trim();
+        }
+
+        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
+        if (genericGuidLabelMatch?.[1]?.trim()) {
+            return genericGuidLabelMatch[1].trim();
+        }
+
+        return '';
+    }
+
+    public static extractClaimsLabel(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
+        return claimsLabelMatch?.[1]?.trim() || '';
+    }
+
+    public static extractPersonLikeLabel(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
+        return personLikeLabelMatch?.[1]?.trim() || '';
+    }
+
+    public static extractEmailLikeLabel(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const emailMatch = /([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/.exec(cleanedValue);
+        return emailMatch?.[1] || '';
+    }
+
+    public static extractFirstReadablePipeSegment(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
+        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
+        return firstReadablePart || '';
+    }
+
     public static normalizeGuid(rawGuid: string): string {
         return rawGuid ? rawGuid.replace(/^#/, '').replaceAll('-', '').toLowerCase() : '';
     }

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -4,6 +4,10 @@ export class TaxonomyHelper {
         return value.includes('ǂ');
     }
 
+    private static isGuidLikeToken(value: string): boolean {
+        return /^#?(?:[0-9a-fA-F]{24,}|[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.test(value);
+    }
+
     public static normalizeReadableLabelCandidate(value: string): string {
         return `${value || ''}`.trim().replace(/^"+|"+$/g, '');
     }
@@ -13,7 +17,7 @@ export class TaxonomyHelper {
         return !!cleanedValue
             && !this.containsEncodedTokenMarker(cleanedValue)
             && !cleanedValue.includes('|')
-            && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue);
+            && !this.isGuidLikeToken(cleanedValue);
     }
 
     public static extractTaxonomyLabel(value: string): string {
@@ -74,7 +78,7 @@ export class TaxonomyHelper {
         const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
         const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part)
             && !this.containsEncodedTokenMarker(part)
-            && !/^#?[0-9a-fA-F]{24,}$/.test(part));
+            && !this.isGuidLikeToken(part));
         return firstReadablePart || '';
     }
 

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -1,12 +1,19 @@
 export class TaxonomyHelper {
 
+    private static containsEncodedTokenMarker(value: string): boolean {
+        return value.includes('ǂ');
+    }
+
     public static normalizeReadableLabelCandidate(value: string): string {
         return `${value || ''}`.trim().replace(/^"+|"+$/g, '');
     }
 
     public static isReadablePlainLabel(value: string): boolean {
         const cleanedValue = this.normalizeReadableLabelCandidate(value);
-        return !!cleanedValue && !cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue);
+        return !!cleanedValue
+            && !this.containsEncodedTokenMarker(cleanedValue)
+            && !cleanedValue.includes('|')
+            && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue);
     }
 
     public static extractTaxonomyLabel(value: string): string {
@@ -65,7 +72,9 @@ export class TaxonomyHelper {
         }
 
         const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
-        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
+        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part)
+            && !this.containsEncodedTokenMarker(part)
+            && !/^#?[0-9a-fA-F]{24,}$/.test(part));
         return firstReadablePart || '';
     }
 

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -8,6 +8,10 @@ export class TaxonomyHelper {
         return /^#?(?:[0-9a-fA-F]{24,}|[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})$/.test(value);
     }
 
+    private static isTaxonomyTokenPrefix(value: string): boolean {
+        return /^(?:L0|GP0|GPP)$/i.test(value);
+    }
+
     public static normalizeReadableLabelCandidate(value: string): string {
         return `${value || ''}`.trim().replace(/^"+|"+$/g, '');
     }
@@ -26,12 +30,12 @@ export class TaxonomyHelper {
             return '';
         }
 
-        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
+        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#(?:0|0?[0-9a-f-]{32,36})\|(.+)$/i.exec(cleanedValue);
         if (taxonomyLabelMatch?.[1]?.trim()) {
             return taxonomyLabelMatch[1].trim();
         }
 
-        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
+        const genericGuidLabelMatch = /\|#(?:0|0?[0-9a-f-]{32,36})\|([^|]+)$/i.exec(cleanedValue);
         if (genericGuidLabelMatch?.[1]?.trim()) {
             return genericGuidLabelMatch[1].trim();
         }
@@ -78,6 +82,7 @@ export class TaxonomyHelper {
         const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
         const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part)
             && !this.containsEncodedTokenMarker(part)
+            && !this.isTaxonomyTokenPrefix(part)
             && !this.isGuidLikeToken(part));
         return firstReadablePart || '';
     }

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -13,7 +13,7 @@ export class TaxonomyHelper {
     }
 
     private static containsReadableLetter(value: string): boolean {
-        return Array.from(value).some(char => char.toLocaleLowerCase() !== char.toLocaleUpperCase());
+        return /\p{L}/u.test(value);
     }
 
     public static normalizeReadableLabelCandidate(value: string): string {

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -216,6 +216,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return claimsLabelMatch[1].trim();
         }
 
+        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+            return cleanedValue;
+        }
+
         const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
         if (personLikeLabelMatch?.[1]?.trim()) {
             return personLikeLabelMatch[1].trim();

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -196,44 +196,38 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     private extractReadableLabelFromString(value: string): string {
-        const cleanedValue = `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(value);
         if (!cleanedValue) {
             return '';
         }
 
-        const taxonomyLabelMatch = /(?:L0|GP0|GPP)\|#0?[0-9a-f-]{32,36}\|(.+)$/i.exec(cleanedValue);
-        if (taxonomyLabelMatch?.[1]?.trim()) {
-            return taxonomyLabelMatch[1].trim();
+        const taxonomyLabel = TaxonomyHelper.extractTaxonomyLabel(cleanedValue);
+        if (taxonomyLabel) {
+            return taxonomyLabel;
         }
 
-        const genericGuidLabelMatch = /\|#0?[0-9a-f-]{32,36}\|([^|]+)$/i.exec(cleanedValue);
-        if (genericGuidLabelMatch?.[1]?.trim()) {
-            return genericGuidLabelMatch[1].trim();
+        const claimsLabel = TaxonomyHelper.extractClaimsLabel(cleanedValue);
+        if (claimsLabel) {
+            return claimsLabel;
         }
 
-        const claimsLabelMatch = /^i:0#.*\|([^|]+)$/i.exec(cleanedValue);
-        if (claimsLabelMatch?.[1]?.trim()) {
-            return claimsLabelMatch[1].trim();
-        }
-
-        if (!cleanedValue.includes('|') && !/^#?[0-9a-fA-F]{24,}$/.test(cleanedValue)) {
+        if (TaxonomyHelper.isReadablePlainLabel(cleanedValue)) {
             return cleanedValue;
         }
 
-        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
-        if (personLikeLabelMatch?.[1]?.trim()) {
-            return personLikeLabelMatch[1].trim();
+        const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
+        if (personLikeLabel) {
+            return personLikeLabel;
         }
 
-        const emailMatch = /([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/.exec(cleanedValue);
-        if (emailMatch?.[1]) {
-            return emailMatch[1];
+        const emailLikeLabel = TaxonomyHelper.extractEmailLikeLabel(cleanedValue);
+        if (emailLikeLabel) {
+            return emailLikeLabel;
         }
 
-        const parts = cleanedValue.split('|').map(part => part.trim()).filter(Boolean);
-        const firstReadablePart = parts.find(part => /[A-Za-z]/.test(part) && !/^#?[0-9a-fA-F]{24,}$/.test(part));
-        if (firstReadablePart) {
-            return firstReadablePart;
+        const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (firstReadablePipeSegment) {
+            return firstReadablePipeSegment;
         }
 
         return '';


### PR DESCRIPTION
## Summary
- fix taxonomy label rendering in filter templates when labels already contain readable non-ASCII characters
- preserve readable labels like "Künstliche Intelligenz" instead of falling through to ASCII-only fallback parsing
- centralize shared label extraction heuristics in TaxonomyHelper and keep encoded or GUID-like taxonomy tokens from surfacing as display labels
- keep behavior aligned across checkbox, hierarchical, people, search box, and filter container display-name resolution

## Validation
- ran `npm run build` in `search-parts`
- build completed successfully

## Files changed
- search-parts/src/components/filters/FilterCheckBoxComponent.tsx
- search-parts/src/components/filters/FilterHierarchicalComponent.tsx
- search-parts/src/components/filters/FilterPeopleCheckBoxComponent.tsx
- search-parts/src/components/filters/FilterSearchBoxComponent.tsx
- search-parts/src/helpers/TaxonomyHelper.ts
- search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx

## Issue
- Fixes #4859