### PR TITLE
Fix refiner labels with hyphen suffix

### DIFF
--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -117,7 +117,7 @@ export class TaxonomyHelper {
             return '';
         }
 
-        const personLikeLabelMatch = /([A-Za-z][A-Za-z'-]+(?:\s+[A-Za-z][A-Za-z'-]+)+)/.exec(cleanedValue);
+        const personLikeLabelMatch = /^([A-Za-z][A-Za-z'-]*(?:\s+[A-Za-z][A-Za-z'-]*)+)$/.exec(cleanedValue);
         return personLikeLabelMatch?.[1]?.trim() || '';
     }
 


### PR DESCRIPTION
Fixes the hyphen issue in the refiner values. Related to issue: #4891