### PR TITLE
Add selected-item details action across built-in result layouts

### DIFF
--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "PnP Modern Search - Search Web Parts - v4",
         "id": "59903278-dd5d-4e9e-bef6-562aae716b8b",
-        "version": "4.23.3.0",
+        "version": "4.23.9.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": true,
         "isDomainIsolated": false,

--- a/search-parts/config/package-solution.json
+++ b/search-parts/config/package-solution.json
@@ -3,7 +3,7 @@
     "solution": {
         "name": "PnP Modern Search - Search Web Parts - v4",
         "id": "59903278-dd5d-4e9e-bef6-562aae716b8b",
-        "version": "4.23.9.0",
+        "version": "4.23.2.0",
         "includeClientSideAssets": true,
         "skipFeatureDeployment": true,
         "isDomainIsolated": false,

--- a/search-parts/config/spfx-customize-webpack.js
+++ b/search-parts/config/spfx-customize-webpack.js
@@ -17,6 +17,20 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 module.exports = function (webpackConfig, taskSession, heftConfiguration, webpack) {
     const projectRoot = heftConfiguration.buildFolderPath;
 
+    if (!taskSession.parameters.production) {
+        webpackConfig.devServer = {
+            ...webpackConfig.devServer,
+            hot: false,
+            liveReload: false,
+            client: false,
+            webSocketServer: false,
+        };
+
+        webpackConfig.plugins = (webpackConfig.plugins || []).filter((plugin) => {
+            return plugin?.constructor?.name !== 'HotModuleReplacementPlugin';
+        });
+    }
+
     // ─── resolve.alias ─────────────────────────────────────────────────────────
     webpackConfig.resolve = webpackConfig.resolve || {};
     webpackConfig.resolve.alias = {

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.3",
+    "version": "4.23.9",
     "private": true,
     "engines": {
         "node": ">=22.14.0 < 23.0.0"

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pnp/modern-search-web-parts",
-    "version": "4.23.9",
+    "version": "4.23.2",
     "private": true,
     "engines": {
         "node": ">=22.14.0 < 23.0.0"

--- a/search-parts/src/components/AvailableComponents.ts
+++ b/search-parts/src/components/AvailableComponents.ts
@@ -26,6 +26,7 @@ import { FilterValueOperatorWebComponent } from './filters/FilterValueOperatorCo
 import { SpoPathBreadcrumbWebComponent } from './SpoPathBreadcrumbComponent';
 import { SortWebComponent } from './SortComponent';
 import { DownloadSelectedItemsButtonWebComponent } from './DownloadSelectedItemsButtonComponent';
+import { DetailsSelectedItemButtonWebComponent } from './DetailsSelectedItemButtonComponent';
 import { FilterHierarchicalWebComponent } from './filters/FilterHierarchicalComponent';
 
 export class AvailableComponents {
@@ -33,7 +34,7 @@ export class AvailableComponents {
     /**
      * Returns the list of builtin web components available for Handlebars templates
      */
-    public static BuiltinComponents: IComponentDefinition<any>[] = [
+    public static readonly BuiltinComponents: IComponentDefinition<any>[] = [
         {
             componentName: 'pnp-debugview',
             componentClass: DebugViewWebComponent
@@ -141,6 +142,10 @@ export class AvailableComponents {
         {
             componentName: "pnp-download-selected-items-button",
             componentClass: DownloadSelectedItemsButtonWebComponent
+        },
+        {
+            componentName: "pnp-details-selected-item-button",
+            componentClass: DetailsSelectedItemButtonWebComponent
         },
         {
             componentName: "pnp-filterhierarchical",

--- a/search-parts/src/components/DetailsListComponent.tsx
+++ b/search-parts/src/components/DetailsListComponent.tsx
@@ -616,9 +616,9 @@ export class DetailsListComponent extends React.Component<
 
       return (
         <Fabric>
-          <div 
-            style={{ 
-              height: containerHeight, 
+          <div
+            style={{
+              height: containerHeight,
               position: "relative"
             }}
           >
@@ -1056,6 +1056,7 @@ export class DetailsListComponent extends React.Component<
       }
     );
   };
+
 
   private _buildGroups(
     items: any[],

--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -242,7 +242,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return (
       <div style={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
         <IconButton
-          ariaLabel={strings.Layouts.PersonCard.CloseCardLabel}
+          ariaLabel={strings.Layouts.DetailsList.CloseDetailsPanelLabel}
           iconProps={{ iconName: "Cancel" }}
           onClick={this._closeDetailsPanel}
           styles={{ root: { backgroundColor: panelBackgroundColor, color: panelTextColor } }}

--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -7,8 +7,8 @@ import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext
 import { ObjectHelper } from "../helpers/ObjectHelper";
 import * as strings from "CommonStrings";
 
-const MIN_LIVE_UPDATE_PANEL_HEIGHT = 520;
-const LIVE_UPDATE_PANEL_RIGHT_OFFSET = 32;
+const MIN_DETAILS_PANEL_HEIGHT = 520;
+const DETAILS_PANEL_RIGHT_OFFSET = 32;
 const HEX_COLOR_REGEXP = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 const RGB_COLOR_REGEXP = /^rgba?\((\d+),\s*(\d+),\s*(\d+)/i;
 
@@ -22,59 +22,55 @@ interface IDetailsSelectedItemButtonProps {
 }
 
 interface IDetailsSelectedItemButtonState {
-  activeLiveUpdateFormUrl?: string;
-  activeLiveUpdateItemTitle?: string;
-  isLiveUpdateFrameReady?: boolean;
+  activeDetailsFormUrl?: string;
+  activeDetailsItemTitle?: string;
+  isDetailsFrameReady?: boolean;
 }
 
-interface ILiveUpdatePanelSessionState {
+interface IDetailsPanelSessionState {
   isOpen: boolean;
-  activeLiveUpdateFormUrl?: string;
-  activeLiveUpdateItemTitle?: string;
+  activeDetailsFormUrl?: string;
+  activeDetailsItemTitle?: string;
 }
 
-const liveUpdatePanelSessionState: ILiveUpdatePanelSessionState = {
-  isOpen: false,
-  activeLiveUpdateFormUrl: null,
-  activeLiveUpdateItemTitle: null,
-};
+const detailsPanelSessionStates = new Map<string, IDetailsPanelSessionState>();
 
 export class DetailsSelectedItemButtonComponent extends React.Component<IDetailsSelectedItemButtonProps, IDetailsSelectedItemButtonState> {
   private _selectedItems: any[] = [];
-  private _liveUpdateLayoutAnimationFrame: number | null = null;
+  private _detailsLayoutAnimationFrame: number | null = null;
 
   constructor(props: IDetailsSelectedItemButtonProps) {
     super(props);
 
     this.state = {
-      activeLiveUpdateFormUrl: null,
-      activeLiveUpdateItemTitle: null,
-      isLiveUpdateFrameReady: false,
+      activeDetailsFormUrl: null,
+      activeDetailsItemTitle: null,
+      isDetailsFrameReady: false,
     };
   }
 
   public componentDidMount(): void {
-    window.addEventListener("resize", this._refreshLiveUpdatePanelLayout);
-    window.addEventListener("scroll", this._refreshLiveUpdatePanelLayout, { capture: true, passive: true });
+    window.addEventListener("resize", this._refreshDetailsPanelLayout);
+    window.addEventListener("scroll", this._refreshDetailsPanelLayout, { capture: true, passive: true });
     this._updateSelectedItems();
-    this._restoreLiveUpdatePanelIfNeeded();
+    this._restoreDetailsPanelIfNeeded();
   }
 
   public componentDidUpdate(prevProps: IDetailsSelectedItemButtonProps): void {
     if (prevProps.context?.selectedKeys !== this.props.context?.selectedKeys || prevProps.items !== this.props.items) {
       this._updateSelectedItems();
       this._syncOpenPanelWithSelection();
-      this._restoreLiveUpdatePanelIfNeeded();
+      this._restoreDetailsPanelIfNeeded();
     }
   }
 
   public componentWillUnmount(): void {
-    window.removeEventListener("resize", this._refreshLiveUpdatePanelLayout);
-    window.removeEventListener("scroll", this._refreshLiveUpdatePanelLayout, true);
+    window.removeEventListener("resize", this._refreshDetailsPanelLayout);
+    window.removeEventListener("scroll", this._refreshDetailsPanelLayout, true);
 
-    if (this._liveUpdateLayoutAnimationFrame !== null) {
-      window.cancelAnimationFrame(this._liveUpdateLayoutAnimationFrame);
-      this._liveUpdateLayoutAnimationFrame = null;
+    if (this._detailsLayoutAnimationFrame !== null) {
+      window.cancelAnimationFrame(this._detailsLayoutAnimationFrame);
+      this._detailsLayoutAnimationFrame = null;
     }
   }
 
@@ -82,9 +78,9 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     const detailsIcon: IIconProps = { iconName: "OpenPane" };
     const isMultiSelectEnabled = this.props.allowMulti === true;
     const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
-    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
-    const shouldRenderButton = this._selectedItems.length > 0 && (isMultiSelectEnabled || !!liveUpdateFormUrl);
-    const isButtonDisabled = isMultiSelectEnabled || !selectedItem || !liveUpdateFormUrl;
+    const detailsFormUrl = selectedItem ? this._buildDetailsFormUrl(selectedItem) : null;
+    const shouldRenderButton = this._selectedItems.length > 0 && (isMultiSelectEnabled || !!detailsFormUrl);
+    const isButtonDisabled = isMultiSelectEnabled || !selectedItem || !detailsFormUrl;
 
     return (
       <>
@@ -93,21 +89,23 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
             text={strings.Layouts.DetailsList.DetailsButtonLabel}
             iconProps={detailsIcon}
             disabled={isButtonDisabled}
-            onClick={(event) => this._openLiveUpdatePanel(event, selectedItem)}
+            onClick={(event) => this._openDetailsPanel(event, selectedItem)}
             theme={(this.props.themeVariant as ITheme) || getTheme()}
           />
         )}
-        {this._renderLiveUpdatePanel()}
+        {this._renderDetailsPanel()}
       </>
     );
   }
 
   private _updateSelectedItems(): void {
     if (this.props.context?.selectedKeys?.length > 0 && this.props.items?.length > 0) {
-      this._selectedItems = this.props.context.selectedKeys
-        .filter((key) => key.startsWith(this.props.context.paging.currentPageNumber.toString()))
-        .map((key) => this.props.items[key.replace(this.props.context.paging.currentPageNumber.toString(), "")])
-        .filter((item) => !!item);
+      const currentPageNumber = this.props.context.paging.currentPageNumber;
+      const selectedKeys = new Set(this.props.context.selectedKeys);
+
+      this._selectedItems = this.props.items.filter((item, index) => {
+        return selectedKeys.has(`${currentPageNumber}${index}`);
+      });
     } else {
       this._selectedItems = [];
     }
@@ -116,71 +114,75 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   }
 
   private _syncOpenPanelWithSelection(): void {
-    if (!this._getResolvedLiveUpdateFormUrl()) {
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
+
+    if (!this._getResolvedDetailsFormUrl()) {
       return;
     }
 
     const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
-    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
+    const detailsFormUrl = selectedItem ? this._buildDetailsFormUrl(selectedItem) : null;
 
-    if (!selectedItem || !liveUpdateFormUrl) {
+    if (!selectedItem || !detailsFormUrl) {
       return;
     }
 
-    if (liveUpdateFormUrl !== this.state.activeLiveUpdateFormUrl) {
-      liveUpdatePanelSessionState.activeLiveUpdateFormUrl = liveUpdateFormUrl;
-      liveUpdatePanelSessionState.activeLiveUpdateItemTitle = this._getLiveUpdateItemTitle(selectedItem);
+    if (detailsFormUrl !== this.state.activeDetailsFormUrl) {
+      detailsPanelSessionState.activeDetailsFormUrl = detailsFormUrl;
+      detailsPanelSessionState.activeDetailsItemTitle = this._getDetailsItemTitle(selectedItem);
 
       this.setState({
-        activeLiveUpdateFormUrl: liveUpdateFormUrl,
-        activeLiveUpdateItemTitle: this._getLiveUpdateItemTitle(selectedItem),
-        isLiveUpdateFrameReady: false,
+        activeDetailsFormUrl: detailsFormUrl,
+        activeDetailsItemTitle: this._getDetailsItemTitle(selectedItem),
+        isDetailsFrameReady: false,
       });
     }
   }
 
-  private _restoreLiveUpdatePanelIfNeeded(): void {
-    if (!liveUpdatePanelSessionState.isOpen || this.state.activeLiveUpdateFormUrl) {
+  private _restoreDetailsPanelIfNeeded(): void {
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
+
+    if (!detailsPanelSessionState.isOpen || this.state.activeDetailsFormUrl) {
       return;
     }
 
     const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
-    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
-    const restoredLiveUpdateFormUrl = liveUpdateFormUrl ?? liveUpdatePanelSessionState.activeLiveUpdateFormUrl;
-    const restoredLiveUpdateItemTitle = selectedItem
-      ? this._getLiveUpdateItemTitle(selectedItem)
-      : liveUpdatePanelSessionState.activeLiveUpdateItemTitle;
+    const detailsFormUrl = selectedItem ? this._buildDetailsFormUrl(selectedItem) : null;
+    const restoredDetailsFormUrl = detailsFormUrl ?? detailsPanelSessionState.activeDetailsFormUrl;
+    const restoredDetailsItemTitle = selectedItem
+      ? this._getDetailsItemTitle(selectedItem)
+      : detailsPanelSessionState.activeDetailsItemTitle;
 
-    if (!restoredLiveUpdateFormUrl) {
+    if (!restoredDetailsFormUrl) {
       return;
     }
 
     this.setState({
-      activeLiveUpdateFormUrl: restoredLiveUpdateFormUrl,
-      activeLiveUpdateItemTitle: restoredLiveUpdateItemTitle,
-      isLiveUpdateFrameReady: false,
+      activeDetailsFormUrl: restoredDetailsFormUrl,
+      activeDetailsItemTitle: restoredDetailsItemTitle,
+      isDetailsFrameReady: false,
     });
   }
 
-  private _renderLiveUpdatePanel(): JSX.Element {
-    const liveUpdatePanelTopOffset = this._getLiveUpdatePanelTopOffset();
-    const activeLiveUpdateFormUrl = this._getResolvedLiveUpdateFormUrl();
-    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+  private _renderDetailsPanel(): JSX.Element {
+    const detailsPanelTopOffset = this._getDetailsPanelTopOffset();
+    const activeDetailsFormUrl = this._getResolvedDetailsFormUrl();
+    const panelSurfaceStyle = this._getDetailsPanelSurfaceStyle();
 
     return (
       <Panel
-        isOpen={!!activeLiveUpdateFormUrl}
+        isOpen={!!activeDetailsFormUrl}
         isBlocking={false}
         type={PanelType.custom}
         customWidth="320px"
-        onDismiss={this._closeLiveUpdatePanel}
-        onRenderNavigation={this._renderLiveUpdatePanelNavigation}
-        onRenderBody={this._renderLiveUpdatePanelBody}
+        onDismiss={this._closeDetailsPanel}
+        onRenderNavigation={this._renderDetailsPanelNavigation}
+        onRenderBody={this._renderDetailsPanelBody}
         styles={{
           main: {
-            top: liveUpdatePanelTopOffset,
-            right: `${LIVE_UPDATE_PANEL_RIGHT_OFFSET}px`,
-            height: `calc(100vh - ${liveUpdatePanelTopOffset}px)`,
+            top: detailsPanelTopOffset,
+            right: `${DETAILS_PANEL_RIGHT_OFFSET}px`,
+            height: `calc(100vh - ${detailsPanelTopOffset}px)`,
             paddingTop: 0,
             backgroundColor: panelSurfaceStyle.backgroundColor,
             color: panelSurfaceStyle.color,
@@ -232,8 +234,8 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     );
   }
 
-  private readonly _renderLiveUpdatePanelNavigation = (): JSX.Element => {
-    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+  private readonly _renderDetailsPanelNavigation = (): JSX.Element => {
+    const panelSurfaceStyle = this._getDetailsPanelSurfaceStyle();
     const panelBackgroundColor = panelSurfaceStyle.backgroundColor as string | undefined;
     const panelTextColor = panelSurfaceStyle.color as string | undefined;
 
@@ -242,17 +244,17 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
         <IconButton
           ariaLabel={strings.Layouts.PersonCard.CloseCardLabel}
           iconProps={{ iconName: "Cancel" }}
-          onClick={this._closeLiveUpdatePanel}
+          onClick={this._closeDetailsPanel}
           styles={{ root: { backgroundColor: panelBackgroundColor, color: panelTextColor } }}
         />
       </div>
     );
   };
 
-  private readonly _renderLiveUpdatePanelBody = (): JSX.Element => {
-    const activeLiveUpdateFormUrl = this._getResolvedLiveUpdateFormUrl();
-    const activeLiveUpdateItemTitle = this._getResolvedLiveUpdateItemTitle();
-    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+  private readonly _renderDetailsPanelBody = (): JSX.Element => {
+    const activeDetailsFormUrl = this._getResolvedDetailsFormUrl();
+    const activeDetailsItemTitle = this._getResolvedDetailsItemTitle();
+    const panelSurfaceStyle = this._getDetailsPanelSurfaceStyle();
 
     return (
       <div
@@ -268,7 +270,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
           width: "100%",
         }}
       >
-        {this.state.isLiveUpdateFrameReady === false && (
+        {this.state.isDetailsFrameReady === false && (
           <div
             style={{
               ...panelSurfaceStyle,
@@ -283,11 +285,11 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
             <Spinner label={strings.Layouts.DetailsList.DetailsPanelHeader} size={SpinnerSize.medium} />
           </div>
         )}
-        {activeLiveUpdateFormUrl && (
+        {activeDetailsFormUrl && (
           <iframe
-            src={activeLiveUpdateFormUrl}
-            title={activeLiveUpdateItemTitle || strings.Layouts.DetailsList.DetailsPanelHeader}
-            onLoad={this._onLiveUpdateFrameLoad}
+            src={activeDetailsFormUrl}
+            title={activeDetailsItemTitle || strings.Layouts.DetailsList.DetailsPanelHeader}
+            onLoad={this._onDetailsFrameLoad}
             style={{
               display: "block",
               flex: "1 1 auto",
@@ -296,7 +298,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
               height: "100%",
               border: 0,
               backgroundColor: panelSurfaceStyle.backgroundColor,
-              opacity: this.state.isLiveUpdateFrameReady === false ? 0 : 1,
+              opacity: this.state.isDetailsFrameReady === false ? 0 : 1,
             }}
           />
         )}
@@ -304,31 +306,50 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     );
   };
 
-  private readonly _refreshLiveUpdatePanelLayout = (): void => {
-    if (!this._getResolvedLiveUpdateFormUrl() || this._liveUpdateLayoutAnimationFrame !== null) {
+  private readonly _refreshDetailsPanelLayout = (): void => {
+    if (!this._getResolvedDetailsFormUrl() || this._detailsLayoutAnimationFrame !== null) {
       return;
     }
 
-    this._liveUpdateLayoutAnimationFrame = window.requestAnimationFrame(() => {
-      this._liveUpdateLayoutAnimationFrame = null;
+    this._detailsLayoutAnimationFrame = window.requestAnimationFrame(() => {
+      this._detailsLayoutAnimationFrame = null;
       this.forceUpdate();
     });
   };
 
-  private _getResolvedLiveUpdateFormUrl(): string | null {
-    return this.state.activeLiveUpdateFormUrl ?? liveUpdatePanelSessionState.activeLiveUpdateFormUrl ?? null;
+  private _getResolvedDetailsFormUrl(): string | null {
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
+    return this.state.activeDetailsFormUrl ?? detailsPanelSessionState.activeDetailsFormUrl ?? null;
   }
 
-  private _getResolvedLiveUpdateItemTitle(): string | null {
-    return this.state.activeLiveUpdateItemTitle ?? liveUpdatePanelSessionState.activeLiveUpdateItemTitle ?? null;
+  private _getResolvedDetailsItemTitle(): string | null {
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
+    return this.state.activeDetailsItemTitle ?? detailsPanelSessionState.activeDetailsItemTitle ?? null;
   }
 
-  private readonly _getLiveUpdatePanelTopOffset = (): number => {
+  private _getDetailsPanelSessionState(): IDetailsPanelSessionState {
+    const instanceId = this.props.context?.instanceId ?? "default";
+    let panelSessionState = detailsPanelSessionStates.get(instanceId);
+
+    if (!panelSessionState) {
+      panelSessionState = {
+        isOpen: false,
+        activeDetailsFormUrl: null,
+        activeDetailsItemTitle: null,
+      };
+
+      detailsPanelSessionStates.set(instanceId, panelSessionState);
+    }
+
+    return panelSessionState;
+  }
+
+  private readonly _getDetailsPanelTopOffset = (): number => {
     if (typeof window === "undefined" || typeof document === "undefined") {
       return 0;
     }
 
-    const maxTopOffset = Math.max(0, window.innerHeight - MIN_LIVE_UPDATE_PANEL_HEIGHT);
+    const maxTopOffset = Math.max(0, window.innerHeight - MIN_DETAILS_PANEL_HEIGHT);
 
     const resolveBottom = (selectors: string[]): number => {
       const bottoms = selectors
@@ -365,44 +386,47 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return Math.min(toolbarBottom, maxTopOffset);
   };
 
-  private readonly _openLiveUpdatePanel = (event: React.MouseEvent<any>, item: any): void => {
+  private readonly _openDetailsPanel = (event: React.MouseEvent<any>, item: any): void => {
     event.preventDefault();
     event.stopPropagation();
 
-    const liveUpdateFormUrl = this._buildLiveUpdateFormUrl(item);
+    const detailsFormUrl = this._buildDetailsFormUrl(item);
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
 
-    if (!liveUpdateFormUrl) {
+    if (!detailsFormUrl) {
       return;
     }
 
-    liveUpdatePanelSessionState.isOpen = true;
-    liveUpdatePanelSessionState.activeLiveUpdateFormUrl = liveUpdateFormUrl;
-    liveUpdatePanelSessionState.activeLiveUpdateItemTitle = this._getLiveUpdateItemTitle(item);
+    detailsPanelSessionState.isOpen = true;
+    detailsPanelSessionState.activeDetailsFormUrl = detailsFormUrl;
+    detailsPanelSessionState.activeDetailsItemTitle = this._getDetailsItemTitle(item);
 
     this.setState({
-      activeLiveUpdateFormUrl: liveUpdateFormUrl,
-      activeLiveUpdateItemTitle: this._getLiveUpdateItemTitle(item),
-      isLiveUpdateFrameReady: false,
+      activeDetailsFormUrl: detailsFormUrl,
+      activeDetailsItemTitle: this._getDetailsItemTitle(item),
+      isDetailsFrameReady: false,
     });
   };
 
-  private readonly _closeLiveUpdatePanel = (): void => {
-    liveUpdatePanelSessionState.isOpen = false;
-    liveUpdatePanelSessionState.activeLiveUpdateFormUrl = null;
-    liveUpdatePanelSessionState.activeLiveUpdateItemTitle = null;
+  private readonly _closeDetailsPanel = (): void => {
+    const detailsPanelSessionState = this._getDetailsPanelSessionState();
+
+    detailsPanelSessionState.isOpen = false;
+    detailsPanelSessionState.activeDetailsFormUrl = null;
+    detailsPanelSessionState.activeDetailsItemTitle = null;
 
     this.setState({
-      activeLiveUpdateFormUrl: null,
-      activeLiveUpdateItemTitle: null,
-      isLiveUpdateFrameReady: false,
+      activeDetailsFormUrl: null,
+      activeDetailsItemTitle: null,
+      isDetailsFrameReady: false,
     });
   };
 
-  private readonly _onLiveUpdateFrameLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
-    this._enhanceLiveUpdateFrame(event.currentTarget, 0);
+  private readonly _onDetailsFrameLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
+    this._enhanceDetailsFrame(event.currentTarget, 0);
   };
 
-  private readonly _enhanceLiveUpdateFrame = (iframe: HTMLIFrameElement, attempt: number): void => {
+  private readonly _enhanceDetailsFrame = (iframe: HTMLIFrameElement, attempt: number): void => {
     const iframeUrl = iframe.getAttribute("src") || "";
 
     try {
@@ -420,7 +444,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
       }
 
       this._prepareEmbeddedFrame(iframeDocument);
-      this._setLiveUpdateFrameReady(true);
+      this._setDetailsFrameReady(true);
     } catch {
       // Ignore cross-origin or transient iframe access failures.
     }
@@ -431,18 +455,18 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
       return false;
     }
 
-    this._hideLiveUpdateEmbeddedCloseButton(iframeDocument);
-    this._hideLiveUpdateAccessSection(iframeDocument);
+    this._hideDetailsEmbeddedCloseButton(iframeDocument);
+    this._hideDetailsAccessSection(iframeDocument);
 
     const detailsPaneFrame = iframeDocument.querySelector('iframe[src*="modernFrame.aspx"][src*="scenario=detailsPane"]') as HTMLIFrameElement;
 
     if (detailsPaneFrame?.src) {
-      const normalizedDetailsPaneUrl = this._normalizeLiveUpdateDetailsPaneUrl(detailsPaneFrame.src);
+      const normalizedDetailsPaneUrl = this._normalizeDetailsPaneUrl(detailsPaneFrame.src);
 
       if (iframe.src !== normalizedDetailsPaneUrl) {
         iframe.src = normalizedDetailsPaneUrl;
       } else {
-        this._hideLiveUpdateNestedFrameSections(detailsPaneFrame);
+        this._hideDetailsNestedFrameSections(detailsPaneFrame);
       }
 
       return true;
@@ -451,9 +475,9 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     this._openViewerDetailsPane(iframe, iframeDocument, iframeUrl);
 
     if (attempt < 40) {
-      window.setTimeout(() => this._enhanceLiveUpdateFrame(iframe, attempt + 1), 150);
+      window.setTimeout(() => this._enhanceDetailsFrame(iframe, attempt + 1), 150);
     } else {
-      this._setLiveUpdateFrameReady(true);
+      this._setDetailsFrameReady(true);
     }
 
     return true;
@@ -464,7 +488,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
       return false;
     }
 
-    const normalizedIframeUrl = this._normalizeLiveUpdateDetailsPaneUrl(iframeUrl);
+    const normalizedIframeUrl = this._normalizeDetailsPaneUrl(iframeUrl);
 
     if (iframe.src !== normalizedIframeUrl) {
       iframe.src = normalizedIframeUrl;
@@ -473,25 +497,25 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
 
     this._prepareDetailsPaneFrame(iframeDocument);
 
-    const hasRenderableFrameContent = this._hasRenderableLiveUpdateFrameContent(iframeDocument);
-    const hasInitialFrameShell = this._hasInitialLiveUpdateFrameShell(iframeDocument);
+    const hasRenderableFrameContent = this._hasRenderableDetailsFrameContent(iframeDocument);
+    const hasInitialFrameShell = this._hasInitialDetailsFrameShell(iframeDocument);
 
-    this._setLiveUpdateFrameReady(hasRenderableFrameContent || hasInitialFrameShell || attempt >= 10);
+    this._setDetailsFrameReady(hasRenderableFrameContent || hasInitialFrameShell || attempt >= 10);
 
     if (attempt < 10) {
-      window.setTimeout(() => this._enhanceLiveUpdateFrame(iframe, attempt + 1), 300);
+      window.setTimeout(() => this._enhanceDetailsFrame(iframe, attempt + 1), 300);
     }
 
     return true;
   }
 
-  private _hideLiveUpdateNestedFrameSections(detailsPaneFrame: HTMLIFrameElement): void {
+  private _hideDetailsNestedFrameSections(detailsPaneFrame: HTMLIFrameElement): void {
     try {
       const detailsPaneDocument = detailsPaneFrame.contentDocument;
 
       if (detailsPaneDocument) {
-        this._hideLiveUpdateEmbeddedCloseButton(detailsPaneDocument);
-        this._hideLiveUpdateAccessSection(detailsPaneDocument);
+        this._hideDetailsEmbeddedCloseButton(detailsPaneDocument);
+        this._hideDetailsAccessSection(detailsPaneDocument);
       }
     } catch {
       // Ignore nested frame access timing issues.
@@ -503,13 +527,13 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     const overflowInfoButton = this._findViewerDetailsTrigger<HTMLElement>(iframeDocument, '[role="menuitem"]');
     const moreButton = this._findViewerMoreButton(iframeDocument);
 
-    if (overflowInfoButton && iframe.dataset.liveUpdateViewerMarker !== `${iframeUrl}:info`) {
-      iframe.dataset.liveUpdateViewerMarker = `${iframeUrl}:info`;
+    if (overflowInfoButton && iframe.dataset.detailsViewerMarker !== `${iframeUrl}:info`) {
+      iframe.dataset.detailsViewerMarker = `${iframeUrl}:info`;
       overflowInfoButton.click();
     }
 
-    if (infoButton && iframe.dataset.liveUpdateViewerMarker !== iframeUrl) {
-      iframe.dataset.liveUpdateViewerMarker = iframeUrl;
+    if (infoButton && iframe.dataset.detailsViewerMarker !== iframeUrl) {
+      iframe.dataset.detailsViewerMarker = iframeUrl;
       infoButton.click();
       return;
     }
@@ -540,17 +564,17 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   }
 
   private _prepareDetailsPaneFrame(iframeDocument: Document): void {
-    this._hideLiveUpdateEmbeddedCloseButton(iframeDocument);
-    this._hideLiveUpdateAccessSection(iframeDocument);
-    this._moveLiveUpdateCommandBarToBottom(iframeDocument);
+    this._hideDetailsEmbeddedCloseButton(iframeDocument);
+    this._hideDetailsAccessSection(iframeDocument);
+    this._moveDetailsCommandBarToBottom(iframeDocument);
     this._resetFrameScroll(iframeDocument);
   }
 
   private _prepareEmbeddedFrame(iframeDocument: Document): void {
-    this._moveLiveUpdateCommandBarToBottom(iframeDocument);
+    this._moveDetailsCommandBarToBottom(iframeDocument);
     this._ensureFrameStyle(
       iframeDocument,
-      "pnp-modern-search-live-update-frame-style",
+      "pnp-modern-search-details-frame-style",
       `
         .sp-skipToContent,
         .ms-accessible,
@@ -603,14 +627,14 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     iframeDocument.body.scrollTop = 0;
   }
 
-  private readonly _setLiveUpdateFrameReady = (isReady: boolean): void => {
-    if (this.state.isLiveUpdateFrameReady !== isReady) {
-      this.setState({ isLiveUpdateFrameReady: isReady });
+  private readonly _setDetailsFrameReady = (isReady: boolean): void => {
+    if (this.state.isDetailsFrameReady !== isReady) {
+      this.setState({ isDetailsFrameReady: isReady });
     }
   };
 
-  private readonly _hideLiveUpdateEmbeddedCloseButton = (iframeDocument: Document): void => {
-    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-details-pane-style", `
+  private readonly _hideDetailsEmbeddedCloseButton = (iframeDocument: Document): void => {
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-details-pane-style", `
       .od-DetailsPane-PrimaryPane-header-close,
       button[aria-label="Close the details pane"] {
         display: none !important;
@@ -618,8 +642,8 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     `);
   };
 
-  private readonly _hideLiveUpdateAccessSection = (iframeDocument: Document): void => {
-    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-access-section-style", `
+  private readonly _hideDetailsAccessSection = (iframeDocument: Document): void => {
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-details-access-section-style", `
         button[aria-label="Has access"],
         button[aria-label="Manage access"] {
           display: none !important;
@@ -643,7 +667,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     });
   };
 
-  private readonly _moveLiveUpdateCommandBarToBottom = (iframeDocument: Document): void => {
+  private readonly _moveDetailsCommandBarToBottom = (iframeDocument: Document): void => {
     const commandBar = Array.from(iframeDocument.querySelectorAll('div[role="menubar"]')).find((element) => {
       const htmlElement = element as HTMLElement;
 
@@ -658,11 +682,11 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
       return;
     }
 
-    commandBar.classList.add("pnp-modern-search-live-update-command-bar");
-    iframeDocument.body?.classList.add("pnp-modern-search-live-update-has-bottom-command-bar");
+    commandBar.classList.add("pnp-modern-search-details-command-bar");
+    iframeDocument.body?.classList.add("pnp-modern-search-has-details-bottom-command-bar");
 
-    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-command-bar-style", `
-      .pnp-modern-search-live-update-command-bar {
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-details-command-bar-style", `
+      .pnp-modern-search-details-command-bar {
         position: fixed !important;
         left: 0 !important;
         right: 0 !important;
@@ -674,13 +698,13 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
         box-sizing: border-box !important;
       }
 
-      body.pnp-modern-search-live-update-has-bottom-command-bar {
+      body.pnp-modern-search-has-details-bottom-command-bar {
         padding-bottom: 72px !important;
       }
     `);
   };
 
-  private _hasRenderableLiveUpdateFrameContent(iframeDocument: Document): boolean {
+  private _hasRenderableDetailsFrameContent(iframeDocument: Document): boolean {
     const detailsRegion = iframeDocument.querySelector('[role="region"][aria-label="Details pane"]');
     const detailsTerms = iframeDocument.querySelectorAll("dt, dd");
     const detailsHeadings = Array.from(iframeDocument.querySelectorAll("h1, h2, h3")).filter((element) => {
@@ -690,7 +714,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return !!detailsRegion || detailsTerms.length > 0 || detailsHeadings.length > 0;
   }
 
-  private _hasInitialLiveUpdateFrameShell(iframeDocument: Document): boolean {
+  private _hasInitialDetailsFrameShell(iframeDocument: Document): boolean {
     const detailsHeadings = Array.from(iframeDocument.querySelectorAll("h1, h2, h3")).filter((element) => {
       return (element.textContent || "").trim().length > 0;
     });
@@ -700,7 +724,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return detailsHeadings.length > 0 && (hasSecondaryPane || hasCommandBar);
   }
 
-  private _getLiveUpdatePanelSurfaceStyle(): React.CSSProperties {
+  private _getDetailsPanelSurfaceStyle(): React.CSSProperties {
     const theme = (this.props.themeVariant as ITheme) || getTheme();
     const backgroundColor = theme.semanticColors?.bodyBackground ?? theme.semanticColors?.bodyStandoutBackground ?? theme.palette?.white;
     const color = theme.semanticColors?.bodyText ?? theme.palette?.neutralPrimary;
@@ -711,10 +735,10 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     };
   }
 
-  private _buildLiveUpdateFormUrl(item: any): string | null {
+  private _buildDetailsFormUrl(item: any): string | null {
     const webUrl = this._resolveExternalItemFieldValue(item, "SPWebUrl") ?? this._resolveExternalItemFieldValue(item, "SPSiteURL") ?? this._resolveExternalItemFieldValue(item, "SitePath");
     const listId = this._resolveExternalItemFieldValue(item, "ListId") ?? this._resolveExternalItemFieldValue(item, "NormListID") ?? this._resolveExternalItemFieldValue(item, "IdentityListId");
-    const listItemId = this._resolveLiveUpdateListItemId(item);
+    const listItemId = this._resolveDetailsListItemId(item);
 
     if (!webUrl) {
       return null;
@@ -727,7 +751,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
         return null;
       }
 
-      if (this._isLiveUpdateDocumentItem(item)) {
+      if (this._isDetailsDocumentItem(item)) {
         return this._buildDocumentViewerUrl(item, baseUrl) ?? this._buildDocumentDetailsPaneUrl(item, baseUrl);
       }
 
@@ -735,14 +759,14 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
         return null;
       }
 
-      if (!this._isLiveUpdateListItem(item, listItemId)) {
+      if (!this._isDetailsListItem(item, listItemId)) {
         return null;
       }
 
       const formUrl = new URL(baseUrl.origin);
       formUrl.pathname = `${baseUrl.pathname.replace(/\/$/, "")}/_layouts/15/listform.aspx`;
       formUrl.searchParams.set("PageType", "4");
-      formUrl.searchParams.set("ListId", this._normalizeLiveUpdateGuid(listId));
+      formUrl.searchParams.set("ListId", this._normalizeDetailsGuid(listId));
       formUrl.searchParams.set("ID", String(listItemId));
       formUrl.searchParams.set("env", "Embedded");
 
@@ -752,7 +776,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     }
   }
 
-  private _resolveLiveUpdateListItemId(item: any): string | number | null {
+  private _resolveDetailsListItemId(item: any): string | number | null {
     const explicitListItemId = this._resolveExternalItemFieldValue(item, "ListItemID") ?? this._resolveExternalItemFieldValue(item, "Id");
 
     if (this._hasRenderableValue(explicitListItemId)) {
@@ -779,7 +803,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
 
   private _buildDocumentDetailsPaneUrl(item: any, baseUrl: URL): string | null {
     const itemPath = this._resolveExternalItemFieldValue(item, "Path") ?? this._resolveExternalItemFieldValue(item, "OriginalPath") ?? this._resolveExternalItemFieldValue(item, "ServerRedirectedURL");
-    const selectedItemId = this._resolveLiveUpdateListItemId(item);
+    const selectedItemId = this._resolveDetailsListItemId(item);
     const normalizedSelectedItemId = /^\d+$/.test(String(selectedItemId ?? "")) ? String(selectedItemId) : null;
 
     if (!itemPath) {
@@ -809,10 +833,10 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
       detailsPaneUrl.searchParams.set("parent", parentPath);
       detailsPaneUrl.searchParams.set("listUrl", listUrl);
       detailsPaneUrl.searchParams.set("scenario", "detailsPane");
-      detailsPaneUrl.searchParams.set("channelId", this._getLiveUpdateChannelId());
+      detailsPaneUrl.searchParams.set("channelId", this._getDetailsChannelId());
       detailsPaneUrl.searchParams.set("app", "OneUp");
       detailsPaneUrl.searchParams.set("component", "detailsPane");
-      detailsPaneUrl.searchParams.set("isDarkMode", String(this._getLiveUpdateIsDarkMode()));
+      detailsPaneUrl.searchParams.set("isDarkMode", String(this._getDetailsIsDarkMode()));
       detailsPaneUrl.searchParams.set("options", JSON.stringify({
         itemIds: [`id=${encodeURIComponent(itemServerRelativePath)}`],
         isOD3UIEnabled: true,
@@ -848,7 +872,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     try {
       const viewerUrl = new URL(baseUrl.origin);
       viewerUrl.pathname = `${baseUrl.pathname.replace(/\/$/, "")}/_layouts/15/viewer.aspx`;
-      viewerUrl.searchParams.set("sourcedoc", `{${this._normalizeLiveUpdateGuid(String(documentUniqueId))}}`);
+      viewerUrl.searchParams.set("sourcedoc", `{${this._normalizeDetailsGuid(String(documentUniqueId))}}`);
 
       return viewerUrl.toString();
     } catch {
@@ -856,7 +880,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     }
   }
 
-  private _getLiveUpdateChannelId(): string {
+  private _getDetailsChannelId(): string {
     if (window.crypto?.randomUUID) {
       return window.crypto.randomUUID();
     }
@@ -864,7 +888,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return `pnp-modern-search-${Date.now()}`;
   }
 
-  private _getLiveUpdateIsDarkMode(): boolean {
+  private _getDetailsIsDarkMode(): boolean {
     const theme = (this.props.themeVariant as ITheme) || getTheme();
 
     if (theme.isInverted) {
@@ -911,13 +935,13 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return ((0.299 * red) + (0.587 * green) + (0.114 * blue)) / 255;
   }
 
-  private _normalizeLiveUpdateDetailsPaneUrl(rawUrl: string): string {
+  private _normalizeDetailsPaneUrl(rawUrl: string): string {
     const detailsPaneUrl = new URL(rawUrl, window.location.origin);
-    detailsPaneUrl.searchParams.set("isDarkMode", String(this._getLiveUpdateIsDarkMode()));
+    detailsPaneUrl.searchParams.set("isDarkMode", String(this._getDetailsIsDarkMode()));
     return detailsPaneUrl.toString();
   }
 
-  private _isLiveUpdateListItem(item: any, listItemId: any): boolean {
+  private _isDetailsListItem(item: any, listItemId: any): boolean {
     const contentClass = String(ObjectHelper.byPath(item, BuiltinTemplateSlots.ContentClass) ?? "").toLowerCase();
     const itemPath = this._resolveExternalItemFieldValue(item, "Path") ?? this._resolveExternalItemFieldValue(item, "OriginalPath") ?? this._resolveExternalItemFieldValue(item, "AutoPreviewUrl");
     const normalizedItemPath = typeof itemPath === "string" ? itemPath.toLowerCase() : "";
@@ -936,7 +960,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return /^\d+$/.test(String(listItemId ?? ""));
   }
 
-  private _isLiveUpdateDocumentItem(item: any): boolean {
+  private _isDetailsDocumentItem(item: any): boolean {
     const isContainer = this.props.isContainerField ? ObjectHelper.byPath(item, this.props.isContainerField) : this._resolveExternalItemFieldValue(item, "IsContainer");
 
     if (isContainer === true || String(isContainer).toLowerCase() === "true") {
@@ -972,11 +996,11 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     return typeof fileName === "string" && /\.[^./\\]+$/.test(fileName);
   }
 
-  private _getLiveUpdateItemTitle(item: any): string {
+  private _getDetailsItemTitle(item: any): string {
     return this._resolveExternalItemFieldValue(item, "Title") ?? this._resolveExternalItemFieldValue(item, "Filename") ?? strings.Layouts.DetailsList.DetailsPanelHeader;
   }
 
-  private _normalizeLiveUpdateGuid(value: string): string {
+  private _normalizeDetailsGuid(value: string): string {
     return String(value).replace(/[{}]/g, "");
   }
 

--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -1,0 +1,969 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { BaseWebComponent, BuiltinTemplateSlots } from "@pnp/modern-search-extensibility";
+import { ActionButton, IIconProps, ITheme, getTheme, Panel, PanelType, IconButton, Spinner, SpinnerSize } from "@fluentui/react";
+import { IReadonlyTheme } from "@microsoft/sp-component-base";
+import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext";
+import { ObjectHelper } from "../helpers/ObjectHelper";
+import strings from "CommonStrings";
+
+const MIN_LIVE_UPDATE_PANEL_HEIGHT = 520;
+const LIVE_UPDATE_PANEL_RIGHT_OFFSET = 32;
+const HEX_COLOR_REGEXP = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+const RGB_COLOR_REGEXP = /^rgba?\((\d+),\s*(\d+),\s*(\d+)/i;
+
+interface IDetailsSelectedItemButtonProps {
+  context?: ISearchResultsTemplateContext;
+  items?: { [key: string]: any }[];
+  themeVariant?: IReadonlyTheme;
+  fileExtensionField?: string;
+  isContainerField?: string;
+  allowMulti?: boolean;
+}
+
+interface IDetailsSelectedItemButtonState {
+  activeLiveUpdateFormUrl?: string;
+  activeLiveUpdateItemTitle?: string;
+  isLiveUpdateFrameReady?: boolean;
+}
+
+interface ILiveUpdatePanelSessionState {
+  isOpen: boolean;
+  activeLiveUpdateFormUrl?: string;
+  activeLiveUpdateItemTitle?: string;
+}
+
+const liveUpdatePanelSessionState: ILiveUpdatePanelSessionState = {
+  isOpen: false,
+  activeLiveUpdateFormUrl: null,
+  activeLiveUpdateItemTitle: null,
+};
+
+export class DetailsSelectedItemButtonComponent extends React.Component<IDetailsSelectedItemButtonProps, IDetailsSelectedItemButtonState> {
+  private _selectedItems: any[] = [];
+
+  constructor(props: IDetailsSelectedItemButtonProps) {
+    super(props);
+
+    this.state = {
+      activeLiveUpdateFormUrl: null,
+      activeLiveUpdateItemTitle: null,
+      isLiveUpdateFrameReady: false,
+    };
+  }
+
+  public componentDidMount(): void {
+    window.addEventListener("resize", this._refreshLiveUpdatePanelLayout);
+    window.addEventListener("scroll", this._refreshLiveUpdatePanelLayout, true);
+    this._updateSelectedItems();
+    this._restoreLiveUpdatePanelIfNeeded();
+  }
+
+  public componentDidUpdate(prevProps: IDetailsSelectedItemButtonProps): void {
+    if (prevProps.context?.selectedKeys !== this.props.context?.selectedKeys || prevProps.items !== this.props.items) {
+      this._updateSelectedItems();
+      this._syncOpenPanelWithSelection();
+      this._restoreLiveUpdatePanelIfNeeded();
+    }
+  }
+
+  public componentWillUnmount(): void {
+    window.removeEventListener("resize", this._refreshLiveUpdatePanelLayout);
+    window.removeEventListener("scroll", this._refreshLiveUpdatePanelLayout, true);
+  }
+
+  public render(): JSX.Element {
+    const detailsIcon: IIconProps = { iconName: "OpenPane" };
+    const isMultiSelectEnabled = this.props.allowMulti === true;
+    const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
+    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
+    const shouldRenderButton = this._selectedItems.length > 0 && (isMultiSelectEnabled || !!liveUpdateFormUrl);
+    const isButtonDisabled = isMultiSelectEnabled || !selectedItem || !liveUpdateFormUrl;
+
+    return (
+      <>
+        {shouldRenderButton && (
+          <ActionButton
+            text={strings.Layouts.DetailsList.DetailsButtonLabel}
+            iconProps={detailsIcon}
+            disabled={isButtonDisabled}
+            onClick={(event) => this._openLiveUpdatePanel(event, selectedItem)}
+            theme={(this.props.themeVariant as ITheme) || getTheme()}
+          />
+        )}
+        {this._renderLiveUpdatePanel()}
+      </>
+    );
+  }
+
+  private _updateSelectedItems(): void {
+    if (this.props.context?.selectedKeys?.length > 0 && this.props.items?.length > 0) {
+      this._selectedItems = this.props.context.selectedKeys
+        .filter((key) => key.startsWith(this.props.context.paging.currentPageNumber.toString()))
+        .map((key) => this.props.items[key.replace(this.props.context.paging.currentPageNumber.toString(), "")])
+        .filter((item) => !!item);
+    } else {
+      this._selectedItems = [];
+    }
+
+    this.forceUpdate();
+  }
+
+  private _syncOpenPanelWithSelection(): void {
+    if (!this._getResolvedLiveUpdateFormUrl()) {
+      return;
+    }
+
+    const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
+    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
+
+    if (!selectedItem || !liveUpdateFormUrl) {
+      return;
+    }
+
+    if (liveUpdateFormUrl !== this.state.activeLiveUpdateFormUrl) {
+      liveUpdatePanelSessionState.activeLiveUpdateFormUrl = liveUpdateFormUrl;
+      liveUpdatePanelSessionState.activeLiveUpdateItemTitle = this._getLiveUpdateItemTitle(selectedItem);
+
+      this.setState({
+        activeLiveUpdateFormUrl: liveUpdateFormUrl,
+        activeLiveUpdateItemTitle: this._getLiveUpdateItemTitle(selectedItem),
+        isLiveUpdateFrameReady: false,
+      });
+    }
+  }
+
+  private _restoreLiveUpdatePanelIfNeeded(): void {
+    if (!liveUpdatePanelSessionState.isOpen || this.state.activeLiveUpdateFormUrl) {
+      return;
+    }
+
+    const selectedItem = this._selectedItems.length === 1 ? this._selectedItems[0] : null;
+    const liveUpdateFormUrl = selectedItem ? this._buildLiveUpdateFormUrl(selectedItem) : null;
+    const restoredLiveUpdateFormUrl = liveUpdateFormUrl ?? liveUpdatePanelSessionState.activeLiveUpdateFormUrl;
+    const restoredLiveUpdateItemTitle = selectedItem
+      ? this._getLiveUpdateItemTitle(selectedItem)
+      : liveUpdatePanelSessionState.activeLiveUpdateItemTitle;
+
+    if (!restoredLiveUpdateFormUrl) {
+      return;
+    }
+
+    this.setState({
+      activeLiveUpdateFormUrl: restoredLiveUpdateFormUrl,
+      activeLiveUpdateItemTitle: restoredLiveUpdateItemTitle,
+      isLiveUpdateFrameReady: false,
+    });
+  }
+
+  private _renderLiveUpdatePanel(): JSX.Element {
+    const liveUpdatePanelTopOffset = this._getLiveUpdatePanelTopOffset();
+    const activeLiveUpdateFormUrl = this._getResolvedLiveUpdateFormUrl();
+    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+
+    return (
+      <Panel
+        isOpen={!!activeLiveUpdateFormUrl}
+        isBlocking={false}
+        type={PanelType.custom}
+        customWidth="320px"
+        onDismiss={this._closeLiveUpdatePanel}
+        onRenderNavigation={this._renderLiveUpdatePanelNavigation}
+        onRenderBody={this._renderLiveUpdatePanelBody}
+        styles={{
+          main: {
+            top: liveUpdatePanelTopOffset,
+            right: `${LIVE_UPDATE_PANEL_RIGHT_OFFSET}px`,
+            height: `calc(100vh - ${liveUpdatePanelTopOffset}px)`,
+            paddingTop: 0,
+            backgroundColor: panelSurfaceStyle.backgroundColor,
+            color: panelSurfaceStyle.color,
+          },
+          content: {
+            display: "flex",
+            flexDirection: "column",
+            backgroundColor: panelSurfaceStyle.backgroundColor,
+            color: panelSurfaceStyle.color,
+            paddingBottom: 0,
+            paddingLeft: 0,
+            paddingRight: 0,
+            paddingTop: 0,
+            height: "100%",
+            width: "100%",
+          },
+          contentInner: {
+            display: "flex",
+            flex: "1 1 auto",
+            flexDirection: "column",
+            backgroundColor: panelSurfaceStyle.backgroundColor,
+            color: panelSurfaceStyle.color,
+            height: "100%",
+            minHeight: 0,
+            paddingBottom: 0,
+            paddingLeft: 0,
+            paddingRight: 0,
+            paddingTop: 0,
+          },
+          scrollableContent: {
+            display: "flex",
+            flex: "1 1 auto",
+            flexDirection: "column",
+            backgroundColor: panelSurfaceStyle.backgroundColor,
+            color: panelSurfaceStyle.color,
+            height: "100%",
+            minHeight: 0,
+            paddingTop: 0,
+            paddingLeft: 0,
+            paddingRight: 0,
+          },
+          commands: {
+            backgroundColor: panelSurfaceStyle.backgroundColor,
+            color: panelSurfaceStyle.color,
+            paddingTop: 0,
+          },
+        }}
+      />
+    );
+  }
+
+  private readonly _renderLiveUpdatePanelNavigation = (): JSX.Element => {
+    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+    const panelBackgroundColor = panelSurfaceStyle.backgroundColor as string | undefined;
+    const panelTextColor = panelSurfaceStyle.color as string | undefined;
+
+    return (
+      <div style={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
+        <IconButton
+          ariaLabel={strings.Layouts.PersonCard.CloseCardLabel}
+          iconProps={{ iconName: "Cancel" }}
+          onClick={this._closeLiveUpdatePanel}
+          styles={{ root: { backgroundColor: panelBackgroundColor, color: panelTextColor } }}
+        />
+      </div>
+    );
+  };
+
+  private readonly _renderLiveUpdatePanelBody = (): JSX.Element => {
+    const activeLiveUpdateFormUrl = this._getResolvedLiveUpdateFormUrl();
+    const activeLiveUpdateItemTitle = this._getResolvedLiveUpdateItemTitle();
+    const panelSurfaceStyle = this._getLiveUpdatePanelSurfaceStyle();
+
+    return (
+      <div
+        style={{
+          ...panelSurfaceStyle,
+          display: "flex",
+          flex: "1 1 auto",
+          flexDirection: "column",
+          height: "100%",
+          minHeight: 0,
+          padding: 0,
+          position: "relative",
+          width: "100%",
+        }}
+      >
+        {this.state.isLiveUpdateFrameReady === false && (
+          <div
+            style={{
+              ...panelSurfaceStyle,
+              alignItems: "center",
+              display: "flex",
+              inset: 0,
+              justifyContent: "center",
+              position: "absolute",
+              zIndex: 1,
+            }}
+          >
+            <Spinner label={strings.Layouts.DetailsList.DetailsPanelHeader} size={SpinnerSize.medium} />
+          </div>
+        )}
+        {activeLiveUpdateFormUrl && (
+          <iframe
+            src={activeLiveUpdateFormUrl}
+            title={activeLiveUpdateItemTitle || strings.Layouts.DetailsList.DetailsPanelHeader}
+            onLoad={this._onLiveUpdateFrameLoad}
+            style={{
+              display: "block",
+              flex: "1 1 auto",
+              minHeight: 0,
+              width: "100%",
+              height: "100%",
+              border: 0,
+              backgroundColor: panelSurfaceStyle.backgroundColor,
+              opacity: this.state.isLiveUpdateFrameReady === false ? 0 : 1,
+            }}
+          />
+        )}
+      </div>
+    );
+  };
+
+  private readonly _refreshLiveUpdatePanelLayout = (): void => {
+    if (this._getResolvedLiveUpdateFormUrl()) {
+      this.forceUpdate();
+    }
+  };
+
+  private _getResolvedLiveUpdateFormUrl(): string | null {
+    return this.state.activeLiveUpdateFormUrl ?? liveUpdatePanelSessionState.activeLiveUpdateFormUrl ?? null;
+  }
+
+  private _getResolvedLiveUpdateItemTitle(): string | null {
+    return this.state.activeLiveUpdateItemTitle ?? liveUpdatePanelSessionState.activeLiveUpdateItemTitle ?? null;
+  }
+
+  private readonly _getLiveUpdatePanelTopOffset = (): number => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return 0;
+    }
+
+    const maxTopOffset = Math.max(0, window.innerHeight - MIN_LIVE_UPDATE_PANEL_HEIGHT);
+
+    const resolveBottom = (selectors: string[]): number => {
+      const bottoms = selectors
+        .flatMap((selector) => Array.from(document.querySelectorAll(selector)))
+        .map((element) => {
+          const rect = element.getBoundingClientRect();
+          const style = window.getComputedStyle(element);
+
+          if (rect.height <= 0 || rect.bottom <= 0 || style.display === "none" || style.visibility === "hidden") {
+            return 0;
+          }
+
+          return Math.round(rect.bottom);
+        });
+
+      return bottoms.length > 0 ? Math.max(...bottoms) : 0;
+    };
+
+    const titleSectionBottom = resolveBottom([
+      '[data-automation-id="pageTitleInput"]',
+      '[data-automation-id="TitleTextId"]',
+      '[data-automation-id="webPartTitleReadMode"]',
+    ]);
+
+    if (titleSectionBottom > 0) {
+      return Math.min(titleSectionBottom, maxTopOffset);
+    }
+
+    const toolbarBottom = resolveBottom([
+      '#spCommandBar',
+      '[data-automation-id="pageCommandBar"]',
+    ]);
+
+    return Math.min(toolbarBottom, maxTopOffset);
+  };
+
+  private readonly _openLiveUpdatePanel = (event: React.MouseEvent<any>, item: any): void => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const liveUpdateFormUrl = this._buildLiveUpdateFormUrl(item);
+
+    if (!liveUpdateFormUrl) {
+      return;
+    }
+
+    liveUpdatePanelSessionState.isOpen = true;
+    liveUpdatePanelSessionState.activeLiveUpdateFormUrl = liveUpdateFormUrl;
+    liveUpdatePanelSessionState.activeLiveUpdateItemTitle = this._getLiveUpdateItemTitle(item);
+
+    this.setState({
+      activeLiveUpdateFormUrl: liveUpdateFormUrl,
+      activeLiveUpdateItemTitle: this._getLiveUpdateItemTitle(item),
+      isLiveUpdateFrameReady: false,
+    });
+  };
+
+  private readonly _closeLiveUpdatePanel = (): void => {
+    liveUpdatePanelSessionState.isOpen = false;
+    liveUpdatePanelSessionState.activeLiveUpdateFormUrl = null;
+    liveUpdatePanelSessionState.activeLiveUpdateItemTitle = null;
+
+    this.setState({
+      activeLiveUpdateFormUrl: null,
+      activeLiveUpdateItemTitle: null,
+      isLiveUpdateFrameReady: false,
+    });
+  };
+
+  private readonly _onLiveUpdateFrameLoad = (event: React.SyntheticEvent<HTMLIFrameElement>): void => {
+    this._enhanceLiveUpdateFrame(event.currentTarget, 0);
+  };
+
+  private readonly _enhanceLiveUpdateFrame = (iframe: HTMLIFrameElement, attempt: number): void => {
+    const iframeUrl = iframe.getAttribute("src") || "";
+
+    try {
+      const iframeDocument = iframe.contentDocument;
+      if (!iframeDocument) {
+        return;
+      }
+
+      if (this._handleViewerFrame(iframe, iframeDocument, iframeUrl, attempt)) {
+        return;
+      }
+
+      if (this._handleDetailsPaneFrame(iframe, iframeDocument, iframeUrl, attempt)) {
+        return;
+      }
+
+      this._prepareEmbeddedFrame(iframeDocument);
+      this._setLiveUpdateFrameReady(true);
+    } catch {
+      // Ignore cross-origin or transient iframe access failures.
+    }
+  };
+
+  private _handleViewerFrame(iframe: HTMLIFrameElement, iframeDocument: Document, iframeUrl: string, attempt: number): boolean {
+    if (!iframeUrl.includes("/_layouts/15/viewer.aspx")) {
+      return false;
+    }
+
+    this._hideLiveUpdateEmbeddedCloseButton(iframeDocument);
+    this._hideLiveUpdateAccessSection(iframeDocument);
+
+    const detailsPaneFrame = iframeDocument.querySelector('iframe[src*="modernFrame.aspx"][src*="scenario=detailsPane"]') as HTMLIFrameElement;
+
+    if (detailsPaneFrame?.src) {
+      const normalizedDetailsPaneUrl = this._normalizeLiveUpdateDetailsPaneUrl(detailsPaneFrame.src);
+
+      if (iframe.src !== normalizedDetailsPaneUrl) {
+        iframe.src = normalizedDetailsPaneUrl;
+      } else {
+        this._hideLiveUpdateNestedFrameSections(detailsPaneFrame);
+      }
+
+      return true;
+    }
+
+    this._openViewerDetailsPane(iframe, iframeDocument, iframeUrl);
+
+    if (attempt < 40) {
+      window.setTimeout(() => this._enhanceLiveUpdateFrame(iframe, attempt + 1), 150);
+    } else {
+      this._setLiveUpdateFrameReady(true);
+    }
+
+    return true;
+  }
+
+  private _handleDetailsPaneFrame(iframe: HTMLIFrameElement, iframeDocument: Document, iframeUrl: string, attempt: number): boolean {
+    if (!iframeUrl.includes("modernFrame.aspx") || !iframeUrl.includes("scenario=detailsPane")) {
+      return false;
+    }
+
+    const normalizedIframeUrl = this._normalizeLiveUpdateDetailsPaneUrl(iframeUrl);
+
+    if (iframe.src !== normalizedIframeUrl) {
+      iframe.src = normalizedIframeUrl;
+      return true;
+    }
+
+    this._prepareDetailsPaneFrame(iframeDocument);
+
+    const hasRenderableFrameContent = this._hasRenderableLiveUpdateFrameContent(iframeDocument);
+    const hasInitialFrameShell = this._hasInitialLiveUpdateFrameShell(iframeDocument);
+
+    this._setLiveUpdateFrameReady(hasRenderableFrameContent || hasInitialFrameShell || attempt >= 10);
+
+    if (attempt < 10) {
+      window.setTimeout(() => this._enhanceLiveUpdateFrame(iframe, attempt + 1), 300);
+    }
+
+    return true;
+  }
+
+  private _hideLiveUpdateNestedFrameSections(detailsPaneFrame: HTMLIFrameElement): void {
+    try {
+      const detailsPaneDocument = detailsPaneFrame.contentDocument;
+
+      if (detailsPaneDocument) {
+        this._hideLiveUpdateEmbeddedCloseButton(detailsPaneDocument);
+        this._hideLiveUpdateAccessSection(detailsPaneDocument);
+      }
+    } catch {
+      // Ignore nested frame access timing issues.
+    }
+  }
+
+  private _openViewerDetailsPane(iframe: HTMLIFrameElement, iframeDocument: Document, iframeUrl: string): void {
+    const infoButton = Array.from(iframeDocument.querySelectorAll("button")).find((button) => button.getAttribute("aria-label") === "Info, View file details") as HTMLButtonElement;
+    const overflowInfoButton = Array.from(iframeDocument.querySelectorAll('[role="menuitem"]')).find((item) => item.getAttribute("aria-label") === "Info, View file details") as HTMLElement;
+    const moreButton = Array.from(iframeDocument.querySelectorAll("button")).find((button) => button.getAttribute("aria-label") === "More") as HTMLButtonElement;
+
+    if (overflowInfoButton && iframe.dataset.liveUpdateViewerMarker !== `${iframeUrl}:info`) {
+      iframe.dataset.liveUpdateViewerMarker = `${iframeUrl}:info`;
+      overflowInfoButton.click();
+    }
+
+    if (infoButton && iframe.dataset.liveUpdateViewerMarker !== iframeUrl) {
+      iframe.dataset.liveUpdateViewerMarker = iframeUrl;
+      infoButton.click();
+      return;
+    }
+
+    if (!infoButton && moreButton && moreButton.getAttribute("aria-expanded") !== "true") {
+      moreButton.click();
+    }
+  }
+
+  private _prepareDetailsPaneFrame(iframeDocument: Document): void {
+    this._hideLiveUpdateEmbeddedCloseButton(iframeDocument);
+    this._hideLiveUpdateAccessSection(iframeDocument);
+    this._moveLiveUpdateCommandBarToBottom(iframeDocument);
+    this._resetFrameScroll(iframeDocument);
+  }
+
+  private _prepareEmbeddedFrame(iframeDocument: Document): void {
+    this._moveLiveUpdateCommandBarToBottom(iframeDocument);
+    this._ensureFrameStyle(
+      iframeDocument,
+      "pnp-modern-search-live-update-frame-style",
+      `
+        .sp-skipToContent,
+        .ms-accessible,
+        .od-TopBar,
+        .od-Files-topBar,
+        .od-ListForm-breadcrumb,
+        .BreadcrumbBar {
+          display: none !important;
+        }
+
+        html,
+        body,
+        .sp-App-body,
+        .sp-App-bodyMain,
+        .Files-main,
+        .Files-mainColumn,
+        .Files-content,
+        .Files-contentAreaFlexContainer,
+        .Files-rightPaneInteractionContainer,
+        .Files-rightPanePushedContainer,
+        .Files-rightPane,
+        .Files-rightPaneContent,
+        .od-ListItemFormRoot,
+        .od-ListForm-root,
+        .list-form-container-root,
+        .list-form-wrapper {
+          margin-top: 0 !important;
+          padding-top: 0 !important;
+        }
+      `
+    );
+    this._resetFrameScroll(iframeDocument);
+  }
+
+  private _ensureFrameStyle(iframeDocument: Document, styleId: string, cssText: string): void {
+    let styleElement = iframeDocument.getElementById(styleId) as HTMLStyleElement;
+
+    if (styleElement) {
+      return;
+    }
+
+    styleElement = iframeDocument.createElement("style");
+    styleElement.id = styleId;
+    styleElement.textContent = cssText;
+    iframeDocument.head.appendChild(styleElement);
+  }
+
+  private _resetFrameScroll(iframeDocument: Document): void {
+    iframeDocument.documentElement.scrollTop = 0;
+    iframeDocument.body.scrollTop = 0;
+  }
+
+  private readonly _setLiveUpdateFrameReady = (isReady: boolean): void => {
+    if (this.state.isLiveUpdateFrameReady !== isReady) {
+      this.setState({ isLiveUpdateFrameReady: isReady });
+    }
+  };
+
+  private readonly _hideLiveUpdateEmbeddedCloseButton = (iframeDocument: Document): void => {
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-details-pane-style", `
+      .od-DetailsPane-PrimaryPane-header-close,
+      button[aria-label="Close the details pane"] {
+        display: none !important;
+      }
+    `);
+  };
+
+  private readonly _hideLiveUpdateAccessSection = (iframeDocument: Document): void => {
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-access-section-style", `
+        button[aria-label="Has access"],
+        button[aria-label="Manage access"] {
+          display: none !important;
+        }
+      `);
+
+    const accessTriggers = Array.from(iframeDocument.querySelectorAll("button, [role='button'], [role='heading']"))
+      .filter((element) => {
+        const label = (element.getAttribute("aria-label") || element.textContent || "").trim().toLowerCase();
+        return label === "has access" || label === "manage access";
+      });
+
+    accessTriggers.forEach((element) => {
+      const section = (element.closest("section") || element.closest("[role='group']") || element.closest("div")) as HTMLElement;
+
+      if (section) {
+        section.style.display = "none";
+      } else if (element instanceof HTMLElement) {
+        element.style.display = "none";
+      }
+    });
+  };
+
+  private readonly _moveLiveUpdateCommandBarToBottom = (iframeDocument: Document): void => {
+    const commandBar = Array.from(iframeDocument.querySelectorAll('div[role="menubar"]')).find((element) => {
+      const htmlElement = element as HTMLElement;
+
+      return !!(
+        htmlElement.querySelector('button[aria-label="Edit all"]') ||
+        htmlElement.querySelector('button[aria-label="Show comments"]') ||
+        htmlElement.querySelector('.od-Command--Comment')
+      );
+    }) as HTMLElement;
+
+    if (!commandBar) {
+      return;
+    }
+
+    commandBar.classList.add("pnp-modern-search-live-update-command-bar");
+    iframeDocument.body?.classList.add("pnp-modern-search-live-update-has-bottom-command-bar");
+
+    this._ensureFrameStyle(iframeDocument, "pnp-modern-search-live-update-command-bar-style", `
+      .pnp-modern-search-live-update-command-bar {
+        position: fixed !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        z-index: 1000 !important;
+        background: inherit !important;
+        border-top: 1px solid rgba(0, 0, 0, 0.08) !important;
+        padding: 8px 12px !important;
+        box-sizing: border-box !important;
+      }
+
+      body.pnp-modern-search-live-update-has-bottom-command-bar {
+        padding-bottom: 72px !important;
+      }
+    `);
+  };
+
+  private _hasRenderableLiveUpdateFrameContent(iframeDocument: Document): boolean {
+    const detailsRegion = iframeDocument.querySelector('[role="region"][aria-label="Details pane"]');
+    const detailsTerms = iframeDocument.querySelectorAll("dt, dd");
+    const detailsHeadings = Array.from(iframeDocument.querySelectorAll("h1, h2, h3")).filter((element) => {
+      return (element.textContent || "").trim().length > 0;
+    });
+
+    return !!detailsRegion || detailsTerms.length > 0 || detailsHeadings.length > 0;
+  }
+
+  private _hasInitialLiveUpdateFrameShell(iframeDocument: Document): boolean {
+    const detailsHeadings = Array.from(iframeDocument.querySelectorAll("h1, h2, h3")).filter((element) => {
+      return (element.textContent || "").trim().length > 0;
+    });
+    const hasSecondaryPane = !!iframeDocument.querySelector(".od-DetailsPane-SecondaryPane-wrapper, .od-DetailsPane-ScrollableSection, .od-DetailsPane-SecondaryPane");
+    const hasCommandBar = !!iframeDocument.querySelector('div[role="menubar"]');
+
+    return detailsHeadings.length > 0 && (hasSecondaryPane || hasCommandBar);
+  }
+
+  private _getLiveUpdatePanelSurfaceStyle(): React.CSSProperties {
+    const theme = (this.props.themeVariant as ITheme) || getTheme();
+    const backgroundColor = theme.semanticColors?.bodyBackground ?? theme.semanticColors?.bodyStandoutBackground ?? theme.palette?.white;
+    const color = theme.semanticColors?.bodyText ?? theme.palette?.neutralPrimary;
+
+    return {
+      backgroundColor,
+      color,
+    };
+  }
+
+  private _buildLiveUpdateFormUrl(item: any): string | null {
+    const webUrl = this._resolveExternalItemFieldValue(item, "SPWebUrl") ?? this._resolveExternalItemFieldValue(item, "SPSiteURL") ?? this._resolveExternalItemFieldValue(item, "SitePath");
+    const listId = this._resolveExternalItemFieldValue(item, "ListId") ?? this._resolveExternalItemFieldValue(item, "NormListID") ?? this._resolveExternalItemFieldValue(item, "IdentityListId");
+    const listItemId = this._resolveLiveUpdateListItemId(item);
+
+    if (!webUrl) {
+      return null;
+    }
+
+    try {
+      const baseUrl = new URL(webUrl, window.location.origin);
+
+      if (this._isLiveUpdateDocumentItem(item)) {
+        return this._buildDocumentViewerUrl(item, baseUrl) ?? this._buildDocumentDetailsPaneUrl(item, baseUrl);
+      }
+
+      if (!listId || !listItemId) {
+        return null;
+      }
+
+      if (!this._isLiveUpdateListItem(item, listItemId)) {
+        return null;
+      }
+
+      const formUrl = new URL(baseUrl.origin);
+      formUrl.pathname = `${baseUrl.pathname.replace(/\/$/, "")}/_layouts/15/listform.aspx`;
+      formUrl.searchParams.set("PageType", "4");
+      formUrl.searchParams.set("ListId", this._normalizeLiveUpdateGuid(listId));
+      formUrl.searchParams.set("ID", String(listItemId));
+      formUrl.searchParams.set("env", "Embedded");
+
+      return formUrl.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private _resolveLiveUpdateListItemId(item: any): string | number | null {
+    const explicitListItemId = this._resolveExternalItemFieldValue(item, "ListItemID") ?? this._resolveExternalItemFieldValue(item, "Id");
+
+    if (this._hasRenderableValue(explicitListItemId)) {
+      return explicitListItemId;
+    }
+
+    const itemPath = this._resolveExternalItemFieldValue(item, "Path") ?? this._resolveExternalItemFieldValue(item, "OriginalPath") ?? this._resolveExternalItemFieldValue(item, "AutoPreviewUrl");
+
+    if (typeof itemPath === "string") {
+      try {
+        const itemUrl = new URL(itemPath, window.location.origin);
+        const queryListItemId = itemUrl.searchParams.get("ID");
+
+        if (this._hasRenderableValue(queryListItemId)) {
+          return queryListItemId;
+        }
+      } catch {
+        // Ignore malformed item URLs and fall back to null.
+      }
+    }
+
+    return null;
+  }
+
+  private _buildDocumentDetailsPaneUrl(item: any, baseUrl: URL): string | null {
+    const itemPath = this._resolveExternalItemFieldValue(item, "Path") ?? this._resolveExternalItemFieldValue(item, "OriginalPath") ?? this._resolveExternalItemFieldValue(item, "ServerRedirectedURL");
+    const selectedItemId = this._resolveLiveUpdateListItemId(item);
+    const normalizedSelectedItemId = /^\d+$/.test(String(selectedItemId ?? "")) ? String(selectedItemId) : null;
+
+    if (!itemPath) {
+      return null;
+    }
+
+    try {
+      const itemUrl = new URL(itemPath, window.location.origin);
+      const webServerRelativePath = baseUrl.pathname.replace(/\/$/, "");
+      const itemServerRelativePath = itemUrl.pathname;
+
+      if (!itemServerRelativePath.startsWith(`${webServerRelativePath}/`)) {
+        return null;
+      }
+
+      const relativeSegments = itemServerRelativePath.slice(webServerRelativePath.length).split("/").filter(Boolean);
+
+      if (relativeSegments.length < 2) {
+        return null;
+      }
+
+      const listUrl = `${webServerRelativePath}/${relativeSegments[0]}`;
+      const parentPath = itemServerRelativePath.slice(0, itemServerRelativePath.lastIndexOf("/"));
+      const detailsPaneUrl = new URL(baseUrl.origin);
+      detailsPaneUrl.pathname = `${webServerRelativePath}/_layouts/15/modernFrame.aspx`;
+      detailsPaneUrl.searchParams.set("origin", window.location.origin);
+      detailsPaneUrl.searchParams.set("parent", parentPath);
+      detailsPaneUrl.searchParams.set("listUrl", listUrl);
+      detailsPaneUrl.searchParams.set("scenario", "detailsPane");
+      detailsPaneUrl.searchParams.set("channelId", this._getLiveUpdateChannelId());
+      detailsPaneUrl.searchParams.set("app", "OneUp");
+      detailsPaneUrl.searchParams.set("component", "detailsPane");
+      detailsPaneUrl.searchParams.set("isDarkMode", String(this._getLiveUpdateIsDarkMode()));
+      detailsPaneUrl.searchParams.set("options", JSON.stringify({
+        itemIds: [`id=${encodeURIComponent(itemServerRelativePath)}`],
+        isOD3UIEnabled: true,
+        isCrossList: false,
+        ...(normalizedSelectedItemId ? { selectedItemIds: [normalizedSelectedItemId] } : {}),
+      }));
+      detailsPaneUrl.searchParams.set("hidePreview", "1");
+      detailsPaneUrl.searchParams.set("disableAutoScroll", "1");
+
+      return detailsPaneUrl.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private _buildDocumentViewerUrl(item: any, baseUrl: URL): string | null {
+    const autoPreviewUrl = this._resolveExternalItemFieldValue(item, "AutoPreviewUrl");
+
+    if (autoPreviewUrl) {
+      try {
+        return new URL(autoPreviewUrl, window.location.origin).toString();
+      } catch {
+        // Fall back to a sourcedoc-based viewer URL.
+      }
+    }
+
+    const documentUniqueId = this._resolveExternalItemFieldValue(item, "UniqueID") ?? this._resolveExternalItemFieldValue(item, "NormUniqueID") ?? this._resolveExternalItemFieldValue(item, "IdentityListItemId") ?? this._resolveExternalItemFieldValue(item, "ListItemID") ?? this._resolveExternalItemFieldValue(item, "Id");
+
+    if (!documentUniqueId) {
+      return null;
+    }
+
+    try {
+      const viewerUrl = new URL(baseUrl.origin);
+      viewerUrl.pathname = `${baseUrl.pathname.replace(/\/$/, "")}/_layouts/15/viewer.aspx`;
+      viewerUrl.searchParams.set("sourcedoc", `{${this._normalizeLiveUpdateGuid(String(documentUniqueId))}}`);
+
+      return viewerUrl.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  private _getLiveUpdateChannelId(): string {
+    if (window.crypto?.randomUUID) {
+      return window.crypto.randomUUID();
+    }
+
+    return `pnp-modern-search-${Date.now()}`;
+  }
+
+  private _getLiveUpdateIsDarkMode(): boolean {
+    const theme = (this.props.themeVariant as ITheme) || getTheme();
+
+    if (theme.isInverted) {
+      return true;
+    }
+
+    const backgroundColor = theme.semanticColors?.bodyBackground ?? theme.semanticColors?.bodyStandoutBackground ?? theme.palette?.white;
+
+    return this._isDarkColor(backgroundColor);
+  }
+
+  private _isDarkColor(colorValue?: string): boolean {
+    if (!colorValue) {
+      return false;
+    }
+
+    const normalizedColorValue = colorValue.trim();
+    const hexMatch = HEX_COLOR_REGEXP.exec(normalizedColorValue);
+
+    if (hexMatch) {
+      const hex = hexMatch[1];
+      const expandedHex = hex.length === 3 ? hex.split("").map((value) => `${value}${value}`).join("") : hex;
+      const red = Number.parseInt(expandedHex.slice(0, 2), 16);
+      const green = Number.parseInt(expandedHex.slice(2, 4), 16);
+      const blue = Number.parseInt(expandedHex.slice(4, 6), 16);
+
+      return this._getRelativeLuminance(red, green, blue) < 0.5;
+    }
+
+    const rgbMatch = RGB_COLOR_REGEXP.exec(normalizedColorValue);
+
+    if (rgbMatch) {
+      const red = Number.parseInt(rgbMatch[1], 10);
+      const green = Number.parseInt(rgbMatch[2], 10);
+      const blue = Number.parseInt(rgbMatch[3], 10);
+
+      return this._getRelativeLuminance(red, green, blue) < 0.5;
+    }
+
+    return false;
+  }
+
+  private _getRelativeLuminance(red: number, green: number, blue: number): number {
+    return ((0.299 * red) + (0.587 * green) + (0.114 * blue)) / 255;
+  }
+
+  private _normalizeLiveUpdateDetailsPaneUrl(rawUrl: string): string {
+    const detailsPaneUrl = new URL(rawUrl, window.location.origin);
+    detailsPaneUrl.searchParams.set("isDarkMode", String(this._getLiveUpdateIsDarkMode()));
+    return detailsPaneUrl.toString();
+  }
+
+  private _isLiveUpdateListItem(item: any, listItemId: any): boolean {
+    const contentClass = String(ObjectHelper.byPath(item, BuiltinTemplateSlots.ContentClass) ?? "").toLowerCase();
+    const itemPath = this._resolveExternalItemFieldValue(item, "Path") ?? this._resolveExternalItemFieldValue(item, "OriginalPath") ?? this._resolveExternalItemFieldValue(item, "AutoPreviewUrl");
+    const normalizedItemPath = typeof itemPath === "string" ? itemPath.toLowerCase() : "";
+
+    if (contentClass === "sts_list_documentlibrary" || /\/allitems\.aspx(?:$|\?)/i.test(normalizedItemPath)) {
+      return false;
+    }
+
+    const isListItemContentClass = contentClass.includes("listitem");
+    const isListItemFormPath = /\/(dispform|editform|newform)\.aspx(?:$|\?)/i.test(normalizedItemPath);
+
+    if (!isListItemContentClass && !isListItemFormPath) {
+      return false;
+    }
+
+    return /^\d+$/.test(String(listItemId ?? ""));
+  }
+
+  private _isLiveUpdateDocumentItem(item: any): boolean {
+    const isContainer = this.props.isContainerField ? ObjectHelper.byPath(item, this.props.isContainerField) : this._resolveExternalItemFieldValue(item, "IsContainer");
+
+    if (isContainer === true || String(isContainer).toLowerCase() === "true") {
+      return false;
+    }
+
+    const contentClass = String(ObjectHelper.byPath(item, BuiltinTemplateSlots.ContentClass) ?? "").toLowerCase();
+
+    if (contentClass.startsWith("sts_list_") && !contentClass.includes("listitem")) {
+      return false;
+    }
+
+    if (contentClass === "sts_list_documentlibrary") {
+      return false;
+    }
+
+    if (contentClass.includes("document")) {
+      return true;
+    }
+
+    const fileExtension = this.props.fileExtensionField ? ObjectHelper.byPath(item, this.props.fileExtensionField) : this._resolveExternalItemFieldValue(item, "FileExtension");
+
+    if (this._hasRenderableValue(fileExtension)) {
+      return true;
+    }
+
+    const fileName = this._resolveExternalItemFieldValue(item, "Filename") ?? this._resolveExternalItemFieldValue(item, "Path");
+
+    if (typeof fileName === "string" && /\/(forms\/allitems|lists\/[^/]+\/(allitems|dispform|editform|newform))\.aspx(?:$|\?)/i.test(fileName)) {
+      return false;
+    }
+
+    return typeof fileName === "string" && /\.[^./\\]+$/.test(fileName);
+  }
+
+  private _getLiveUpdateItemTitle(item: any): string {
+    return this._resolveExternalItemFieldValue(item, "Title") ?? this._resolveExternalItemFieldValue(item, "Filename") ?? strings.Layouts.DetailsList.DetailsPanelHeader;
+  }
+
+  private _normalizeLiveUpdateGuid(value: string): string {
+    return String(value).replace(/[{}]/g, "");
+  }
+
+  private _resolveExternalItemFieldValue(item: any, fieldName: string): any {
+    return ObjectHelper.byPath(item, `resource.fields.${fieldName}`)
+      ?? ObjectHelper.byPath(item, `resource.properties.${fieldName}`)
+      ?? ObjectHelper.byPath(item, `resource.${fieldName}`)
+      ?? ObjectHelper.byPath(item, fieldName);
+  }
+
+  private _hasRenderableValue(value: any): boolean {
+    return value !== undefined && value !== null && value !== "";
+  }
+}
+
+export class DetailsSelectedItemButtonWebComponent extends BaseWebComponent {
+  public connectedCallback() {
+    const props = this.resolveAttributes();
+    ReactDOM.render(<DetailsSelectedItemButtonComponent {...props} />, this);
+  }
+
+  protected onDispose(): void {
+    ReactDOM.unmountComponentAtNode(this);
+  }
+}

--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -5,7 +5,7 @@ import { ActionButton, IIconProps, ITheme, getTheme, Panel, PanelType, IconButto
 import { IReadonlyTheme } from "@microsoft/sp-component-base";
 import { ISearchResultsTemplateContext } from "../models/common/ITemplateContext";
 import { ObjectHelper } from "../helpers/ObjectHelper";
-import strings from "CommonStrings";
+import * as strings from "CommonStrings";
 
 const MIN_LIVE_UPDATE_PANEL_HEIGHT = 520;
 const LIVE_UPDATE_PANEL_RIGHT_OFFSET = 32;
@@ -41,6 +41,7 @@ const liveUpdatePanelSessionState: ILiveUpdatePanelSessionState = {
 
 export class DetailsSelectedItemButtonComponent extends React.Component<IDetailsSelectedItemButtonProps, IDetailsSelectedItemButtonState> {
   private _selectedItems: any[] = [];
+  private _liveUpdateLayoutAnimationFrame: number | null = null;
 
   constructor(props: IDetailsSelectedItemButtonProps) {
     super(props);
@@ -54,7 +55,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
 
   public componentDidMount(): void {
     window.addEventListener("resize", this._refreshLiveUpdatePanelLayout);
-    window.addEventListener("scroll", this._refreshLiveUpdatePanelLayout, true);
+    window.addEventListener("scroll", this._refreshLiveUpdatePanelLayout, { capture: true, passive: true });
     this._updateSelectedItems();
     this._restoreLiveUpdatePanelIfNeeded();
   }
@@ -70,6 +71,11 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   public componentWillUnmount(): void {
     window.removeEventListener("resize", this._refreshLiveUpdatePanelLayout);
     window.removeEventListener("scroll", this._refreshLiveUpdatePanelLayout, true);
+
+    if (this._liveUpdateLayoutAnimationFrame !== null) {
+      window.cancelAnimationFrame(this._liveUpdateLayoutAnimationFrame);
+      this._liveUpdateLayoutAnimationFrame = null;
+    }
   }
 
   public render(): JSX.Element {
@@ -299,9 +305,14 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   };
 
   private readonly _refreshLiveUpdatePanelLayout = (): void => {
-    if (this._getResolvedLiveUpdateFormUrl()) {
-      this.forceUpdate();
+    if (!this._getResolvedLiveUpdateFormUrl() || this._liveUpdateLayoutAnimationFrame !== null) {
+      return;
     }
+
+    this._liveUpdateLayoutAnimationFrame = window.requestAnimationFrame(() => {
+      this._liveUpdateLayoutAnimationFrame = null;
+      this.forceUpdate();
+    });
   };
 
   private _getResolvedLiveUpdateFormUrl(): string | null {
@@ -488,9 +499,9 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   }
 
   private _openViewerDetailsPane(iframe: HTMLIFrameElement, iframeDocument: Document, iframeUrl: string): void {
-    const infoButton = Array.from(iframeDocument.querySelectorAll("button")).find((button) => button.getAttribute("aria-label") === "Info, View file details") as HTMLButtonElement;
-    const overflowInfoButton = Array.from(iframeDocument.querySelectorAll('[role="menuitem"]')).find((item) => item.getAttribute("aria-label") === "Info, View file details") as HTMLElement;
-    const moreButton = Array.from(iframeDocument.querySelectorAll("button")).find((button) => button.getAttribute("aria-label") === "More") as HTMLButtonElement;
+    const infoButton = this._findViewerDetailsTrigger<HTMLButtonElement>(iframeDocument, "button");
+    const overflowInfoButton = this._findViewerDetailsTrigger<HTMLElement>(iframeDocument, '[role="menuitem"]');
+    const moreButton = this._findViewerMoreButton(iframeDocument);
 
     if (overflowInfoButton && iframe.dataset.liveUpdateViewerMarker !== `${iframeUrl}:info`) {
       iframe.dataset.liveUpdateViewerMarker = `${iframeUrl}:info`;
@@ -506,6 +517,26 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     if (!infoButton && moreButton && moreButton.getAttribute("aria-expanded") !== "true") {
       moreButton.click();
     }
+  }
+
+  private _findViewerDetailsTrigger<TElement extends Element>(iframeDocument: Document, selector: string): TElement | null {
+    return Array.from(iframeDocument.querySelectorAll(selector)).find((element) => {
+      const htmlElement = element as HTMLElement;
+      const ariaLabel = htmlElement.getAttribute("aria-label") || "";
+
+      return ariaLabel === "Info, View file details"
+        || !!htmlElement.querySelector('[data-icon-name="Info"], [data-icon-name="InfoSolid"], [data-icon-name="Info2"]');
+    }) as TElement | null;
+  }
+
+  private _findViewerMoreButton(iframeDocument: Document): HTMLButtonElement | null {
+    return Array.from(iframeDocument.querySelectorAll("button")).find((element) => {
+      const htmlElement = element as HTMLButtonElement;
+      const ariaLabel = htmlElement.getAttribute("aria-label") || "";
+
+      return ariaLabel === "More"
+        || !!htmlElement.querySelector('[data-icon-name="More"], [data-icon-name="MoreVertical"]');
+    }) as HTMLButtonElement | null;
   }
 
   private _prepareDetailsPaneFrame(iframeDocument: Document): void {
@@ -691,6 +722,10 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
 
     try {
       const baseUrl = new URL(webUrl, window.location.origin);
+
+      if (baseUrl.origin !== window.location.origin) {
+        return null;
+      }
 
       if (this._isLiveUpdateDocumentItem(item)) {
         return this._buildDocumentViewerUrl(item, baseUrl) ?? this._buildDocumentDetailsPaneUrl(item, baseUrl);

--- a/search-parts/src/layouts/results/cards/CardsLayout.ts
+++ b/search-parts/src/layouts/results/cards/CardsLayout.ts
@@ -43,6 +43,11 @@ export interface ICardsLayoutProperties {
      * If the download button should be visible
      */
     enableDownload: boolean;
+
+    /**
+    * If the details action should be visible
+     */
+    enableDetails?: boolean;
 }
 
 export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
@@ -112,6 +117,8 @@ export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
         this.properties.enablePreview = this.properties.enablePreview ?? false; // Watch out performance issues if too many items displayed
         this.properties.preferedCardNumberPerRow = this.properties.preferedCardNumberPerRow ?? 3;
         this.properties.columnSizePercentage = this.properties.columnSizePercentage ?? 33;
+        const legacyEnableDetails = (this.properties as { enableLiveUpdate?: boolean }).enableLiveUpdate;
+        this.properties.enableDetails = this.properties.enableDetails ?? legacyEnableDetails ?? false;
 
         const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
             /* webpackChunkName: 'pnp-modern-search-results-cards-layout' */
@@ -229,6 +236,10 @@ export class CardsLayout extends BaseLayout<ICardsLayoutProperties> {
                 step: 1,
                 showValue: true,
                 value: this.properties.preferedCardNumberPerRow,
+            }),
+            PropertyPaneToggle('layoutProperties.enableDetails', {
+                label: strings.Layouts.DetailsList.EnableDetails,
+                checked: this.properties.enableDetails
             }),
             PropertyPaneToggle('layoutProperties.enableDownload', {
                 label: strings.Layouts.DetailsList.EnableDownload,

--- a/search-parts/src/layouts/results/cards/cards.html
+++ b/search-parts/src/layouts/results/cards/cards.html
@@ -31,6 +31,17 @@
             </div>
 
             <div class="template--toolbar">
+                            {{#and properties.layoutProperties.enableDetails @root.properties.itemSelectionProps.allowItemSelection}}
+                                <pnp-details-selected-item-button
+                                    data-items="{{JSONstringify data.items}}"
+                                    data-context="{{JSONstringify (truncateContext @root)}}"
+                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                    data-file-extension-field="{{@root.slots.FileType}}"
+                                    data-is-container-field="{{@root.slots.IsFolder}}"
+                                    data-allow-multi="{{properties.itemSelectionProps.allowMulti}}"
+                                >
+                                </pnp-details-selected-item-button>
+                            {{/and}}
               {{#and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection}}
                 <pnp-download-selected-items-button 
                   data-items="{{JSONstringify data.items}}" 

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { BaseLayout, IDataContext } from "@pnp/modern-search-extensibility";
-import * as strings from 'CommonStrings';
+import strings from 'CommonStrings';
 import { IComboBoxOption } from '@fluentui/react';
 import { IDetailsListColumnConfiguration } from '../../../components/DetailsListComponent';
 import { IPropertyPaneField, PropertyPaneToggle, PropertyPaneDropdown, PropertyPaneHorizontalRule, PropertyPaneButton, PropertyPaneButtonType, PropertyPaneTextField } from '@microsoft/sp-property-pane';
@@ -77,6 +77,11 @@ export interface IDetailsListLayoutProperties {
     enableDownload: boolean;
 
     /**
+    * If the details action should be available for selected items
+     */
+    enableDetails?: boolean;
+
+    /**
      * enable in order to have every other row with a different background color
      */
     useAlternatingBackgroundColor?: boolean;
@@ -136,6 +141,8 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         this.properties.groupByOthersGroupTitle = this.properties.groupByOthersGroupTitle ?? strings.Layouts.DetailsList.GroupByOthersGroupDefaultValue;
         this.properties.additionalGroupByFields = this.properties.additionalGroupByFields ?? [];
         this.properties.groupsCollapsed = this.properties.groupsCollapsed ?? true;
+        const legacyEnableDetails = (this.properties as { enableLiveUpdate?: boolean }).enableLiveUpdate;
+        this.properties.enableDetails = this.properties.enableDetails ?? legacyEnableDetails ?? false;
 
         if (this.editMode) {
             const { PropertyFieldCollectionData, CustomCollectionFieldType } = await import(
@@ -169,8 +176,8 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
         // Sort ascending
         availableOptions = availableOptions.sort((a, b) => {
 
-            const aValue = a.text ? a.text : a.key ? a.key.toString() : null;
-            const bValue = b.text ? b.text : b.key ? b.key.toString() : null;
+            const aValue = a.text || (a.key ? a.key.toString() : null);
+            const bValue = b.text || (b.key ? b.key.toString() : null);
 
             if (aValue && bValue) {
                 if (aValue.toLowerCase() > bValue.toLowerCase()) return 1;
@@ -305,6 +312,10 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
                 label: strings.Layouts.DetailsList.ShowFileIcon,
                 checked: this.properties.showFileIcon
             }),
+            PropertyPaneToggle('layoutProperties.enableDetails', {
+                label: strings.Layouts.DetailsList.EnableDetails,
+                checked: this.properties.enableDetails
+            }),
         ];
 
         // Show file icon
@@ -404,10 +415,7 @@ export class DetailsListLayout extends BaseLayout<IDetailsListLayoutProperties> 
             PropertyPaneToggle('layoutProperties.enableDownload', {
                 label: strings.Layouts.DetailsList.EnableDownload,
                 checked: this.properties.enableDownload
-            })
-        );
-
-        propertyPaneFields.push(
+            }),
             PropertyPaneToggle('layoutProperties.useAlternatingBackgroundColor', {
                 label: strings.Layouts.DetailsList.UseAlternatingBackgroundColor || 'Use Alternating Background color',
                 checked: this.properties.useAlternatingBackgroundColor

--- a/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
+++ b/search-parts/src/layouts/results/detailsList/DetailListLayout.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { BaseLayout, IDataContext } from "@pnp/modern-search-extensibility";
-import strings from 'CommonStrings';
+import * as strings from 'CommonStrings';
 import { IComboBoxOption } from '@fluentui/react';
 import { IDetailsListColumnConfiguration } from '../../../components/DetailsListComponent';
 import { IPropertyPaneField, PropertyPaneToggle, PropertyPaneDropdown, PropertyPaneHorizontalRule, PropertyPaneButton, PropertyPaneButtonType, PropertyPaneTextField } from '@microsoft/sp-property-pane';

--- a/search-parts/src/layouts/results/detailsList/details-list.html
+++ b/search-parts/src/layouts/results/detailsList/details-list.html
@@ -23,14 +23,25 @@
             </pnp-selectedfilters>
         {{/if}}
         
-        {{#or @root.properties.showResultsCount (and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection) }}
+        {{#or @root.properties.showResultsCount (and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection) (and properties.layoutProperties.enableDetails @root.properties.itemSelectionProps.allowItemSelection) }}
           <div class="template--toolbar">
             <div class="template--resultCount">
               {{#if @root.properties.showResultsCount}}
-                <label class="ms-fontWeight-semibold">{{getCountMessage @root.data.totalItemsCount @root.inputQueryText}}</label>
+                                <span class="ms-fontWeight-semibold">{{getCountMessage @root.data.totalItemsCount @root.inputQueryText}}</span>
               {{/if}}
             </div>
             <div>
+                            {{#and properties.layoutProperties.enableDetails @root.properties.itemSelectionProps.allowItemSelection}}
+                                <pnp-details-selected-item-button
+                                    data-items="{{JSONstringify data.items}}"
+                                    data-context="{{JSONstringify (truncateContext @root)}}"
+                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                    data-file-extension-field="{{@root.slots.FileType}}"
+                                    data-is-container-field="{{@root.slots.IsFolder}}"
+                                    data-allow-multi="{{properties.itemSelectionProps.allowMulti}}"
+                                >
+                                </pnp-details-selected-item-button>
+                            {{/and}}
               {{#and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection}}
                 <pnp-download-selected-items-button 
                   data-items="{{JSONstringify data.items}}" 

--- a/search-parts/src/layouts/results/simpleList/SimpleListLayout.ts
+++ b/search-parts/src/layouts/results/simpleList/SimpleListLayout.ts
@@ -18,6 +18,11 @@ export interface ISimpleListLayoutProperties {
      * If the download button should be visible
      */
     enableDownload: boolean;
+
+    /**
+    * If the details action should be visible
+     */
+    enableDetails?: boolean;
 }
 
 export class SimpleListLayout extends BaseLayout<ISimpleListLayoutProperties> {
@@ -26,6 +31,8 @@ export class SimpleListLayout extends BaseLayout<ISimpleListLayoutProperties> {
 
         this.properties.showFileIcon = this.properties.showFileIcon !== null && this.properties.showFileIcon !== undefined ?  this.properties.showFileIcon: true;
         this.properties.showItemThumbnail = this.properties.showItemThumbnail !== null && this.properties.showItemThumbnail !== undefined ?  this.properties.showItemThumbnail: true;
+        const legacyEnableDetails = (this.properties as { enableLiveUpdate?: boolean }).enableLiveUpdate;
+        this.properties.enableDetails = this.properties.enableDetails ?? legacyEnableDetails ?? false;
     }
 
     public getPropertyPaneFieldsConfiguration(availableFields: string[]): IPropertyPaneField<any>[] {
@@ -37,6 +44,10 @@ export class SimpleListLayout extends BaseLayout<ISimpleListLayoutProperties> {
             PropertyPaneToggle('layoutProperties.showItemThumbnail', {
                 label: strings.Layouts.SimpleList.ShowItemThumbnailLabel
             }),
+                        PropertyPaneToggle('layoutProperties.enableDetails', {
+                            label: strings.Layouts.DetailsList.EnableDetails,
+                            checked: this.properties.enableDetails
+                        }),
             PropertyPaneToggle('layoutProperties.enableDownload', {
               label: strings.Layouts.DetailsList.EnableDownload,
               checked: this.properties.enableDownload

--- a/search-parts/src/layouts/results/simpleList/simple-list.html
+++ b/search-parts/src/layouts/results/simpleList/simple-list.html
@@ -36,6 +36,17 @@
             </div>
 
             <div class="template--toolbar">
+                            {{#and properties.layoutProperties.enableDetails @root.properties.itemSelectionProps.allowItemSelection}}
+                                <pnp-details-selected-item-button
+                                    data-items="{{JSONstringify data.items}}"
+                                    data-context="{{JSONstringify (truncateContext @root)}}"
+                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                    data-file-extension-field="{{@root.slots.FileType}}"
+                                    data-is-container-field="{{@root.slots.IsFolder}}"
+                                    data-allow-multi="{{properties.itemSelectionProps.allowMulti}}"
+                                >
+                                </pnp-details-selected-item-button>
+                            {{/and}}
               {{#and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection}}
                 <pnp-download-selected-items-button 
                   data-items="{{JSONstringify data.items}}" 

--- a/search-parts/src/layouts/results/slider/SliderLayout.ts
+++ b/search-parts/src/layouts/results/slider/SliderLayout.ts
@@ -24,6 +24,11 @@ export interface ISliderLayoutProperties {
      * If the download button should be visible
      */
     enableDownload: boolean;
+
+    /**
+    * If the details action should be visible
+     */
+    enableDetails?: boolean;
 }
 
 export class SliderLayout extends BaseLayout<ISliderLayoutProperties> {
@@ -42,6 +47,8 @@ export class SliderLayout extends BaseLayout<ISliderLayoutProperties> {
 
         this.properties.slideHeight = this.properties.slideHeight ? this.properties.slideHeight : 360;
         this.properties.slideWidth = this.properties.slideWidth ? this.properties.slideWidth : 318;
+        const legacyEnableDetails = (this.properties as { enableLiveUpdate?: boolean }).enableLiveUpdate;
+        this.properties.enableDetails = this.properties.enableDetails ?? legacyEnableDetails ?? false;
     }
 
     public getPropertyPaneFieldsConfiguration(availableFields: string[]): IPropertyPaneField<any>[] {
@@ -102,6 +109,10 @@ export class SliderLayout extends BaseLayout<ISliderLayoutProperties> {
                 step: 1,
                 showValue: true
             }),
+                        PropertyPaneToggle('layoutProperties.enableDetails', {
+                            label: strings.Layouts.DetailsList.EnableDetails,
+                            checked: this.properties.enableDetails
+                        }),
             PropertyPaneToggle('layoutProperties.enableDownload', {
               label: strings.Layouts.DetailsList.EnableDownload,
               checked: this.properties.enableDownload

--- a/search-parts/src/layouts/results/slider/slider.html
+++ b/search-parts/src/layouts/results/slider/slider.html
@@ -21,6 +21,17 @@
             </div>
 
             <div class="template--toolbar">
+                            {{#and properties.layoutProperties.enableDetails @root.properties.itemSelectionProps.allowItemSelection}}
+                                <pnp-details-selected-item-button
+                                    data-items="{{JSONstringify data.items}}"
+                                    data-context="{{JSONstringify (truncateContext @root)}}"
+                                    data-theme-variant="{{JSONstringify @root.theme}}"
+                                    data-file-extension-field="{{@root.slots.FileType}}"
+                                    data-is-container-field="{{@root.slots.IsFolder}}"
+                                    data-allow-multi="{{properties.itemSelectionProps.allowMulti}}"
+                                >
+                                </pnp-details-selected-item-button>
+                            {{/and}}
               {{#and properties.layoutProperties.enableDownload @root.properties.itemSelectionProps.allowItemSelection}}
                 <pnp-download-selected-items-button 
                   data-items="{{JSONstringify data.items}}" 

--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -245,6 +245,10 @@ declare interface ICommonStrings {
         EnableStickyHeader: string;
         StickyHeaderListViewHeight: string;
         EnableDownload: string;
+        EnableDetails: string;
+        DetailsButtonLabel: string;
+        DetailsPanelHeader: string;
+        DetailsUnavailableLabel: string;
         UseAlternatingBackgroundColor:string;
         ColumnDescriptionFieldLabel: string;
       };

--- a/search-parts/src/loc/commonStrings.d.ts
+++ b/search-parts/src/loc/commonStrings.d.ts
@@ -249,6 +249,7 @@ declare interface ICommonStrings {
         DetailsButtonLabel: string;
         DetailsPanelHeader: string;
         DetailsUnavailableLabel: string;
+        CloseDetailsPanelLabel: string;
         UseAlternatingBackgroundColor:string;
         ColumnDescriptionFieldLabel: string;
       };

--- a/search-parts/src/loc/cs-cz.js
+++ b/search-parts/src/loc/cs-cz.js
@@ -244,6 +244,10 @@ define([], function () {
                 EnableStickyHeader: "Povolit pevnou hlavičku",
                 StickyHeaderListViewHeight: "Výška zobrazení seznamu (v px)",
                 EnableDownload: "Povolit stažení",
+                EnableDetails: "Povolit podrobnosti",
+                DetailsButtonLabel: "Podrobnosti",
+                DetailsPanelHeader: "Podrobnosti",
+                DetailsUnavailableLabel: "Podrobnosti nejsou k dispozici",
                 UseAlternatingBackgroundColor: "Použijte střídající se barvu pozadí"
             },
             Cards: {

--- a/search-parts/src/loc/cs-cz.js
+++ b/search-parts/src/loc/cs-cz.js
@@ -248,6 +248,7 @@ define([], function () {
                 DetailsButtonLabel: "Podrobnosti",
                 DetailsPanelHeader: "Podrobnosti",
                 DetailsUnavailableLabel: "Podrobnosti nejsou k dispozici",
+                CloseDetailsPanelLabel: "Zavřít panel podrobností",
                 UseAlternatingBackgroundColor: "Použijte střídající se barvu pozadí"
             },
             Cards: {

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Aktivér fastgjort header",
                 StickyHeaderListViewHeight: "Listevisningshøjde (px)",
                 EnableDownload: "Aktivér download",
+                EnableDetails: "Aktivér detaljer",
+                DetailsButtonLabel: "Detaljer",
+                DetailsPanelHeader: "Detaljer",
+                DetailsUnavailableLabel: "Detaljer er ikke tilgængelige",
                 UseAlternatingBackgroundColor: "Vis skiftende baggrundsfarve"
             },
             Cards: {

--- a/search-parts/src/loc/da-dk.js
+++ b/search-parts/src/loc/da-dk.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Detaljer",
                 DetailsPanelHeader: "Detaljer",
                 DetailsUnavailableLabel: "Detaljer er ikke tilgængelige",
+                CloseDetailsPanelLabel: "Luk detaljepanel",
                 UseAlternatingBackgroundColor: "Vis skiftende baggrundsfarve"
             },
             Cards: {

--- a/search-parts/src/loc/de-de.js
+++ b/search-parts/src/loc/de-de.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Details",
                 DetailsPanelHeader: "Details",
                 DetailsUnavailableLabel: "Details sind nicht verfügbar",
+                CloseDetailsPanelLabel: "Detailbereich schließen",
                 UseAlternatingBackgroundColor: "Verwenden Sie abwechselnde Hintergrundfarben"
             },
             Cards: {

--- a/search-parts/src/loc/de-de.js
+++ b/search-parts/src/loc/de-de.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Fixierte Kopfzeile aktivieren",
                 StickyHeaderListViewHeight: "Höhe der Listenansicht (px)",
                 EnableDownload: "Download aktivieren",
+                EnableDetails: "Details aktivieren",
+                DetailsButtonLabel: "Details",
+                DetailsPanelHeader: "Details",
+                DetailsUnavailableLabel: "Details sind nicht verfügbar",
                 UseAlternatingBackgroundColor: "Verwenden Sie abwechselnde Hintergrundfarben"
             },
             Cards: {

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Enable sticky header",
                 StickyHeaderListViewHeight: "List view height (in px)",
                 EnableDownload: "Enable download",
+                EnableDetails: "Enable details",
+                DetailsButtonLabel: "Details",
+                DetailsPanelHeader: "Details",
+                DetailsUnavailableLabel: "Details unavailable",
                 UseAlternatingBackgroundColor: "Use Alternating Background Color",
                 ColumnDescriptionFieldLabel: "Column description (tooltip)"
             },

--- a/search-parts/src/loc/en-us.js
+++ b/search-parts/src/loc/en-us.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Details",
                 DetailsPanelHeader: "Details",
                 DetailsUnavailableLabel: "Details unavailable",
+                CloseDetailsPanelLabel: "Close details panel",
                 UseAlternatingBackgroundColor: "Use Alternating Background Color",
                 ColumnDescriptionFieldLabel: "Column description (tooltip)"
             },

--- a/search-parts/src/loc/es-es.js
+++ b/search-parts/src/loc/es-es.js
@@ -251,6 +251,7 @@ define([], function () {
                 DetailsButtonLabel: "Detalles",
                 DetailsPanelHeader: "Detalles",
                 DetailsUnavailableLabel: "Los detalles no están disponibles",
+                CloseDetailsPanelLabel: "Cerrar panel de detalles",
                 UseAlternatingBackgroundColor: "Utilice colores de fondo alternos"
             },
             Cards: {

--- a/search-parts/src/loc/es-es.js
+++ b/search-parts/src/loc/es-es.js
@@ -247,6 +247,10 @@ define([], function () {
                 EnableStickyHeader: "Activar el encabezado fijo",
                 StickyHeaderListViewHeight: "Altura de la vista de lista con encabezado fijo (en píxeles)",
                 EnableDownload: "Activar la descarga de archivos",
+                EnableDetails: "Habilitar detalles",
+                DetailsButtonLabel: "Detalles",
+                DetailsPanelHeader: "Detalles",
+                DetailsUnavailableLabel: "Los detalles no están disponibles",
                 UseAlternatingBackgroundColor: "Utilice colores de fondo alternos"
             },
             Cards: {

--- a/search-parts/src/loc/fi-fi.js
+++ b/search-parts/src/loc/fi-fi.js
@@ -244,6 +244,10 @@ define([], function () {
                 EnableStickyHeader: "Kiinnitä ylätunniste",
                 StickyHeaderListViewHeight: "Kiinnitetyn ylätunnisteen korkeus (px)",
                 EnableDownload: "Salli lataus",
+                EnableDetails: "Ota tiedot käyttöön",
+                DetailsButtonLabel: "Tiedot",
+                DetailsPanelHeader: "Tiedot",
+                DetailsUnavailableLabel: "Tiedot eivät ole käytettävissä",
                 UseAlternatingBackgroundColor: "Käytä Vaihtelevaa taustaväriä"
             },
             Cards: {

--- a/search-parts/src/loc/fi-fi.js
+++ b/search-parts/src/loc/fi-fi.js
@@ -248,6 +248,7 @@ define([], function () {
                 DetailsButtonLabel: "Tiedot",
                 DetailsPanelHeader: "Tiedot",
                 DetailsUnavailableLabel: "Tiedot eivät ole käytettävissä",
+                CloseDetailsPanelLabel: "Sulje tietopaneeli",
                 UseAlternatingBackgroundColor: "Käytä Vaihtelevaa taustaväriä"
             },
             Cards: {

--- a/search-parts/src/loc/fr-fr.js
+++ b/search-parts/src/loc/fr-fr.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Détails",
                 DetailsPanelHeader: "Détails",
                 DetailsUnavailableLabel: "Les détails ne sont pas disponibles",
+                CloseDetailsPanelLabel: "Fermer le panneau des détails",
                 UseAlternatingBackgroundColor: "Utiliser une couleur d'arrière-plan alternée"
             },
             Cards: {

--- a/search-parts/src/loc/fr-fr.js
+++ b/search-parts/src/loc/fr-fr.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Activer l’en-tête collant",
                 StickyHeaderListViewHeight: "Hauteur de la liste de détails (en pixels)",
                 EnableDownload: "Activer le téléchargement",
+                EnableDetails: "Activer les détails",
+                DetailsButtonLabel: "Détails",
+                DetailsPanelHeader: "Détails",
+                DetailsUnavailableLabel: "Les détails ne sont pas disponibles",
                 UseAlternatingBackgroundColor: "Utiliser une couleur d'arrière-plan alternée"
             },
             Cards: {

--- a/search-parts/src/loc/it-it.js
+++ b/search-parts/src/loc/it-it.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Dettagli",
                 DetailsPanelHeader: "Dettagli",
                 DetailsUnavailableLabel: "I dettagli non sono disponibili",
+                CloseDetailsPanelLabel: "Chiudi riquadro dettagli",
                 UseAlternatingBackgroundColor: "Usa colori di sfondo alternati"
 
             },

--- a/search-parts/src/loc/it-it.js
+++ b/search-parts/src/loc/it-it.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Abilita intestazione fissa",
                 StickyHeaderListViewHeight: "Altezza vista elenco (in px)",
                 EnableDownload: "Abilita download",
+                EnableDetails: "Abilita dettagli",
+                DetailsButtonLabel: "Dettagli",
+                DetailsPanelHeader: "Dettagli",
+                DetailsUnavailableLabel: "I dettagli non sono disponibili",
                 UseAlternatingBackgroundColor: "Usa colori di sfondo alternati"
 
             },

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -249,6 +249,7 @@ define([], function () {
                 DetailsButtonLabel: "Detaljer",
                 DetailsPanelHeader: "Detaljer",
                 DetailsUnavailableLabel: "Detaljer er ikke tilgjengelige",
+                CloseDetailsPanelLabel: "Lukk detaljpanelet",
                 UseAlternatingBackgroundColor: "Bruk vekslende bakgrunnsfarge"
             },
             Cards: {

--- a/search-parts/src/loc/nb-no.js
+++ b/search-parts/src/loc/nb-no.js
@@ -245,6 +245,10 @@ define([], function () {
                 EnableStickyHeader: "Aktiver klebrig overskrift",
                 StickyHeaderListViewHeight: "Høyde på listevisning med klebrig overskrift (px)",
                 EnableDownload: "Aktiver nedlasting",
+                EnableDetails: "Aktiver detaljer",
+                DetailsButtonLabel: "Detaljer",
+                DetailsPanelHeader: "Detaljer",
+                DetailsUnavailableLabel: "Detaljer er ikke tilgjengelige",
                 UseAlternatingBackgroundColor: "Bruk vekslende bakgrunnsfarge"
             },
             Cards: {

--- a/search-parts/src/loc/nl-nl.js
+++ b/search-parts/src/loc/nl-nl.js
@@ -249,6 +249,7 @@ define([], function () {
                 DetailsButtonLabel: "Details",
                 DetailsPanelHeader: "Details",
                 DetailsUnavailableLabel: "Details zijn niet beschikbaar",
+                CloseDetailsPanelLabel: "Detailvenster sluiten",
                 UseAlternatingBackgroundColor: "Gebruik afwisselende achtergrondkleur"
 
             },

--- a/search-parts/src/loc/nl-nl.js
+++ b/search-parts/src/loc/nl-nl.js
@@ -245,6 +245,10 @@ define([], function () {
                 EnableStickyHeader: "Sticky header inschakelen",
                 StickyHeaderListViewHeight: "Hoogte van de lijstweergave (px)",
                 EnableDownload: "Downloaden inschakelen",
+                EnableDetails: "Details inschakelen",
+                DetailsButtonLabel: "Details",
+                DetailsPanelHeader: "Details",
+                DetailsUnavailableLabel: "Details zijn niet beschikbaar",
                 UseAlternatingBackgroundColor: "Gebruik afwisselende achtergrondkleur"
 
             },

--- a/search-parts/src/loc/pl-pl.js
+++ b/search-parts/src/loc/pl-pl.js
@@ -251,6 +251,7 @@ define([], function () {
                 DetailsButtonLabel: "Szczegóły",
                 DetailsPanelHeader: "Szczegóły",
                 DetailsUnavailableLabel: "Szczegóły są niedostępne",
+                CloseDetailsPanelLabel: "Zamknij panel szczegółów",
                 UseAlternatingBackgroundColor: "Użyj naprzemiennego koloru tła"
             },
             Cards: {

--- a/search-parts/src/loc/pl-pl.js
+++ b/search-parts/src/loc/pl-pl.js
@@ -247,6 +247,10 @@ define([], function () {
                 EnableStickyHeader: "Włącz lepką nagłówkę",
                 StickyListViewHeight: "Wysokość listy ze szczegółami (px)",
                 EnableDownload: "Włącz pobieranie",
+                EnableDetails: "Włącz szczegóły",
+                DetailsButtonLabel: "Szczegóły",
+                DetailsPanelHeader: "Szczegóły",
+                DetailsUnavailableLabel: "Szczegóły są niedostępne",
                 UseAlternatingBackgroundColor: "Użyj naprzemiennego koloru tła"
             },
             Cards: {

--- a/search-parts/src/loc/pt-br.js
+++ b/search-parts/src/loc/pt-br.js
@@ -246,6 +246,10 @@ define([], function () {
                 EnableStickyHeader: "Cabeçalho fixo",
                 StickyHeaderListViewHeight: "Altura da lista de visualização (px)",
                 EnableDownload: "Habilitar download",
+                EnableDetails: "Habilitar detalhes",
+                DetailsButtonLabel: "Detalhes",
+                DetailsPanelHeader: "Detalhes",
+                DetailsUnavailableLabel: "Os detalhes não estão disponíveis",
                 UseAlternatingBackgroundColor: "Utilize cores de fundo alternadas"
             },
             Cards: {

--- a/search-parts/src/loc/pt-br.js
+++ b/search-parts/src/loc/pt-br.js
@@ -250,6 +250,7 @@ define([], function () {
                 DetailsButtonLabel: "Detalhes",
                 DetailsPanelHeader: "Detalhes",
                 DetailsUnavailableLabel: "Os detalhes não estão disponíveis",
+                CloseDetailsPanelLabel: "Fechar painel de detalhes",
                 UseAlternatingBackgroundColor: "Utilize cores de fundo alternadas"
             },
             Cards: {

--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -251,6 +251,7 @@ define([], function () {
                 DetailsButtonLabel: "Detaljer",
                 DetailsPanelHeader: "Detaljer",
                 DetailsUnavailableLabel: "Detaljer är inte tillgängliga",
+                CloseDetailsPanelLabel: "Stäng informationspanelen",
                 UseAlternatingBackgroundColor: "Använd alternerande bakgrundsfärg"
             },
             Cards: {

--- a/search-parts/src/loc/sv-SE.js
+++ b/search-parts/src/loc/sv-SE.js
@@ -247,6 +247,10 @@ define([], function () {
                 EnableStickyHeader: "Aktivera fast rubrik",
                 StickyHeaderListViewHeight: "Höjd för listvy (px)",
                 EnableDownload: "Aktivera nedladdning",
+                EnableDetails: "Aktivera detaljer",
+                DetailsButtonLabel: "Detaljer",
+                DetailsPanelHeader: "Detaljer",
+                DetailsUnavailableLabel: "Detaljer är inte tillgängliga",
                 UseAlternatingBackgroundColor: "Använd alternerande bakgrundsfärg"
             },
             Cards: {


### PR DESCRIPTION
## Summary
Implements a selected-item Details action for built-in result layouts and opens the SharePoint details experience in a right-hand panel for supported files and list items.

Original source: [Add an option to the Detailed List layout (perhaps other layouts too) to update an item in a IFramed Item Update Form on the side · microsoft-search/pnp-modern-search · Discussion #4879](https://github.com/microsoft-search/pnp-modern-search/discussions/4879)

## What changed
- Add a shared selected-item Details button component for built-in templates.
- Add independent `enableDetails` toggles to Detailed List, Cards, Simple List, and Slider.
- Keep backward compatibility for saved layout settings via fallback from legacy `enableLiveUpdate`.
- Show the Details action only when item selection is enabled.
- Disable Details when multi-select is enabled.
- Remove the old row-level pencil/live-update approach from the detailed list experience.
- Rename user-facing strings from live update wording to details wording across supported locales.
- Adjust non-production webpack dev-server settings used during local debug/test iterations.

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec heft build`
- Browser verification on the SharePoint debug page:
  - selected an item
  - confirmed the `Detaljer` button rendered enabled
  - opened the right-hand pane and verified item details loaded

## Notes
- Version bump is intentionally excluded from this PR.
- The PR still includes the `ExternalConnection.Read.All` permission request change in `search-parts/config/package-solution.json`.
- Branch commits:
  - `16f22918` Add selected-item details action
  - `4bfb6d4a` Exclude version bump from details PR
