### PR TITLE
chore(release): bump version to 4.23.3

### DIFF
--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "PnP Modern Search - Search Web Parts - v4",
         "id": "59903278-dd5d-4e9e-bef6-562aae716b8b",
-        "version": "4.23.2.0",
+        "version": "4.23.3.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": true,
         "isDomainIsolated": false,

--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.2",
+    "version": "4.23.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pnp/modern-search-web-parts",
-            "version": "4.23.2",
+            "version": "4.23.3",
             "dependencies": {
                 "@fluentui/font-icons-mdl2": "^8.5.67",
                 "@fluentui/react": "8.125.4",

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.2",
+    "version": "4.23.3",
     "private": true,
     "engines": {
         "node": ">=22.14.0 < 23.0.0"


### PR DESCRIPTION
Keeps `develop` in sync with the 4.23.3 hotfix released from `main` (#4872). Version bump only — the code change (#4871) is already on `develop`.

- `search-parts/package.json` 4.23.2 → 4.23.3
- `search-parts/config/package-solution.json` 4.23.2.0 → 4.23.3.0
- `search-parts/package-lock.json` root refs updated