### PR TITLE
Add Microsoft Search schema discovery and field normalization

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,6 +26,7 @@
     | _Calendars.Read_ | Allow search for user's calendar appointments using Graph API (Events).
     | _Sites.Read.All_ | Allow search for sites using Graph API (Sites / List Items).
     | _ExternalItem.Read.All_ | Allow search for connector items using Graph API (External Items).
+    | _ExternalConnection.Read.All_ | Allow reading Graph connector definitions and schemas for external connection metadata discovery. See the [Graph connector scenario](./scenarios/Create-a-search-page-showing-graph-connector-data.md) for details.
     | _Bookmark.Read.All_ | Allow search for Bookmarks in Microsoft Search in your organization.
     | _Acronym.Read.All_ | Allow search for Acronyms in Microsoft Search in your organization.
     | _Chat.Read_ | Allow search for Teams messages.    

--- a/docs/scenarios/Create-a-search-page-showing-graph-connector-data.md
+++ b/docs/scenarios/Create-a-search-page-showing-graph-connector-data.md
@@ -35,7 +35,9 @@ In most cases we are using SharePoint as the source of our data. But in this cas
 
 Set the Entity type to External Items and set the Content sources to the name of the Graph Connector you are using. In this case we are using the AzureSqlConnector3.
 
-Unfortunately we are unable to read the Properties from the Graph Connector, so you will have to type ( or copy and paste) from the schema.
+If you want the solution to read Graph connector definitions and schema metadata, approve the Microsoft Graph permission _ExternalConnection.Read.All_ for the package in addition to _ExternalItem.Read.All_.
+
+With _ExternalConnection.Read.All_ approved, the Content sources and schema properties can be loaded automatically from Microsoft Graph in the property pane. Without this permission, you can still type or paste values manually.
 
 ![SelectedProperties](../scenarios/assets/Create-a-search-page-showing-graph-connector-data/SelectedProperties.png "Selected Properties")
 

--- a/search-parts/.vscode/launch.json
+++ b/search-parts/.vscode/launch.json
@@ -1,16 +1,12 @@
 {
-  /**
-   * Install Chrome Debugger Extension for Visual Studio Code to debug your components with the
-   * Chrome browser: https://aka.ms/spfx-debugger-extensions
-   */
   "version": "0.2.0",
   "configurations": [
     {
       "name": "Local workbench",
-      "type": "chrome",
+      "type": "pwa-msedge",
       "request": "launch",
       "url": "https://localhost:4321/temp/workbench.html",
-      "webRoot": "${workspaceRoot}",
+      "webRoot": "${workspaceFolder}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {
         "webpack:///.././src/*": "${webRoot}/src/*",
@@ -18,14 +14,14 @@
         "webpack:///../../../../src/*": "${webRoot}/src/*",
         "webpack:///../../../../../src/*": "${webRoot}/src/*"
       },
-      "runtimeArgs": ["--remote-debugging-port=9222"]
+      "runtimeArgs": ["--remote-debugging-port=9222", "--inprivate"]
     },
     {
-      "name": "Hosted workbench",
-      "type": "chrome",
+      "name": "Hosted page (PnPModernSearchHQ)",
+      "type": "pwa-msedge",
       "request": "launch",
-      "url": "https://sonbaedev.sharepoint.com/sites/ThePerspective/_layouts/15/workbench.aspx",
-      "webRoot": "${workspaceRoot}",
+      "url": "https://m365thinking.sharepoint.com/sites/PnPModernSearchHQ/SitePages/Question-on-externalItems-properties-in-Search--4876.aspx?debugManifestsFile=https%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fbuild%2Fmanifests.js&debug=true&noredir=true&Mode=Edit",
+      "webRoot": "${workspaceFolder}",
       "sourceMaps": true,
       "sourceMapPathOverrides": {
         "webpack:///.././src/*": "${webRoot}/src/*",
@@ -34,16 +30,16 @@
         "webpack:///../../../../../src/*": "${webRoot}/src/*"
       },
       "outFiles": ["${workspaceFolder}/**/*.js", "!**/node_modules/**"],
-      "runtimeArgs": ["--remote-debugging-port=9222", "--incognito"]
+      "runtimeArgs": ["--remote-debugging-port=9222", "--inprivate"]
     },
     {
       "name": "GulpTester",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+      "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
       "stopOnEntry": false,
       "args": [],
-      "cwd": "${workspaceRoot}",
+      "cwd": "${workspaceFolder}",
       "runtimeArgs": ["--nolazy"],
       "console": "internalConsole"
     }

--- a/search-parts/.vscode/tasks.json
+++ b/search-parts/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Heft start (nobrowser)",
+      "type": "shell",
+      "command": "pnpm run start -- --nobrowser",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    }
+  ]
+}

--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -50,6 +50,10 @@
             },
             {
                 "resource": "Microsoft Graph",
+                "scope": "ExternalConnection.Read.All"
+            },
+            {
+                "resource": "Microsoft Graph",
                 "scope": "Chat.Read"
             },
             {

--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -471,9 +471,8 @@ export class DetailsListComponent extends React.Component<
                 }
               } else {
                 // A field has been selected
-                value = ObjectHelper.byPath(item, column.value);
+                value = this._resolveColumnValue(item, column.value);
               }
-
               const tempColumnValueAsHtml = new DOMParser().parseFromString(
                 `<span>${value ?? ""}</span>`,
                 "text/html"
@@ -1109,6 +1108,33 @@ export class DetailsListComponent extends React.Component<
     }
 
     return groups;
+  }
+
+  private _resolveColumnValue(item: any, columnValue: string): any {
+    if (!columnValue) {
+      return undefined;
+    }
+
+    const exactValue = ObjectHelper.byPath(item, columnValue);
+    if (this._hasRenderableValue(exactValue)) {
+      return exactValue;
+    }
+
+    const externalItemValue = this._resolveExternalItemFieldValue(item, columnValue);
+    if (this._hasRenderableValue(externalItemValue)) {
+      return externalItemValue;
+    }
+  }
+
+  private _resolveExternalItemFieldValue(item: any, fieldName: string): any {
+    return ObjectHelper.byPath(item, `resource.fields.${fieldName}`)
+      ?? ObjectHelper.byPath(item, `resource.properties.${fieldName}`)
+      ?? ObjectHelper.byPath(item, `resource.${fieldName}`)
+      ?? ObjectHelper.byPath(item, fieldName);
+  }
+
+  private _hasRenderableValue(value: any): boolean {
+    return value !== undefined && value !== null && value !== '';
   }
 
   private _processHandleBarsExprValue(columnValue: string, item: any): string {

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -1,9 +1,10 @@
 import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, BuiltinTemplateSlots, IDataContext, ITokenService, FilterBehavior, PagingBehavior, IDataFilterResult, IDataFilterResultValue, FilterComparisonOperator, IDataSourceData, SortFieldDirection } from "@pnp/modern-search-extensibility";
 import { IPropertyPaneGroup, PropertyPaneLabel, IPropertyPaneField, PropertyPaneToggle, PropertyPaneHorizontalRule } from "@microsoft/sp-property-pane";
 import { cloneDeep, isEmpty } from '@microsoft/sp-lodash-subset';
-import { MSGraphClientFactory } from "@microsoft/sp-http";
+import { MSGraphClientFactory, SPHttpClient } from "@microsoft/sp-http";
 import { TokenService } from "../services/tokenService/TokenService";
 import { ServiceScope } from '@microsoft/sp-core-library';
+import { PageContext } from '@microsoft/sp-page-context';
 import { Dropdown, IComboBoxOption, IDropdownProps, ITextFieldProps, TextField } from '@fluentui/react';
 import { PropertyPaneAsyncCombo } from "../controls/PropertyPaneAsyncCombo/PropertyPaneAsyncCombo";
 import * as commonStrings from 'CommonStrings';
@@ -121,8 +122,17 @@ export interface IMicrosoftSearchDataSourceProperties {
 export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDataSourceProperties> {
 
     private _tokenService: ITokenService;
+    private _spHttpClient: SPHttpClient;
+    private _pageContext: PageContext;
     private _propertyPaneWebPartInformation: any = null;
     private _availableFields: IComboBoxOption[] = [];
+    private _availableSharePointSchemaFields: IComboBoxOption[] = [];
+    private _availableExternalConnectionIds: IComboBoxOption[] = [];
+    private readonly _availableFieldsFromResults = new Set<string>();
+    private _externalConnectionsLoadPermissionError = false;
+    private _externalConnectionsLoadGenericError = false;
+    private _externalSchemaLoadPermissionError = false;
+    private _externalSchemaLoadGenericError = false;
     private _microsoftSearchUrl: string;
     private _sortableFields: IComboBoxOption[] = SortableFields.map(field => {
         return {
@@ -201,6 +211,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
 
     private _propertyFieldCollectionData: any = null;
     private _customCollectionFieldType: any = null;
+    private readonly _defaultDriveItemFields: string[] = ["title", "name", "webUrl", "fileType", "createdBy", "createdDateTime", "lastModifiedDateTime", "parentReference", "size", "description", "file", "folder", "subject", "bodyPreview", "replyTo", "from", "sender", "start", "end", "displayName", "givenName", "surname", "userPrincipalName", "mail", "phones", "department", "contentTypeId", "siteId", "webId", "contentClass", "siteTitle", "sitePath", "AuthorOWSUSER", "listId", "listItemId", "listItemUniqueId", "driveId", "owstaxidmetadataalltagsinfo"];
     props: any;
 
     public constructor(serviceScope: ServiceScope) {
@@ -208,6 +219,8 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
 
         serviceScope.whenFinished(() => {
             this._tokenService = serviceScope.consume<ITokenService>(TokenService.ServiceKey);
+            this._spHttpClient = serviceScope.consume<SPHttpClient>(SPHttpClient.serviceKey);
+            this._pageContext = serviceScope.consume<PageContext>(PageContext.serviceKey);
         });
     }
 
@@ -364,6 +377,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
                 description: commonStrings.DataSources.MicrosoftSearch.SelectedFieldsPropertiesFieldDescription,
                 label: commonStrings.DataSources.MicrosoftSearch.SelectedFieldsPropertiesFieldLabel,
                 placeholder: commonStrings.DataSources.MicrosoftSearch.SelectedFieldsPlaceholderLabel,
+                onLoadOptions: this.getAvailableFields.bind(this),
                 searchAsYouType: false,
                 defaultSelectedKeys: this.properties.fields,
                 onPropertyChange: this.onCustomPropertyUpdate.bind(this),
@@ -555,17 +569,30 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         if (this.properties.entityTypes.includes(EntityType.ExternalItem)) {
             contentSourceConnectionIdsFields.push(
                 new PropertyPaneAsyncCombo('dataSourceProperties.contentSourceConnectionIds', {
-                    availableOptions: [],
+                    availableOptions: this._availableExternalConnectionIds,
                     allowMultiSelect: true,
                     allowFreeform: true,
                     description: commonStrings.DataSources.MicrosoftSearch.ContentSourcesFieldDescriptionLabel,
                     label: commonStrings.DataSources.MicrosoftSearch.ContentSourcesFieldLabel,
                     placeholder: commonStrings.DataSources.MicrosoftSearch.ContentSourcesFieldPlaceholderLabel,
+                    onLoadOptions: this.getAvailableExternalConnectionIds.bind(this),
                     searchAsYouType: false,
                     defaultSelectedKeys: this.properties.contentSourceConnectionIds,
-                    onPropertyChange: this.onCustomPropertyUpdate.bind(this)
+                    onPropertyChange: this.onCustomPropertyUpdate.bind(this),
+                    onUpdateOptions: (options: IComboBoxOption[]) => {
+                        this._availableExternalConnectionIds = options;
+                    }
                 })
             );
+
+            const metadataWarningMessage = this.getExternalMetadataWarningMessage();
+            if (metadataWarningMessage) {
+                contentSourceConnectionIdsFields.push(
+                    PropertyPaneLabel('externalMetadataWarning', {
+                        text: metadataWarningMessage
+                    })
+                );
+            }
         }
 
         if (this.properties.entityTypes.includes(EntityType.Message) && this.properties.entityTypes.length === 1) {
@@ -632,11 +659,17 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     public onCustomPropertyUpdate(propertyPath: string, newValue: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
 
         if (propertyPath.localeCompare('dataSourceProperties.entityTypes') === 0) {
+            const previousEntityTypes = [...this.properties.entityTypes];
             this.properties.entityTypes = (cloneDeep(newValue) as IComboBoxOption[]).map(v => { return v.key as EntityType; });
+            const hadExternalItem = previousEntityTypes.includes(EntityType.ExternalItem);
+            const hasExternalItem = this.properties.entityTypes.includes(EntityType.ExternalItem);
 
-            if (this.properties.entityTypes.includes(EntityType.ExternalItem)) {
+            if (hasExternalItem) {
                 // Reset result types
                 this.properties.enableResultTypes = false;
+            } else if (hadExternalItem) {
+                this.properties.fields = ["title", "name", "webUrl", "filetype", "fileType", "createdBy", "createdDateTime", "lastModifiedDateTime", "parentReference", "size", "description", "file", "folder", "subject", "bodyPreview", "replyTo", "from", "sender", "start", "end", "displayName", "givenName", "surname", "userPrincipalName", "mail", "phones", "department", "contentTypeId", "siteId", "webId", "contentClass", "siteTitle", "sitePath", "AuthorOWSUSER", "listId", "listItemId", "listItemUniqueId", "driveId", "owstaxidmetadataalltagsinfo"];
+                this.resetExternalMetadataLoadState();
             }
 
             // Reset and set appropriate fields for Bookmark, Acronym, or Person
@@ -672,9 +705,310 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
 
         if (propertyPath.localeCompare('dataSourceProperties.contentSourceConnectionIds') === 0) {
             this.properties.contentSourceConnectionIds = (cloneDeep(newValue) as IComboBoxOption[]).map(v => { return v.key as string; });
+
+            // Force schema fields to be recomputed when selected external connections change.
+            this._availableFields = [];
             this.context.propertyPane.refresh();
             this.render();
         }
+    }
+
+    private async getAvailableFields(): Promise<IComboBoxOption[]> {
+        const defaultFields = this.getDefaultFieldOptions();
+        const resultFields = this.getResultFieldOptions();
+        const sharePointSchemaFields = await this.getSharePointSchemaFieldOptions();
+
+        if (!this.properties.entityTypes.includes(EntityType.ExternalItem) || this.properties.contentSourceConnectionIds.length === 0) {
+            // Prefer live Microsoft Search payload fields first, then keep defaults,
+            // and finally append schema candidates for broader discoverability.
+            return this.mergeFieldOptions(resultFields, defaultFields, sharePointSchemaFields);
+        }
+
+        const schemaOptions = await this.getExternalConnectionSchemaFieldOptions(this.properties.contentSourceConnectionIds);
+        return this.mergeFieldOptions(schemaOptions, resultFields, defaultFields, sharePointSchemaFields);
+    }
+
+    private async getSharePointSchemaFieldOptions(): Promise<IComboBoxOption[]> {
+        if (!this.hasSharePointSchemaEntityType()) {
+            return [];
+        }
+
+        if (this._availableSharePointSchemaFields.length > 0) {
+            return this._availableSharePointSchemaFields;
+        }
+
+        try {
+            const managedProperties = await this.getAvailableSharePointManagedProperties();
+            this._availableSharePointSchemaFields = managedProperties
+                .map((managedProperty) => ({
+                    key: managedProperty.name,
+                    text: managedProperty.name
+                } as IComboBoxOption))
+                .filter((option) => option.key);
+
+            return this._availableSharePointSchemaFields;
+        } catch (error) {
+            console.warn('[PnP Modern Search][Microsoft Search] Unable to load SharePoint-backed schema fields from SharePoint search schema.', error);
+            return [];
+        }
+    }
+
+    private hasSharePointSchemaEntityType(): boolean {
+        return this.properties.entityTypes.some((entityType) =>
+            entityType === EntityType.Drive ||
+            entityType === EntityType.DriveItem ||
+            entityType === EntityType.List ||
+            entityType === EntityType.ListItem ||
+            entityType === EntityType.Site
+        );
+    }
+
+    private async getAvailableSharePointManagedProperties(): Promise<Array<{ name: string }>> {
+        const searchEndpointUrl = `${this._pageContext.web.absoluteUrl}/_api/search/postquery`;
+        const searchQuery = {
+            Querytext: '*',
+            Refiners: 'ManagedProperties(filter=50000/0/*,deephits=50000,sort=name/ascending)',
+            RowLimit: 1,
+            SortList: [
+                {
+                    Property: '[DocId]',
+                    Direction: 0
+                }
+            ]
+        };
+
+        const response = await this._spHttpClient.post(searchEndpointUrl, SPHttpClient.configurations.v1, {
+            body: this.buildSharePointSearchRequestPayload(searchQuery),
+            headers: {
+                'odata-version': '3.0',
+                'accept': 'application/json;odata=nometadata'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`${response['statusMessage']}`);
+        }
+
+        const searchResponse = await response.json() as any;
+        const refiners = searchResponse?.PrimaryQueryResult?.RefinementResults?.Refiners || [];
+        const managedProperties: Array<{ name: string }> = [];
+
+        refiners.forEach((refiner) => {
+            (refiner?.Entries || []).forEach((entry) => {
+                if (entry?.RefinementName) {
+                    managedProperties.push({
+                        name: entry.RefinementName
+                    });
+                }
+            });
+        });
+
+        return managedProperties;
+    }
+
+    private buildSharePointSearchRequestPayload(searchQuery: any): string {
+        const queryPayload = cloneDeep(searchQuery);
+        queryPayload.HitHighlightedProperties = this.fixSharePointSearchArrayProperty(queryPayload.HitHighlightedProperties);
+        queryPayload.Properties = this.fixSharePointSearchArrayProperty(queryPayload.Properties);
+        queryPayload.RefinementFilters = this.fixSharePointSearchArrayProperty(queryPayload.RefinementFilters);
+        queryPayload.ReorderingRules = this.fixSharePointSearchArrayProperty(queryPayload.ReorderingRules);
+        queryPayload.SelectProperties = this.fixSharePointSearchArrayProperty(queryPayload.SelectProperties);
+        queryPayload.SortList = this.fixSharePointSearchArrayProperty(queryPayload.SortList);
+
+        return JSON.stringify({
+            request: {
+                '__metadata': {
+                    'type': 'Microsoft.Office.Server.Search.REST.SearchRequest'
+                },
+                ...queryPayload
+            }
+        });
+    }
+
+    private fixSharePointSearchArrayProperty(property: any): { results: any[] } {
+        if (property == null) {
+            return { results: [] };
+        }
+
+        return { results: Array.isArray(property) ? property : [property] };
+    }
+
+    private getDefaultFieldOptions(): IComboBoxOption[] {
+        return this.properties.fields
+            .filter(Boolean)
+            .map((field) => ({
+                key: field,
+                text: field
+            } as IComboBoxOption));
+    }
+
+    private getResultFieldOptions(): IComboBoxOption[] {
+        return Array.from(this._availableFieldsFromResults)
+            .map((field) => this.normalizeFieldName(field))
+            .map((field) => ({
+            key: field,
+            text: field
+        } as IComboBoxOption));
+    }
+
+    private mergeFieldOptions(...optionGroups: IComboBoxOption[][]): IComboBoxOption[] {
+        const merged = new Map<string, IComboBoxOption>();
+
+        optionGroups.filter(Boolean).forEach((options) => {
+            options.forEach((option) => {
+                if (option?.key !== undefined && option?.key !== null) {
+                    const normalizedKey = this.normalizeFieldName(option.key.toString());
+                    merged.set(normalizedKey, {
+                        key: normalizedKey,
+                        text: normalizedKey
+                    });
+                }
+            });
+        });
+
+        return Array.from(merged.values());
+    }
+
+    private async getAvailableExternalConnectionIds(): Promise<IComboBoxOption[]> {
+        const selectedConnectionOptions = (this.properties.contentSourceConnectionIds || []).map((id) => ({
+            key: id,
+            text: id
+        } as IComboBoxOption));
+
+        try {
+            const msGraphClientFactory: MSGraphClientFactory = this.serviceScope.consume(MSGraphClientFactory.serviceKey);
+            const msGraphClient = await msGraphClientFactory.getClient('3');
+
+            let nextLink = '/external/connections?$top=200';
+            const connections: IComboBoxOption[] = [];
+
+            while (nextLink) {
+                const response = await msGraphClient.api(nextLink).get() as { value?: Array<{ id?: string; name?: string; description?: string }>; '@odata.nextLink'?: string; };
+
+                (response.value || []).forEach((connection) => {
+                    if (connection.id) {
+                        const connectionName = connection.name || connection.description || connection.id;
+                        connections.push({
+                            key: connection.id,
+                            text: connectionName
+                        });
+                    }
+                });
+
+                nextLink = response['@odata.nextLink'] || null;
+            }
+
+            const deduped = new Map<string, IComboBoxOption>();
+            [...selectedConnectionOptions, ...connections].forEach((option) => {
+                deduped.set(option.key.toString(), option);
+            });
+
+            this.setExternalMetadataLoadState('connections', 'none');
+
+            return Array.from(deduped.values());
+        } catch (error) {
+            // Expected until ExternalConnection.Read.All has been granted or when Graph external
+            // connections are not available in the tenant. Keep manual/freeform entry working.
+            const statusCode = this.getGraphErrorStatusCode(error);
+            this.setExternalMetadataLoadState('connections', statusCode === 401 || statusCode === 403 ? 'permission' : 'generic');
+            console.warn('[PnP Modern Search][Microsoft Search] Unable to load external connections from Microsoft Graph.', error);
+            return selectedConnectionOptions;
+        }
+    }
+
+    private async getExternalConnectionSchemaFieldOptions(connectionIds: string[]): Promise<IComboBoxOption[]> {
+        const schemaFields = new Map<string, IComboBoxOption>();
+
+        try {
+            const msGraphClientFactory: MSGraphClientFactory = this.serviceScope.consume(MSGraphClientFactory.serviceKey);
+            const msGraphClient = await msGraphClientFactory.getClient('3');
+
+            for (const connectionId of connectionIds) {
+                const response = await msGraphClient.api(`/external/connections/${connectionId}/schema`).get() as { properties?: Array<{ name?: string }>; };
+
+                (response.properties || []).forEach((property) => {
+                    if (property.name) {
+                        schemaFields.set(property.name, {
+                            key: property.name,
+                            text: property.name
+                        });
+                    }
+                });
+            }
+
+            this.setExternalMetadataLoadState('schema', 'none');
+        } catch (error) {
+            // Keep default fields available when permission isn't granted yet.
+            const statusCode = this.getGraphErrorStatusCode(error);
+            this.setExternalMetadataLoadState('schema', statusCode === 401 || statusCode === 403 ? 'permission' : 'generic');
+            console.warn('[PnP Modern Search][Microsoft Search] Unable to load external connection schema properties from Microsoft Graph.', error);
+        }
+
+        return Array.from(schemaFields.values());
+    }
+
+    private getGraphErrorStatusCode(error: any): number | undefined {
+        const status = error?.statusCode ?? error?.status ?? error?.response?.status;
+
+        if (typeof status === 'number') {
+            return status;
+        }
+
+        if (typeof status === 'string') {
+            const parsedStatus = Number(status);
+            return Number.isNaN(parsedStatus) ? undefined : parsedStatus;
+        }
+
+        return undefined;
+    }
+
+    private setExternalMetadataLoadState(scope: 'connections' | 'schema', state: 'none' | 'permission' | 'generic'): void {
+        let hasChanged = false;
+
+        if (scope === 'connections') {
+            hasChanged = this._externalConnectionsLoadPermissionError !== (state === 'permission')
+                || this._externalConnectionsLoadGenericError !== (state === 'generic');
+
+            this._externalConnectionsLoadPermissionError = state === 'permission';
+            this._externalConnectionsLoadGenericError = state === 'generic';
+        } else {
+            hasChanged = this._externalSchemaLoadPermissionError !== (state === 'permission')
+                || this._externalSchemaLoadGenericError !== (state === 'generic');
+
+            this._externalSchemaLoadPermissionError = state === 'permission';
+            this._externalSchemaLoadGenericError = state === 'generic';
+        }
+
+        if (hasChanged) {
+            this.context.propertyPane.refresh();
+        }
+    }
+
+    private resetExternalMetadataLoadState(): void {
+        this._externalConnectionsLoadPermissionError = false;
+        this._externalConnectionsLoadGenericError = false;
+        this._externalSchemaLoadPermissionError = false;
+        this._externalSchemaLoadGenericError = false;
+    }
+
+    private getExternalMetadataWarningMessage(): string | undefined {
+        if (this._externalConnectionsLoadPermissionError) {
+            return commonStrings.DataSources.MicrosoftSearch.ExternalMetadataPermissionWarning;
+        }
+
+        if (this._externalConnectionsLoadGenericError) {
+            return commonStrings.DataSources.MicrosoftSearch.ExternalMetadataLoadWarning;
+        }
+
+        // Schema metadata retrieval can still fail for specific connections even when
+        // the connection list itself loaded successfully. If users already have selected
+        // fields configured, the warning is not actionable and creates noise.
+        const hasSelectedFields = (this.properties.fields || []).some(Boolean);
+        if (!hasSelectedFields && (this._externalSchemaLoadPermissionError || this._externalSchemaLoadGenericError)) {
+            return commonStrings.DataSources.MicrosoftSearch.ExternalMetadataLoadWarning;
+        }
+
+        return undefined;
     }
 
     public getTemplateSlots(): ITemplateSlot[] {
@@ -1125,9 +1459,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     private initProperties(): void {
         this.properties.entityTypes = this.properties.entityTypes ?? [EntityType.DriveItem];
 
-        const CommonFields = ["title", "name", "webUrl", "filetype", "fileType", "createdBy", "createdDateTime", "lastModifiedDateTime", "parentReference", "size", "description", "file", "folder", "subject", "bodyPreview", "replyTo", "from", "sender", "start", "end", "displayName", "givenName", "surname", "userPrincipalName", "mail", "phones", "department", "contentTypeId", "siteId", "webId", "contentClass", "siteTitle", "sitePath", "AuthorOWSUSER", "listId", "listItemId", "listItemUniqueId", "driveId", "owstaxidmetadataalltagsinfo"];
-
-        this.properties.fields = this.properties.fields ?? CommonFields;
+        this.properties.fields = this.properties.fields ?? this._defaultDriveItemFields;
         this.properties.sortProperties = this.properties.sortProperties ?? [];
         this.properties.sortList = this.properties.sortProperties;
         this.properties.contentSourceConnectionIds = this.properties.contentSourceConnectionIds ?? [];
@@ -1421,8 +1753,8 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private applyResultTemplateOptions(searchRequest: IMicrosoftSearchRequest): void {
-        const supportedTypes = [EntityType.ExternalItem, EntityType.ListItem];
-        if (this.properties.enableResultTypes && this.properties.entityTypes.every(e => supportedTypes.includes(e))) {
+        const supportedTypes = new Set([EntityType.ExternalItem, EntityType.ListItem]);
+        if (this.properties.enableResultTypes && this.properties.entityTypes.every(e => supportedTypes.has(e))) {
             searchRequest.resultTemplateOptions = {
                 enableResultTemplate: true
             };
@@ -1441,6 +1773,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             filters: []
         };
         let aggregationResults: IDataFilterResult[] = [];
+        this._availableFieldsFromResults.clear();
 
         // Get an instance to the MSGraphClient
         const msGraphClientFactory: MSGraphClientFactory = this.serviceScope.consume(MSGraphClientFactory.serviceKey);
@@ -1492,11 +1825,64 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     }
 
     private processSearchHit(hit: any): any {
+        this.collectAvailableFields(hit);
         this.flattenResourceProperties(hit);
         this.flattenListItemFields(hit);
         this.buildAuthorOWSUSER(hit);
         this.createFileTypeAlias(hit);
         return hit;
+    }
+
+    private collectAvailableFields(hit: any): void {
+        if (this.isExternalItemHit(hit)) {
+            return;
+        }
+
+        const sources = this.getAvailableFieldSources(hit);
+
+        sources.forEach((source) => {
+            if (!source || typeof source !== 'object') {
+                return;
+            }
+
+            Object.keys(source).forEach((field) => {
+                if (field !== '@odata.type' && field !== 'listItem' && field !== 'fields' && field !== 'properties') {
+                    this._availableFieldsFromResults.add(this.normalizeFieldName(field));
+                }
+            });
+        });
+    }
+
+    private isExternalItemHit(hit: any): boolean {
+        const resourceType = hit?.resource?.['@odata.type'];
+        return typeof resourceType === 'string' && resourceType.toLowerCase().includes('externalitem');
+    }
+
+    private getAvailableFieldSources(hit: any): any[] {
+        const resource = hit?.resource;
+        const sources: any[] = [];
+
+        if (resource?.listItem?.fields) {
+            sources.push(resource.listItem.fields);
+        }
+
+        if (resource?.fields) {
+            sources.push(resource.fields);
+        } else if (!resource?.properties && resource) {
+            // Site, Drive, List and similar entities expose their values directly on resource.
+            sources.push(resource);
+        }
+
+        return sources;
+    }
+
+    private normalizeFieldName(fieldName: string): string {
+        const normalized = (fieldName || '').trim();
+        if (normalized.toLowerCase() === 'filetype') {
+            return 'fileType';
+        }
+
+        return normalized;
     }
 
     private flattenResourceProperties(hit: any): void {
@@ -1511,14 +1897,14 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
 
         if (propertiesFieldName) {
             Object.keys(hit.resource[propertiesFieldName]).forEach(field => {
-                hit[field] = hit.resource[propertiesFieldName][field];
+                this.copyFieldWithAliases(hit, field, hit.resource[propertiesFieldName][field]);
             });
         } else {
             // For entity types without properties or fields (bookmark, acronym, person, etc.), 
             // flatten root properties from resource directly
             Object.keys(hit.resource).forEach(field => {
                 if (field !== '@odata.type' && !(field in hit)) {
-                    hit[field] = hit.resource[field];
+                    this.copyFieldWithAliases(hit, field, hit.resource[field]);
                 }
             });
         }
@@ -1528,8 +1914,33 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         // Also flatten listItem.fields for driveItem entities backed by SharePoint
         if (hit.resource?.listItem?.fields) {
             Object.keys(hit.resource.listItem.fields).forEach(field => {
-                hit[field] = hit.resource.listItem.fields[field];
+                this.copyFieldWithAliases(hit, field, hit.resource.listItem.fields[field]);
             });
+        }
+    }
+
+    private copyFieldWithAliases(target: any, fieldName: string, value: any): void {
+        if (!target || !fieldName) {
+            return;
+        }
+
+        target[fieldName] = value;
+
+        const normalizedFieldName = fieldName.trim();
+        const pascalCaseFieldName = normalizedFieldName.charAt(0).toUpperCase() + normalizedFieldName.slice(1);
+        const lowerCaseFieldName = normalizedFieldName.charAt(0).toLowerCase() + normalizedFieldName.slice(1);
+        const camelCaseFieldName = normalizedFieldName.charAt(0).toLowerCase() + normalizedFieldName.slice(1);
+
+        if (!(pascalCaseFieldName in target)) {
+            target[pascalCaseFieldName] = value;
+        }
+
+        if (!(lowerCaseFieldName in target)) {
+            target[lowerCaseFieldName] = value;
+        }
+
+        if (!(camelCaseFieldName in target)) {
+            target[camelCaseFieldName] = value;
         }
     }
 

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -664,11 +664,13 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             const hadExternalItem = previousEntityTypes.includes(EntityType.ExternalItem);
             const hasExternalItem = this.properties.entityTypes.includes(EntityType.ExternalItem);
 
+            this._availableFieldsFromResults.clear();
+
             if (hasExternalItem) {
                 // Reset result types
                 this.properties.enableResultTypes = false;
             } else if (hadExternalItem) {
-                this.properties.fields = ["title", "name", "webUrl", "filetype", "fileType", "createdBy", "createdDateTime", "lastModifiedDateTime", "parentReference", "size", "description", "file", "folder", "subject", "bodyPreview", "replyTo", "from", "sender", "start", "end", "displayName", "givenName", "surname", "userPrincipalName", "mail", "phones", "department", "contentTypeId", "siteId", "webId", "contentClass", "siteTitle", "sitePath", "AuthorOWSUSER", "listId", "listItemId", "listItemUniqueId", "driveId", "owstaxidmetadataalltagsinfo"];
+                this.properties.fields = [...this._defaultDriveItemFields];
                 this.resetExternalMetadataLoadState();
             }
 

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -788,7 +788,7 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         });
 
         if (!response.ok) {
-            throw new Error(`${response['statusMessage']}`);
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 
         const searchResponse = await response.json() as any;
@@ -1461,7 +1461,9 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
     private initProperties(): void {
         this.properties.entityTypes = this.properties.entityTypes ?? [EntityType.DriveItem];
 
-        this.properties.fields = this.properties.fields ?? this._defaultDriveItemFields;
+        this.properties.fields = (this.properties.fields ?? this._defaultDriveItemFields)
+            .map((field) => this.normalizeFieldName(field))
+            .filter((field, index, fields) => fields.indexOf(field) === index);
         this.properties.sortProperties = this.properties.sortProperties ?? [];
         this.properties.sortList = this.properties.sortProperties;
         this.properties.contentSourceConnectionIds = this.properties.contentSourceConnectionIds ?? [];
@@ -1926,24 +1928,18 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
             return;
         }
 
-        target[fieldName] = value;
+        const normalizedFieldName = this.normalizeFieldName(fieldName);
+        const aliases = new Set<string>([
+            normalizedFieldName,
+            normalizedFieldName.charAt(0).toUpperCase() + normalizedFieldName.slice(1),
+            normalizedFieldName.charAt(0).toLowerCase() + normalizedFieldName.slice(1)
+        ]);
 
-        const normalizedFieldName = fieldName.trim();
-        const pascalCaseFieldName = normalizedFieldName.charAt(0).toUpperCase() + normalizedFieldName.slice(1);
-        const lowerCaseFieldName = normalizedFieldName.charAt(0).toLowerCase() + normalizedFieldName.slice(1);
-        const camelCaseFieldName = normalizedFieldName.charAt(0).toLowerCase() + normalizedFieldName.slice(1);
-
-        if (!(pascalCaseFieldName in target)) {
-            target[pascalCaseFieldName] = value;
-        }
-
-        if (!(lowerCaseFieldName in target)) {
-            target[lowerCaseFieldName] = value;
-        }
-
-        if (!(camelCaseFieldName in target)) {
-            target[camelCaseFieldName] = value;
-        }
+        aliases.forEach((alias) => {
+            if (alias && !(alias in target)) {
+                target[alias] = value;
+            }
+        });
     }
 
     private buildAuthorOWSUSER(hit: any): void {

--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -143,6 +143,8 @@ declare interface ICommonStrings {
         ContentSourcesFieldLabel: string;
         ContentSourcesFieldDescriptionLabel: string;
         ContentSourcesFieldPlaceholderLabel: string;
+        ExternalMetadataPermissionWarning: string;
+        ExternalMetadataLoadWarning: string;
         EnableTopResultsLabel: string;
         EnableSuggestionLabel: string;
         EnableModificationLabel: string;

--- a/search-parts/src/loc/cs-cz.js
+++ b/search-parts/src/loc/cs-cz.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Zdroje obsahu",
                 ContentSourcesFieldDescriptionLabel: "ID připojení definovaných v administračním portálu konektorů Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "např.: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Nepodařilo se načíst metadata konektoru z Microsoft Graph. Udělte oprávnění ExternalConnection.Read.All, aby bylo možné automatické zjišťování. Hodnoty můžete stále zadat ručně.",
+                ExternalMetadataLoadWarning: "Nepodařilo se načíst metadata konektoru z Microsoft Graph. Zkontrolujte připojení a zkuste to znovu. Hodnoty můžete stále zadat ručně.",
                 EnableSuggestionLabel: "Povolit návrhy pravopisu",
                 EnableModificationLabel: "Povolit úpravy pravopisu",
                 QueryTemplateFieldLabel: "Šablona dotazu",

--- a/search-parts/src/loc/cs-cz.js
+++ b/search-parts/src/loc/cs-cz.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "ID připojení definovaných v administračním portálu konektorů Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "např.: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Nepodařilo se načíst metadata konektoru z Microsoft Graph. Udělte oprávnění ExternalConnection.Read.All, aby bylo možné automatické zjišťování. Hodnoty můžete stále zadat ručně.",
-                ExternalMetadataLoadWarning: "Nepodařilo se načíst metadata konektoru z Microsoft Graph. Zkontrolujte připojení a zkuste to znovu. Hodnoty můžete stále zadat ručně.",
+                ExternalMetadataLoadWarning: "Nepodařilo se načíst metadata konektoru z Microsoft Graph. Požadované delegované oprávnění Graph pravděpodobně nebylo uděleno. Hodnoty můžete stále zadat ručně do pole Vybraná pole.",
                 EnableSuggestionLabel: "Povolit návrhy pravopisu",
                 EnableModificationLabel: "Povolit úpravy pravopisu",
                 QueryTemplateFieldLabel: "Šablona dotazu",

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Viser ID af de forbindelser der er defineret i administrationsportalen for Microsoft Search-connectors.",
                 ContentSourcesFieldPlaceholderLabel: "Fx: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Kunne ikke indlæse connector-metadata fra Microsoft Graph. Giv tilladelsen ExternalConnection.Read.All for at aktivere automatisk registrering. Du kan stadig indtaste værdier manuelt.",
-                ExternalMetadataLoadWarning: "Kunne ikke indlæse connector-metadata fra Microsoft Graph. Kontroller din forbindelse, og prøv igen. Du kan stadig indtaste værdier manuelt.",
+                ExternalMetadataLoadWarning: "Kunne ikke indlæse connector-metadata fra Microsoft Graph. Den krævede delegerede Graph-tilladelse er muligvis ikke blevet givet. Du kan stadig indtaste værdier manuelt i feltet Valgte felter.",
                 EnableSuggestionLabel: "Aktiver staveforslag",
                 EnableModificationLabel: "Aktiver staveændringer",
                 QueryTemplateFieldLabel: "Forespørgselsmodifikator",

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Indholdskilder",
                 ContentSourcesFieldDescriptionLabel: "Viser ID af de forbindelser der er defineret i administrationsportalen for Microsoft Search-connectors.",
                 ContentSourcesFieldPlaceholderLabel: "Fx: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Kunne ikke indlæse connector-metadata fra Microsoft Graph. Giv tilladelsen ExternalConnection.Read.All for at aktivere automatisk registrering. Du kan stadig indtaste værdier manuelt.",
+                ExternalMetadataLoadWarning: "Kunne ikke indlæse connector-metadata fra Microsoft Graph. Kontroller din forbindelse, og prøv igen. Du kan stadig indtaste værdier manuelt.",
                 EnableSuggestionLabel: "Aktiver staveforslag",
                 EnableModificationLabel: "Aktiver staveændringer",
                 QueryTemplateFieldLabel: "Forespørgselsmodifikator",

--- a/search-parts/src/loc/de-de.js
+++ b/search-parts/src/loc/de-de.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Inhaltsquellen",
                 ContentSourcesFieldDescriptionLabel: "IDs von Verbindungen, die im Verwaltungsportal von Microsoft Search Connectors definiert sind.",
                 ContentSourcesFieldPlaceholderLabel: "Bspw.: 'MeineAngepassteVerbindungsId'",
+                ExternalMetadataPermissionWarning: "Die Connectormetadaten konnten nicht aus Microsoft Graph geladen werden. Erteilen Sie ExternalConnection.Read.All, um die automatische Ermittlung zu aktivieren. Sie können Werte weiterhin manuell eingeben.",
+                ExternalMetadataLoadWarning: "Die Connectormetadaten konnten nicht aus Microsoft Graph geladen werden. Überprüfen Sie die Verbindung und versuchen Sie es erneut. Sie können Werte weiterhin manuell eingeben.",
                 EnableSuggestionLabel: "Rechtschreibevorschläge aktivieren",
                 EnableModificationLabel: "Rechtschreibemodifikationen aktivieren",
                 QueryTemplateFieldLabel: "Query Vorlage",

--- a/search-parts/src/loc/de-de.js
+++ b/search-parts/src/loc/de-de.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "IDs von Verbindungen, die im Verwaltungsportal von Microsoft Search Connectors definiert sind.",
                 ContentSourcesFieldPlaceholderLabel: "Bspw.: 'MeineAngepassteVerbindungsId'",
                 ExternalMetadataPermissionWarning: "Die Connectormetadaten konnten nicht aus Microsoft Graph geladen werden. Erteilen Sie ExternalConnection.Read.All, um die automatische Ermittlung zu aktivieren. Sie können Werte weiterhin manuell eingeben.",
-                ExternalMetadataLoadWarning: "Die Connectormetadaten konnten nicht aus Microsoft Graph geladen werden. Überprüfen Sie die Verbindung und versuchen Sie es erneut. Sie können Werte weiterhin manuell eingeben.",
+                ExternalMetadataLoadWarning: "Die Connectormetadaten konnten nicht aus Microsoft Graph geladen werden. Die erforderliche delegierte Graph-Berechtigung wurde möglicherweise nicht erteilt. Sie können Werte weiterhin manuell im Feld Ausgewählte Felder eingeben.",
                 EnableSuggestionLabel: "Rechtschreibevorschläge aktivieren",
                 EnableModificationLabel: "Rechtschreibemodifikationen aktivieren",
                 QueryTemplateFieldLabel: "Query Vorlage",

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Content sources",
                 ContentSourcesFieldDescriptionLabel: "IDs of connections defined in the Microsoft Search connectors administration portal.",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Could not load connector metadata from Microsoft Graph. Grant ExternalConnection.Read.All to enable automatic discovery. You can still enter values manually.",
+                ExternalMetadataLoadWarning: "Could not load connector metadata from Microsoft Graph. The required delegated Graph permission might not be granted. You can still enter values manually in the Selected Fields box.",
                 EnableSuggestionLabel: "Enable spelling suggestions",
                 EnableModificationLabel: "Enable spelling modifications",
                 QueryTemplateFieldLabel: "Query template",

--- a/search-parts/src/loc/es-es.js
+++ b/search-parts/src/loc/es-es.js
@@ -146,6 +146,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Fuentes de contenido",
                 ContentSourcesFieldDescriptionLabel: "IDs de conexiones definidas en el portal de administración de conectores de Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "No se pudieron cargar los metadatos del conector desde Microsoft Graph. Conceda ExternalConnection.Read.All para habilitar la detección automática. Aun puede escribir los valores manualmente.",
+                ExternalMetadataLoadWarning: "No se pudieron cargar los metadatos del conector desde Microsoft Graph. Compruebe la conexión y vuelva a intentarlo. Aun puede escribir los valores manualmente.",
                 EnableSuggestionLabel: "Activar las sugerencias ortográficas",
                 EnableModificationLabel: "Habilitar las modificaciones ortográficas",
                 QueryTemplateFieldLabel: "Plantilla de consulta",

--- a/search-parts/src/loc/es-es.js
+++ b/search-parts/src/loc/es-es.js
@@ -147,7 +147,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "IDs de conexiones definidas en el portal de administración de conectores de Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "No se pudieron cargar los metadatos del conector desde Microsoft Graph. Conceda ExternalConnection.Read.All para habilitar la detección automática. Aun puede escribir los valores manualmente.",
-                ExternalMetadataLoadWarning: "No se pudieron cargar los metadatos del conector desde Microsoft Graph. Compruebe la conexión y vuelva a intentarlo. Aun puede escribir los valores manualmente.",
+                ExternalMetadataLoadWarning: "No se pudieron cargar los metadatos del conector desde Microsoft Graph. Es posible que no se haya concedido el permiso delegado de Graph requerido. Aun puede escribir los valores manualmente en el cuadro Campos seleccionados.",
                 EnableSuggestionLabel: "Activar las sugerencias ortográficas",
                 EnableModificationLabel: "Habilitar las modificaciones ortográficas",
                 QueryTemplateFieldLabel: "Plantilla de consulta",

--- a/search-parts/src/loc/fi-fi.js
+++ b/search-parts/src/loc/fi-fi.js
@@ -144,7 +144,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Microsoft Search yhdistimien hallintaportaalissa määritettyjen yhteyksien ID:t.",
                 ContentSourcesFieldPlaceholderLabel: "esimerkki: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Yhdistimen metatietojen lataaminen Microsoft Graphista epäonnistui. Myönnä ExternalConnection.Read.All, jotta automaattinen tunnistus voidaan ottaa käyttöön. Voit silti syöttää arvot manuaalisesti.",
-                ExternalMetadataLoadWarning: "Yhdistimen metatietojen lataaminen Microsoft Graphista epäonnistui. Tarkista yhteys ja yritä uudelleen. Voit silti syöttää arvot manuaalisesti.",
+                ExternalMetadataLoadWarning: "Yhdistimen metatietoja ei voitu ladata Microsoft Graphista. Tarvittavaa delegoitua Graph-käyttöoikeutta ei ehkä ole myönnetty. Voit silti syöttää arvot manuaalisesti Valitut kentät -ruutuun.",
                 EnableSuggestionLabel: "Salli kirjoitusasun ehdotukset",
                 EnableModificationLabel: "Salli kirjoitusasun muutokset",
                 QueryTemplateFieldLabel: "Kyselytemplaatti",

--- a/search-parts/src/loc/fi-fi.js
+++ b/search-parts/src/loc/fi-fi.js
@@ -143,6 +143,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Sisältölähteet",
                 ContentSourcesFieldDescriptionLabel: "Microsoft Search yhdistimien hallintaportaalissa määritettyjen yhteyksien ID:t.",
                 ContentSourcesFieldPlaceholderLabel: "esimerkki: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Yhdistimen metatietojen lataaminen Microsoft Graphista epäonnistui. Myönnä ExternalConnection.Read.All, jotta automaattinen tunnistus voidaan ottaa käyttöön. Voit silti syöttää arvot manuaalisesti.",
+                ExternalMetadataLoadWarning: "Yhdistimen metatietojen lataaminen Microsoft Graphista epäonnistui. Tarkista yhteys ja yritä uudelleen. Voit silti syöttää arvot manuaalisesti.",
                 EnableSuggestionLabel: "Salli kirjoitusasun ehdotukset",
                 EnableModificationLabel: "Salli kirjoitusasun muutokset",
                 QueryTemplateFieldLabel: "Kyselytemplaatti",

--- a/search-parts/src/loc/fr-fr.js
+++ b/search-parts/src/loc/fr-fr.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Identifiants de connexion définis dans le portail d’administration des connecteurs de recherche Microsoft.",
                 ContentSourcesFieldPlaceholderLabel: "Exemple: « MyCustomConnectorID » ",
                 ExternalMetadataPermissionWarning: "Impossible de charger les métadonnées du connecteur depuis Microsoft Graph. Accordez ExternalConnection.Read.All pour activer la découverte automatique. Vous pouvez toujours saisir les valeurs manuellement.",
-                ExternalMetadataLoadWarning: "Impossible de charger les métadonnées du connecteur depuis Microsoft Graph. Vérifiez la connexion et réessayez. Vous pouvez toujours saisir les valeurs manuellement.",
+                ExternalMetadataLoadWarning: "Impossible de charger les métadonnées du connecteur depuis Microsoft Graph. L’autorisation Graph déléguée requise n’a peut-être pas été accordée. Vous pouvez toujours saisir les valeurs manuellement dans la zone Champs sélectionnés.",
                 EnableSuggestionLabel: "Activer les suggestions orthographiques",
                 EnableModificationLabel: "Activer les modifications orthographiques",
                 QueryTemplateFieldLabel: "Modèle de requête",

--- a/search-parts/src/loc/fr-fr.js
+++ b/search-parts/src/loc/fr-fr.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Sources du contenu",
                 ContentSourcesFieldDescriptionLabel: "Identifiants de connexion définis dans le portail d’administration des connecteurs de recherche Microsoft.",
                 ContentSourcesFieldPlaceholderLabel: "Exemple: « MyCustomConnectorID » ",
+                ExternalMetadataPermissionWarning: "Impossible de charger les métadonnées du connecteur depuis Microsoft Graph. Accordez ExternalConnection.Read.All pour activer la découverte automatique. Vous pouvez toujours saisir les valeurs manuellement.",
+                ExternalMetadataLoadWarning: "Impossible de charger les métadonnées du connecteur depuis Microsoft Graph. Vérifiez la connexion et réessayez. Vous pouvez toujours saisir les valeurs manuellement.",
                 EnableSuggestionLabel: "Activer les suggestions orthographiques",
                 EnableModificationLabel: "Activer les modifications orthographiques",
                 QueryTemplateFieldLabel: "Modèle de requête",

--- a/search-parts/src/loc/it-it.js
+++ b/search-parts/src/loc/it-it.js
@@ -148,7 +148,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "ID delle connessioni definite nel portale di amministrazione dei connettori di Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "es: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Impossibile caricare i metadati del connettore da Microsoft Graph. Concedi ExternalConnection.Read.All per abilitare il rilevamento automatico. Puoi comunque inserire i valori manualmente.",
-                ExternalMetadataLoadWarning: "Impossibile caricare i metadati del connettore da Microsoft Graph. Controlla la connessione e riprova. Puoi comunque inserire i valori manualmente.",
+                ExternalMetadataLoadWarning: "Impossibile caricare i metadati del connettore da Microsoft Graph. È possibile che l'autorizzazione Graph delegata richiesta non sia stata concessa. È comunque possibile inserire manualmente i valori nella casella Campi selezionati.",
                 EnableSuggestionLabel: "Abilita suggerimenti ortografici",
                 EnableModificationLabel: "Abilita modifiche ortografiche",
                 QueryTemplateFieldLabel: "Modello di query",

--- a/search-parts/src/loc/it-it.js
+++ b/search-parts/src/loc/it-it.js
@@ -147,6 +147,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Fonti di contenuto",
                 ContentSourcesFieldDescriptionLabel: "ID delle connessioni definite nel portale di amministrazione dei connettori di Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "es: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Impossibile caricare i metadati del connettore da Microsoft Graph. Concedi ExternalConnection.Read.All per abilitare il rilevamento automatico. Puoi comunque inserire i valori manualmente.",
+                ExternalMetadataLoadWarning: "Impossibile caricare i metadati del connettore da Microsoft Graph. Controlla la connessione e riprova. Puoi comunque inserire i valori manualmente.",
                 EnableSuggestionLabel: "Abilita suggerimenti ortografici",
                 EnableModificationLabel: "Abilita modifiche ortografiche",
                 QueryTemplateFieldLabel: "Modello di query",

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Innholdskilder",
                 ContentSourcesFieldDescriptionLabel: "Viser ID for de tilkoblinger som er definert i admin-portalen for Microsoft Search Connectors",
                 ContentSourcesFieldPlaceholderLabel: "f.eks.: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Kunne ikke laste inn tilkoblingsmetadata fra Microsoft Graph. Gi ExternalConnection.Read.All for å aktivere automatisk oppdagelse. Du kan fortsatt skrive inn verdier manuelt.",
+                ExternalMetadataLoadWarning: "Kunne ikke laste inn tilkoblingsmetadata fra Microsoft Graph. Kontroller tilkoblingen og prøv igjen. Du kan fortsatt skrive inn verdier manuelt.",
                 EnableSuggestionLabel: "Aktiver staveforslag",
                 EnableModificationLabel: "Aktiver stavemåtendringer",
                 QueryTemplateFieldLabel: "Forespørselsmal",

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Viser ID for de tilkoblinger som er definert i admin-portalen for Microsoft Search Connectors",
                 ContentSourcesFieldPlaceholderLabel: "f.eks.: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Kunne ikke laste inn tilkoblingsmetadata fra Microsoft Graph. Gi ExternalConnection.Read.All for å aktivere automatisk oppdagelse. Du kan fortsatt skrive inn verdier manuelt.",
-                ExternalMetadataLoadWarning: "Kunne ikke laste inn tilkoblingsmetadata fra Microsoft Graph. Kontroller tilkoblingen og prøv igjen. Du kan fortsatt skrive inn verdier manuelt.",
+                ExternalMetadataLoadWarning: "Kunne ikke laste inn tilkoblingsmetadata fra Microsoft Graph. Den nødvendige delegerte Graph-tillatelsen er kanskje ikke gitt. Du kan fortsatt skrive inn verdier manuelt i boksen Valgte felt.",
                 EnableSuggestionLabel: "Aktiver staveforslag",
                 EnableModificationLabel: "Aktiver stavemåtendringer",
                 QueryTemplateFieldLabel: "Forespørselsmal",

--- a/search-parts/src/loc/nl-nl.js
+++ b/search-parts/src/loc/nl-nl.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "IDs van verbingingen gedefinieerd in de Microsoft Search connectors administratie portaal.",
                 ContentSourcesFieldPlaceholderLabel: "bijv: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Kan connectormetadata niet laden vanuit Microsoft Graph. Verleen ExternalConnection.Read.All om automatische detectie in te schakelen. Je kunt waarden nog steeds handmatig invoeren.",
-                ExternalMetadataLoadWarning: "Kan connectormetadata niet laden vanuit Microsoft Graph. Controleer de verbinding en probeer het opnieuw. Je kunt waarden nog steeds handmatig invoeren.",
+                ExternalMetadataLoadWarning: "Kan connectormetadata niet laden vanuit Microsoft Graph. De vereiste gedelegeerde Graph-machtiging is mogelijk niet verleend. Je kunt waarden nog steeds handmatig invoeren in het vak Geselecteerde velden.",
                 EnableSuggestionLabel: "Spellingsuggesties inschakelen",
                 EnableModificationLabel: "Spellingaanpassingen inschakelen",
                 QueryTemplateFieldLabel: "Query-modifier",

--- a/search-parts/src/loc/nl-nl.js
+++ b/search-parts/src/loc/nl-nl.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Inhoudsbronnen",
                 ContentSourcesFieldDescriptionLabel: "IDs van verbingingen gedefinieerd in de Microsoft Search connectors administratie portaal.",
                 ContentSourcesFieldPlaceholderLabel: "bijv: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Kan connectormetadata niet laden vanuit Microsoft Graph. Verleen ExternalConnection.Read.All om automatische detectie in te schakelen. Je kunt waarden nog steeds handmatig invoeren.",
+                ExternalMetadataLoadWarning: "Kan connectormetadata niet laden vanuit Microsoft Graph. Controleer de verbinding en probeer het opnieuw. Je kunt waarden nog steeds handmatig invoeren.",
                 EnableSuggestionLabel: "Spellingsuggesties inschakelen",
                 EnableModificationLabel: "Spellingaanpassingen inschakelen",
                 QueryTemplateFieldLabel: "Query-modifier",

--- a/search-parts/src/loc/pl-pl.js
+++ b/search-parts/src/loc/pl-pl.js
@@ -147,7 +147,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Identyfikatory połączeń zdefiniowanych w portalu administracyjnym Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "przykładowo: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Nie można załadować metadanych łącznika z Microsoft Graph. Udziel uprawnienia ExternalConnection.Read.All, aby włączyć automatyczne wykrywanie. Nadal możesz wpisywać wartości ręcznie.",
-                ExternalMetadataLoadWarning: "Nie można załadować metadanych łącznika z Microsoft Graph. Sprawdź połączenie i spróbuj ponownie. Nadal możesz wpisywać wartości ręcznie.",
+                ExternalMetadataLoadWarning: "Nie można załadować metadanych łącznika z Microsoft Graph. Wymagane delegowane uprawnienie Graph mogło nie zostać przyznane. Nadal możesz ręcznie wprowadzać wartości w polu Wybrane pola.",
                 EnableSuggestionLabel: "Włącz sugestie pisowni",
                 EnableModificationLabel: "Włącz modyfikacje pisowni",
                 QueryTemplateFieldLabel: "Modyfikator zapytania",

--- a/search-parts/src/loc/pl-pl.js
+++ b/search-parts/src/loc/pl-pl.js
@@ -146,6 +146,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Źródła zawartości",
                 ContentSourcesFieldDescriptionLabel: "Identyfikatory połączeń zdefiniowanych w portalu administracyjnym Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "przykładowo: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Nie można załadować metadanych łącznika z Microsoft Graph. Udziel uprawnienia ExternalConnection.Read.All, aby włączyć automatyczne wykrywanie. Nadal możesz wpisywać wartości ręcznie.",
+                ExternalMetadataLoadWarning: "Nie można załadować metadanych łącznika z Microsoft Graph. Sprawdź połączenie i spróbuj ponownie. Nadal możesz wpisywać wartości ręcznie.",
                 EnableSuggestionLabel: "Włącz sugestie pisowni",
                 EnableModificationLabel: "Włącz modyfikacje pisowni",
                 QueryTemplateFieldLabel: "Modyfikator zapytania",

--- a/search-parts/src/loc/pt-br.js
+++ b/search-parts/src/loc/pt-br.js
@@ -145,6 +145,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Fontes de conteúdo",
                 ContentSourcesFieldDescriptionLabel: "IDs de conexões definidos no portal de administração de conectores do Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MeuIdDeConectorPersonalizado'",
+                ExternalMetadataPermissionWarning: "Não foi possível carregar os metadados do conector do Microsoft Graph. Conceda ExternalConnection.Read.All para habilitar a descoberta automática. Você ainda pode inserir valores manualmente.",
+                ExternalMetadataLoadWarning: "Não foi possível carregar os metadados do conector do Microsoft Graph. Verifique a conexão e tente novamente. Você ainda pode inserir valores manualmente.",
                 EnableSuggestionLabel: "Ativar sugestões de ortografia",
                 EnableModificationLabel: "Ativar modificações de ortografia",
                 QueryTemplateFieldLabel: "Modelo de consulta",

--- a/search-parts/src/loc/pt-br.js
+++ b/search-parts/src/loc/pt-br.js
@@ -146,7 +146,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "IDs de conexões definidos no portal de administração de conectores do Microsoft Search.",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MeuIdDeConectorPersonalizado'",
                 ExternalMetadataPermissionWarning: "Não foi possível carregar os metadados do conector do Microsoft Graph. Conceda ExternalConnection.Read.All para habilitar a descoberta automática. Você ainda pode inserir valores manualmente.",
-                ExternalMetadataLoadWarning: "Não foi possível carregar os metadados do conector do Microsoft Graph. Verifique a conexão e tente novamente. Você ainda pode inserir valores manualmente.",
+                ExternalMetadataLoadWarning: "Não foi possível carregar os metadados do conector do Microsoft Graph. A permissão delegada do Graph necessária talvez não tenha sido concedida. Você ainda pode inserir valores manualmente na caixa Campos selecionados.",
                 EnableSuggestionLabel: "Ativar sugestões de ortografia",
                 EnableModificationLabel: "Ativar modificações de ortografia",
                 QueryTemplateFieldLabel: "Modelo de consulta",

--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -147,7 +147,7 @@ define([], function () {
                 ContentSourcesFieldDescriptionLabel: "Visar ID för de anslutningar som definierats i administrationsportalen för Microsoft Search Connectors",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MyCustomConnectorId'",
                 ExternalMetadataPermissionWarning: "Det gick inte att läsa in anslutningsmetadata från Microsoft Graph. Bevilja ExternalConnection.Read.All för att aktivera automatisk identifiering. Du kan fortfarande ange värden manuellt.",
-                ExternalMetadataLoadWarning: "Det gick inte att läsa in anslutningsmetadata från Microsoft Graph. Kontrollera anslutningen och försök igen. Du kan fortfarande ange värden manuellt.",
+                ExternalMetadataLoadWarning: "Det gick inte att läsa in anslutningsmetadata från Microsoft Graph. Den nödvändiga delegerade Graph-behörigheten kanske inte har beviljats. Du kan fortfarande ange värden manuellt i rutan Valda fält.",
                 EnableSuggestionLabel: "Aktivera stavningsförslag",
                 EnableModificationLabel: "Aktivera stavningsändringar",
                 QueryTemplateFieldLabel: "Frågemodifierare",

--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -146,6 +146,8 @@ define([], function () {
                 ContentSourcesFieldLabel: "Innehållskällor",
                 ContentSourcesFieldDescriptionLabel: "Visar ID för de anslutningar som definierats i administrationsportalen för Microsoft Search Connectors",
                 ContentSourcesFieldPlaceholderLabel: "ex: 'MyCustomConnectorId'",
+                ExternalMetadataPermissionWarning: "Det gick inte att läsa in anslutningsmetadata från Microsoft Graph. Bevilja ExternalConnection.Read.All för att aktivera automatisk identifiering. Du kan fortfarande ange värden manuellt.",
+                ExternalMetadataLoadWarning: "Det gick inte att läsa in anslutningsmetadata från Microsoft Graph. Kontrollera anslutningen och försök igen. Du kan fortfarande ange värden manuellt.",
                 EnableSuggestionLabel: "Aktivera stavningsförslag",
                 EnableModificationLabel: "Aktivera stavningsändringar",
                 QueryTemplateFieldLabel: "Frågemodifierare",


### PR DESCRIPTION
## Summary
- add Microsoft Search schema discovery for external items and SharePoint-backed entity types
- normalize field discovery and result-field collection across entity types
- improve Details List field resolution for Microsoft Search results
- update docs, localized warning strings, and local debug tasks/config

## Validation
- validated the touched files compile cleanly
- built the SPFx package locally

Related: Discussion #4876

Discussion: https://github.com/microsoft-search/pnp-modern-search/discussions/4876