### PR TITLE
Fix filter labels for encoded and CHCM refiners (#4882)

### DIFF
--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -16,11 +16,16 @@ export class TaxonomyHelper {
         return /\p{L}/u.test(value);
     }
 
+    private static isNonPrintableCodePoint(codePoint: number): boolean {
+        return codePoint < 0x20
+            || (codePoint >= 0x7f && codePoint <= 0x9f)
+            || (codePoint >= 0xd800 && codePoint <= 0xdfff);
+    }
+
     private static containsNonPrintableCharacter(value: string): boolean {
         for (let index = 0; index < value.length; index++) {
             const codePoint = value.codePointAt(index) ?? 0;
-
-            if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+            if (this.isNonPrintableCodePoint(codePoint)) {
                 return true;
             }
 

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -17,10 +17,19 @@ export class TaxonomyHelper {
     }
 
     private static containsNonPrintableCharacter(value: string): boolean {
-        return Array.from(value).some(char => {
-            const codePoint = char.codePointAt(0) ?? 0;
-            return codePoint < 0x20 || codePoint === 0x7f;
-        });
+        for (let index = 0; index < value.length; index++) {
+            const codePoint = value.codePointAt(index) ?? 0;
+
+            if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+                return true;
+            }
+
+            if (codePoint > 0xffff) {
+                index++;
+            }
+        }
+
+        return false;
     }
 
     public static normalizeReadableLabelCandidate(value: string): string {

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -22,6 +22,13 @@ export class TaxonomyHelper {
             || (codePoint >= 0xd800 && codePoint <= 0xdfff);
     }
 
+    private static isHexCharacter(value: string, index: number): boolean {
+        const codePoint = value.codePointAt(index) ?? 0;
+        return (codePoint >= 0x30 && codePoint <= 0x39)
+            || (codePoint >= 0x41 && codePoint <= 0x46)
+            || (codePoint >= 0x61 && codePoint <= 0x66);
+    }
+
     private static containsNonPrintableCharacter(value: string): boolean {
         for (let index = 0; index < value.length; index++) {
             const codePoint = value.codePointAt(index) ?? 0;
@@ -222,7 +229,7 @@ export class TaxonomyHelper {
 
             const payloadChars: string[] = [];
 
-            while (payloadStart < value.length && /[0-9a-fA-F]/.test(value.charAt(payloadStart))) {
+            while (payloadStart < value.length && this.isHexCharacter(value, payloadStart)) {
                 payloadChars.push(value.charAt(payloadStart));
                 payloadStart++;
             }

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -16,13 +16,31 @@ export class TaxonomyHelper {
         return /\p{L}/u.test(value);
     }
 
+    private static containsNonPrintableCharacter(value: string): boolean {
+        return Array.from(value).some(char => {
+            const codePoint = char.codePointAt(0) ?? 0;
+            return codePoint < 0x20 || codePoint === 0x7f;
+        });
+    }
+
     public static normalizeReadableLabelCandidate(value: string): string {
-        return `${value || ''}`.trim().replace(/^"+|"+$/g, '');
+        let normalizedValue = `${value || ''}`.trim();
+
+        while (normalizedValue.startsWith('"')) {
+            normalizedValue = normalizedValue.substring(1);
+        }
+
+        while (normalizedValue.endsWith('"')) {
+            normalizedValue = normalizedValue.substring(0, normalizedValue.length - 1);
+        }
+
+        return normalizedValue;
     }
 
     public static isReadablePlainLabel(value: string): boolean {
         const cleanedValue = this.normalizeReadableLabelCandidate(value);
         return !!cleanedValue
+            && !this.containsNonPrintableCharacter(cleanedValue)
             && !this.containsEncodedTokenMarker(cleanedValue)
             && !cleanedValue.includes('|')
             && !this.isGuidLikeToken(cleanedValue);
@@ -148,9 +166,7 @@ export class TaxonomyHelper {
             // If escaped quotes remain in the middle, normalize them.
             value = value.replaceAll(escapedQuote, '"');
 
-            value = value.replace(/^#?ǂ+/, '');
-
-            value = this.getLongestHexSegment(value);
+            value = this.extractEncodedHexPayload(value);
 
             if (value.length % 2 !== 0) {
                 value = value.substring(0, value.length - 1);
@@ -181,14 +197,28 @@ export class TaxonomyHelper {
         }
     }
 
-    private static getLongestHexSegment(value: string): string {
-        if (/^[0-9a-fA-F]+$/.test(value)) {
-            return value;
+    private static extractEncodedHexPayload(value: string): string {
+        const markerIndex = value.indexOf('ǂ');
+        if (markerIndex >= 0) {
+            let payloadStart = markerIndex;
+
+            while (value.charAt(payloadStart) === 'ǂ') {
+                payloadStart++;
+            }
+
+            const payloadChars: string[] = [];
+
+            while (payloadStart < value.length && /[0-9a-fA-F]/.test(value.charAt(payloadStart))) {
+                payloadChars.push(value.charAt(payloadStart));
+                payloadStart++;
+            }
+
+            if (payloadChars.length > 0) {
+                return payloadChars.join('');
+            }
         }
 
-        const hexSegments = value.match(/[0-9a-fA-F]+/g) || [];
-        const longestHexSegment = hexSegments.sort((left, right) => right.length - left.length)[0];
-        return longestHexSegment || '';
+        return '';
     }
 
     private static tryDecodeUtf8(hexPairs: string[]): string {

--- a/search-parts/src/services/searchService/SharePointSearchService.ts
+++ b/search-parts/src/services/searchService/SharePointSearchService.ts
@@ -38,6 +38,20 @@ export class SharePointSearchService implements ISharePointSearchService {
      */
     private serviceScope: ServiceScope;
 
+    private normalizeRefinementLabel(refinementValue: string): string {
+        const normalizedValue = `${refinementValue ?? ''}`.replace('string;#', '');
+
+        if (!normalizedValue.includes(';#')) {
+            return normalizedValue;
+        }
+
+        return normalizedValue
+            .split(';#')
+            .map(value => value.trim())
+            .filter(Boolean)
+            .join(', ');
+    }
+
     /**
      * The SPHttpClient instance
      */
@@ -120,8 +134,8 @@ export class SharePointSearchService implements ISharePointSearchService {
                         let values: IDataFilterResultValue[] = [];
                         refiner.Entries.forEach((item) => {
                             values.push({
-                                count: parseInt(item.RefinementCount, 10),
-                                name: item.RefinementValue.replace("string;#", ""), // Replace string;# for calculated columns https://github.com/SharePoint/sp-dev-solutions/issues/304
+                                count: Number.parseInt(item.RefinementCount, 10),
+                                name: this.normalizeRefinementLabel(item.RefinementValue),
                                 value: item.RefinementToken,
                                 operator: FilterComparisonOperator.Contains
                             } as IDataFilterResultValue);

--- a/search-parts/src/services/searchService/SharePointSearchService.ts
+++ b/search-parts/src/services/searchService/SharePointSearchService.ts
@@ -39,7 +39,9 @@ export class SharePointSearchService implements ISharePointSearchService {
     private serviceScope: ServiceScope;
 
     private normalizeRefinementLabel(refinementValue: string): string {
-        const normalizedValue = `${refinementValue ?? ''}`.replace('string;#', '');
+        const normalizedValue = `${refinementValue ?? ''}`.startsWith('string;#')
+            ? `${refinementValue ?? ''}`.substring('string;#'.length)
+            : `${refinementValue ?? ''}`;
 
         if (!normalizedValue.includes(';#')) {
             return normalizedValue;

--- a/search-parts/src/services/searchService/SharePointSearchService.ts
+++ b/search-parts/src/services/searchService/SharePointSearchService.ts
@@ -39,9 +39,10 @@ export class SharePointSearchService implements ISharePointSearchService {
     private serviceScope: ServiceScope;
 
     private normalizeRefinementLabel(refinementValue: string): string {
-        const normalizedValue = `${refinementValue ?? ''}`.startsWith('string;#')
-            ? `${refinementValue ?? ''}`.substring('string;#'.length)
-            : `${refinementValue ?? ''}`;
+        const safeRefinementValue = `${refinementValue ?? ''}`;
+        const normalizedValue = safeRefinementValue.startsWith('string;#')
+            ? safeRefinementValue.substring('string;#'.length)
+            : safeRefinementValue;
 
         if (!normalizedValue.includes(';#')) {
             return normalizedValue;


### PR DESCRIPTION
## Summary

Fixes the Filters web part display issue reported in #4882 where some refiners showed token-derived or corrupted values instead of readable labels.

## What changed

- tighten encoded refinement token decoding so only explicit encoded payloads are decoded
- prevent non-printable/corrupted strings from being treated as valid display labels
- normalize CHCM-style multi-choice refinement labels returned as `;#`-serialized values

## Result

- numeric-only refiners like `RefinableString172` now display readable year values such as `2022` and `2028`
- CHCM/multi-choice refiners like `RefinableString174` no longer show token values and now display normalized combinations such as `2019, 2023`

## Notes

For CHCM-mapped multi-choice properties, SharePoint still refines on stored value combinations. That means combinations like `2021, 2028, 2030` are expected for that property shape and are not part of the token-display bug.

## Validation

- verified locally on the repro page from discussion #4882
- confirmed `RefinableString172` renders readable year labels
- confirmed `RefinableString174` renders normalized multi-choice labels
- ran `pnpm exec tsc -p tsconfig.json --noEmit`
- ran production build successfully