### PR TITLE
Added extensibility support into the filter web part

### DIFF
--- a/docs/extensibility/custom_filter_control.md
+++ b/docs/extensibility/custom_filter_control.md
@@ -100,7 +100,145 @@ public getCustomWebComponents(): IComponentDefinition<any>[] {
 }
 ```
 
-### Use the control in a custom filter layout
+## Complete example: a simple 'tags' filter control
+
+The following control renders the values of a filter as clickable pills instead of checkboxes. It is a full working example you can copy in your extensibility library: two files, no extra dependencies.
+
+!!! tip "Custom element naming"
+    The `componentName` must contain a dash (`my-tags-filter`, not `mytagsfilter`), otherwise the browser refuses to register the custom element.
+
+### 1. The web component
+
+Create `src/components/MyTagsFilterWebComponent.tsx`:
+
+```tsx
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { BaseWebComponent, ExtensibilityConstants, IDataFilterInfo, IDataFilterInternal } from '@pnp/modern-search-extensibility';
+import { IReadonlyTheme } from '@microsoft/sp-component-base';
+
+export interface IMyTagsFilterProps {
+
+    /** The whole filter (values, display name, etc.), from the 'data-filter' attribute */
+    filter?: IDataFilterInternal;
+
+    /** The filter internal name, from the 'data-filter-name' attribute */
+    filterName?: string;
+
+    /** 'true' when the filter shows the values count, from the 'data-show-count' attribute */
+    showCount?: boolean;
+
+    /** The current theme, from the 'data-theme-variant' attribute */
+    themeVariant?: IReadonlyTheme;
+
+    /** Called when a value is selected or unselected */
+    onValueUpdated: (name: string, value: string, selected: boolean) => void;
+}
+
+const MyTagsFilter: React.FunctionComponent<IMyTagsFilterProps> = (props) => {
+
+    const values = props.filter?.values || [];
+    const primaryColor = props.themeVariant?.palette?.themePrimary || '#0078d4';
+    const textColor = props.themeVariant?.semanticColors?.bodyText || '#323130';
+
+    return (
+        <div role='group' aria-label={props.filter?.displayName} style={{ display: 'flex', flexWrap: 'wrap', gap: 8, padding: 8 }}>
+            {values.map((filterValue) => (
+                <button
+                    key={filterValue.value}
+                    type='button'
+                    disabled={filterValue.disabled}
+                    aria-pressed={filterValue.selected}
+                    onClick={() => props.onValueUpdated(filterValue.name, filterValue.value, !filterValue.selected)}
+                    style={{
+                        cursor: filterValue.disabled ? 'default' : 'pointer',
+                        borderRadius: 16,
+                        padding: '4px 12px',
+                        border: `1px solid ${primaryColor}`,
+                        background: filterValue.selected ? primaryColor : 'transparent',
+                        color: filterValue.selected ? '#ffffff' : textColor
+                    }}
+                >
+                    {filterValue.name}{props.showCount && filterValue.count !== undefined ? ` (${filterValue.count})` : ''}
+                </button>
+            ))}
+        </div>
+    );
+};
+
+export class MyTagsFilterWebComponent extends BaseWebComponent {
+
+    public connectedCallback(): void {
+
+        // Turns the 'data-*' attributes set by the filter layout into camelCase props
+        // (ex: 'data-filter-name' becomes 'filterName', 'data-filter' is JSON parsed)
+        const props = this.resolveAttributes();
+
+        const element = <MyTagsFilter
+            {...props}
+            onValueUpdated={(name: string, value: string, selected: boolean) => {
+
+                const detail: IDataFilterInfo = {
+                    filterName: props.filterName,
+                    filterValues: [{ name, value, selected }],
+                    instanceId: props.instanceId
+                };
+
+                // The 'Search Filters' Web Part listens to this event to update the filter
+                this.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_UPDATED, {
+                    detail,
+                    bubbles: true,
+                    cancelable: true
+                }));
+            }}
+        />;
+
+        ReactDOM.render(element, this);
+    }
+}
+```
+
+!!! note "No local state needed"
+    The Web Part re-renders the control with an updated `data-filter` after every selection, including pending (not yet applied) selections of a multi values filter. Reading `filterValue.selected` from the props is therefore enough, and the builtin 'Apply'/'Clear' buttons work out of the box thanks to `showApplyButtons: true` below. Keep in mind the Web Part moves the selected values first in the list of a multi values filter, so the pills reorder as the user selects them.
+
+### 2. Register it in the library
+
+In the class implementing `IExtensibilityLibrary`:
+
+```typescript
+import { IExtensibilityLibrary, IFilterControlDefinition, IComponentDefinition, FilterType } from '@pnp/modern-search-extensibility';
+import { MyTagsFilterWebComponent } from './components/MyTagsFilterWebComponent';
+
+export class MyExtensibilityLibrary implements IExtensibilityLibrary {
+
+    public getCustomFilterControls(): IFilterControlDefinition[] {
+        return [
+            {
+                key: 'MyTagsFilter',
+                name: 'Tags',
+                componentName: 'my-tags-filter',
+                filterType: FilterType.Refiner,
+                showApplyButtons: true
+            }
+        ];
+    }
+
+    public getCustomWebComponents(): IComponentDefinition<any>[] {
+        return [
+            {
+                componentName: 'my-tags-filter',
+                componentClass: MyTagsFilterWebComponent
+            }
+        ];
+    }
+
+    // ... the other IExtensibilityLibrary methods
+}
+```
+
+Deploy the library, register its manifest ID on the 'Search Filters' Web Part, and pick **'Tags'** in the 'Filter template' column of your filter. No template change is required: the builtin vertical, horizontal and panel layouts render it automatically.
+
+## Use the control in a custom filter layout
 
 The builtin layouts render custom filter controls automatically. If you write your own [filter layout](./custom_layout.md) or customize a builtin template, use the `customFilterControl` Handlebars helper to render whichever custom control is configured for a filter:
 

--- a/docs/extensibility/custom_filter_control.md
+++ b/docs/extensibility/custom_filter_control.md
@@ -1,0 +1,121 @@
+# Create a custom filter control
+
+A **filter control** is the UI control used to render the values of a single filter in the 'Search Filters' Web Part. Out of the box the solution ships with a checkbox, combo box, date range, date interval, people, static people, taxonomy picker and hierarchical control.
+
+Starting with `@pnp/modern-search-extensibility` v2.1.0, an extensibility library can add its own filter controls. They show up in the **'Filter template'** column of the filters configuration and are rendered by the builtin filter layouts (vertical, horizontal, panel) like any builtin control.
+
+!!! note "Filter layouts vs filter controls"
+    A **filter layout** ([custom layout](./custom_layout.md) with `type: LayoutType.Filter`) controls how the *whole set* of filters is laid out on the page. A **filter control** only renders the values of *one* filter, and is reusable across every layout.
+
+## Filter control creation process
+
+1. [Create the web component rendering the control](#create-the-web-component).
+2. [Register the filter control for discovery](#register-the-filter-control-information).
+3. [Register the library with the 'Search Filters' Web Part](./index.md#register-your-extensibility-library-with-a-web-part).
+
+### Create the web component
+
+A filter control is rendered as a custom HTML element, so it is a regular [custom web component](./custom_web_component.md). Create it as usual by extending `BaseWebComponent` and returning it from `getCustomWebComponents()`.
+
+The builtin layouts render your component with the following attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `data-instance-id` | The 'Search Filters' Web Part instance ID. Pass it back in the events you dispatch so the Web Part can resolve the right context.
+| `data-filter-name` | The internal name of the filter (i.e. the data source field / managed property).
+| `data-filter` | The whole filter as a JSON string (`IDataFilterInternal`): display name, values with their `selected`/`count`/`disabled` state, `isMulti`, `operator`, `canApply`, `canClear`, etc.
+| `data-selected-filters` | The currently submitted filters as a JSON string (`IDataFilter[]`).
+| `data-is-multi` | `true` when the filter is configured to allow multiple values.
+| `data-show-count` | `true` when the filter is configured to show the values count.
+| `data-operator` | The operator (`and`/`or`) configured between the filter values.
+| `data-theme-variant` | The current theme as a JSON string.
+
+To apply a selection, dispatch the same events as the builtin controls, using the constants from `ExtensibilityConstants`:
+
+```typescript
+import { ExtensibilityConstants, IDataFilterInfo, FilterComparisonOperator } from '@pnp/modern-search-extensibility';
+
+this.dispatchEvent(new CustomEvent(ExtensibilityConstants.EVENT_FILTER_UPDATED, {
+    detail: {
+        filterName: this.filterName,
+        filterValues: [{
+            name: 'My value',
+            value: 'MyValue',
+            selected: true,
+            operator: FilterComparisonOperator.Eq
+        }],
+        instanceId: this.instanceId
+    } as IDataFilterInfo,
+    bubbles: true,
+    cancelable: true
+}));
+```
+
+| Event | Purpose |
+| ----- | ------- |
+| `ExtensibilityConstants.EVENT_FILTER_UPDATED` | A value has been selected or unselected.
+| `ExtensibilityConstants.EVENT_FILTER_APPLY_ALL` | Apply all pending values at once (multi values scenario).
+| `ExtensibilityConstants.EVENT_FILTER_CLEAR_ALL` | Clear all values at once.
+| `ExtensibilityConstants.EVENT_FILTER_VALUE_OPERATOR_UPDATED` | The AND/OR operator between values changed.
+
+### Register the filter control information
+
+In the library main entry point (i.e. the class implementing `IExtensibilityLibrary`), return an `IFilterControlDefinition` object from the `getCustomFilterControls()` method:
+
+| Property | Description |
+| --------- | ---------- |
+| `key` | An unique internal key for your control. This value is persisted as the `selectedTemplate` property of the filters configuration.
+| `name` | The friendly name of your control, displayed in the 'Filter template' dropdown of the filters configuration.
+| `componentName` | The name of the custom HTML element to render. The component must **also** be returned by `getCustomWebComponents()` so it gets registered on the page.
+| `filterType` | `FilterType.Refiner` (default) when the values come from the data source, `FilterType.StaticFilter` when your control provides its own values. Static filters are not requested as refiners/aggregations from the connected data source.
+| `showOperator` | Renders the builtin AND/OR operator control above your control when the filter allows multiple values. Default is `false`.
+| `showApplyButtons` | Renders the builtin 'Apply'/'Clear' buttons below your control when the filter allows multiple values. Default is `false`.
+| `supportsMultiValues` | Set to `false` to disable the 'Multi values' option in the filters configuration for this control. Default is `true`.
+| `supportsValuesCount` | Set to `false` to disable the 'Show count' option in the filters configuration for this control. Default is `true`.
+| `supportsMaxBuckets` | Set to `false` to disable the 'Number of values' option in the filters configuration for this control. Default is `true`.
+
+```typescript
+public getCustomFilterControls(): IFilterControlDefinition[] {
+
+    return [
+        {
+            key: 'MyCompanyRatingFilter',
+            name: 'Rating',
+            componentName: 'my-rating-filter',
+            filterType: FilterType.Refiner,
+            showApplyButtons: true,
+            supportsValuesCount: false
+        }
+    ];
+}
+
+public getCustomWebComponents(): IComponentDefinition<any>[] {
+
+    return [
+        {
+            componentName: 'my-rating-filter',
+            componentClass: MyRatingFilterWebComponent
+        }
+    ];
+}
+```
+
+### Use the control in a custom filter layout
+
+The builtin layouts render custom filter controls automatically. If you write your own [filter layout](./custom_layout.md) or customize a builtin template, use the `customFilterControl` Handlebars helper to render whichever custom control is configured for a filter:
+
+```handlebars
+{{#each @root.filters as |filter|}}
+    {{{customFilterControl filter @root.instanceId @root.theme @root.selectedFilters}}}
+{{/each}}
+```
+
+Two companion helpers are available:
+
+| Helper | Description |
+| ------ | ----------- |
+| `{{#isCustomFilterControl filter}}...{{else}}...{{/isCustomFilterControl}}` | Block helper telling whether the filter uses a custom control, so you can branch between your custom markup and the builtin one.
+| `{{{customFilterControlFooter filter @root.instanceId @root.theme}}}` | Renders the builtin 'Apply'/'Clear' buttons for controls declaring `showApplyButtons: true`.
+
+!!! important
+    The custom controls of a filter are only resolved when the extensibility library providing them is registered **on the 'Search Filters' Web Part itself** (last property pane page, _'Extensibility configuration'_ section).

--- a/docs/extensibility/custom_layout.md
+++ b/docs/extensibility/custom_layout.md
@@ -2,7 +2,7 @@
 
 !["Custom layout"](../assets/extensibility/layout/custom_layout.png){: .center}
 
-> Custom layouts are only supported for the 'Search Results' Web Part. You can't add custom layout for the 'Search Filters' Web Part.
+> Custom layouts are supported for both the 'Search Results' and the 'Search Filters' Web Parts. Use the `type` property of the layout definition (`LayoutType.Results` or `LayoutType.Filter`) to decide where your layout shows up. The 'Search Filters' Web Part only renders Handlebars layouts (adaptive cards are not supported for filters).
 
 ## Layout creation process
 
@@ -99,7 +99,7 @@ The next step is to fill information about your new layout. In the library main 
 | `name` | The friendly name of your layout that will show up in tiles.
 | `iconName` | An Office UI Fabric icon for your layout.
 | `key` | An unique internal key for your layout.
-| `type` | The layout type (`LayoutType.Results` is for the 'Data Visualizer' Web Part, `LayoutType.Filter` for the 'Data Filter' Web Part). Only **`LayoutType.Results`** is supported for now. You can't add custom layout for the 'Data Filter' Web Part.
+| `type` | The layout type (`LayoutType.Results` is for the 'Search Results' Web Part, `LayoutType.Filter` for the 'Search Filters' Web Part).
 | `renderType` | The layout render type is used to define if your layout is based on HTML, CSS and Handlebars or JSON (adaptive cards).
 | `templateContent` | The template HTML content as string. Use a `require` statement to get the string content from your HTML file. If you reference a JSON file, you must use the stringified value (ex: `JSON.stringify(require('../custom-layout.json'), null, "\t")`)
 | `serviceKey` | A service key used to instanciate your layout class. Builtin or custom data layouts are instanciated dynamically using [SPFx service scopes](https://docs.microsoft.com/en-us/javascript/api/sp-core-library/servicescope?view=sp-typescript-latest).

--- a/docs/extensibility/extensibility_compatibility_matrix.md
+++ b/docs/extensibility/extensibility_compatibility_matrix.md
@@ -8,7 +8,7 @@ The following table lists the SPFx version used by each PnP Modern Search releas
 
 | PnP Modern Search Release | Release Date       | SPFx Version used | Extensibility Package | Toolchain |
 |----------------------------|--------------------|--------------------|----------------------|-----------|
-| 4.23.0                     | _upcoming_         | 1.22.2             | 2.0.1                | Heft      |
+| 4.23.0                     | _upcoming_         | 1.22.2             | 2.1.0                | Heft      |
 | 4.22.0                     | May 2026          | 1.22.2             | 1.22.3               | Heft      |
 | 4.21.0                     | April 2026        | 1.22.2             | 1.22.3               | Heft      |
 | 4.16.0                     | February 2025     | 1.20.0             | 1.20.0               | Gulp      |

--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -41,7 +41,7 @@ Each Web Part type in the solution supports several extensions or no extension a
 | Web Part type | Supported extensions |
 | ------------- | -------------------- |
 | **Search Results** | <ul><li>Custom web components.</li><li>Custom Handlebars [customizations](https://handlebarsjs.com/api-reference/runtime.html) (ex: helpers, partials ,etc.).</li><li>Custom event handlers for adaptive cards actions</li><li>Custom Data Sources</li><li>Custom query modifier</li></ul>
-| **Search Filters** |  <ul><li>Custom web components (_not directly but via the 'Search Results' Web Part extensibility library registration_).</li></ul>
+| **Search Filters** |  <ul><li>Custom filter layouts.</li><li>Custom [filter controls](./custom_filter_control.md).</li><li>Custom web components.</li><li>Custom Handlebars [customizations](https://handlebarsjs.com/api-reference/runtime.html) (ex: helpers, partials, etc.).</li></ul>
 | **Search box** | <ul><li>Custom suggestions providers.</li></ul>
 | **Search Verticals** | None.
 
@@ -196,6 +196,7 @@ The extensibility library requires `html-loader` to load Handlebars templates fr
     !["Extensibility interface implementation"](../assets/extensibility/implement_interface.png){: .center}
 6. Implement your extension(s) depending of the type:
     - [Layout](./custom_layout.md)
+    - [Filter control](./custom_filter_control.md)
     - [Web component](./custom_web_component.md)
     - [Suggestions providers](./custom_suggestions_provider.md)
     - [Handlebars customizations](./handlebars_customizations.md)    
@@ -290,6 +291,10 @@ export class MyCustomLibraryComponent implements IExtensibilityLibrary {
   }
 
   public getCustomWebComponents(): IComponentDefinition<any>[] {
+    return [];
+  }
+
+  public getCustomFilterControls(): IFilterControlDefinition[] {
     return [];
   }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
     - Introduction: extensibility/index.md
     - Templating: extensibility/templating.md
     - Custom layout: extensibility/custom_layout.md
+    - Custom filter control: extensibility/custom_filter_control.md
     - Custom web component: extensibility/custom_web_component.md
     - Custom suggestions provider: extensibility/custom_suggestions_provider.md
     - Custom Handlebars customizations: extensibility/handlebars_customizations.md

--- a/search-extensibility/package.json
+++ b/search-extensibility/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pnp/modern-search-extensibility",
     "description": "Base library for creating PnP Modern Search extensions",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "private": false,
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/search-extensibility/src/index.ts
+++ b/search-extensibility/src/index.ts
@@ -15,6 +15,7 @@ export * from './models/filters/IDataFilterInfo';
 export * from './models/filters/IDataFilterInternal';
 export * from './models/filters/IDataFilterConfiguration';
 export * from './models/filters/IDataFilterToken';
+export * from './models/filters/IFilterControlDefinition';
 export * from './models/filters/FilterBehavior';
 export * from './models/dataSources/PagingBehavior';
 export * from './constants/ExtensibilityConstants';

--- a/search-extensibility/src/models/IExtensibilityLibrary.ts
+++ b/search-extensibility/src/models/IExtensibilityLibrary.ts
@@ -6,6 +6,7 @@ import * as Handlebars from 'handlebars';
 import { IAdaptiveCardAction } from './IAdaptiveCardAction';
 import { IQueryModifierDefinition } from './queryModifier/IQueryModifierDefinition';
 import { IDataSourceDefinition } from './dataSources/IDataSourceDefinition';
+import { IFilterControlDefinition } from './filters/IFilterControlDefinition';
 
 export interface IExtensibilityLibrary {
 
@@ -45,4 +46,9 @@ export interface IExtensibilityLibrary {
      * Returns custom data sources
      */
     getCustomDataSources?(): IDataSourceDefinition[];
+
+    /**
+     * Returns custom filter controls to use in the 'Search Filters' Web Part filters configuration
+     */
+    getCustomFilterControls?(): IFilterControlDefinition[];
 }

--- a/search-extensibility/src/models/filters/IDataFilterConfiguration.ts
+++ b/search-extensibility/src/models/filters/IDataFilterConfiguration.ts
@@ -70,9 +70,11 @@ export interface IDataFilterConfiguration {
     isMulti: boolean;
 
     /**
-     * The type of the filter ('Refiner' or 'Static Filter')
+     * The type of the filter ('Refiner' or 'Static Filter').
+     * Only set for filters using a custom filter control coming from an extensibility library, as the
+     * type of builtin controls is already known by the data sources.
      */
-    // type: FilterType;
+    filterType?: FilterType;
 
     /**
      * If the filter should be sorted by name or by count

--- a/search-extensibility/src/models/filters/IFilterControlDefinition.ts
+++ b/search-extensibility/src/models/filters/IFilterControlDefinition.ts
@@ -1,0 +1,59 @@
+import { FilterType } from "./IDataFilterConfiguration";
+
+/**
+ * Describes a custom filter control (i.e. the UI control used to render the values of a single filter,
+ * like the builtin checkbox, combo box or date range controls) provided by an extensibility library.
+ *
+ * Custom filter controls show up in the filters configuration of the 'Search Filters' Web Part and are
+ * rendered by the builtin filter layouts (vertical, horizontal, panel) as any other builtin control.
+ */
+export interface IFilterControlDefinition {
+
+    /**
+     * The unique key of the control. This value is persisted as the 'selectedTemplate' property
+     * of the filters configuration in the 'Search Filters' Web Part.
+     */
+    key: string;
+
+    /**
+     * The friendly name of the control, displayed in the filters configuration of the property pane.
+     */
+    name: string;
+
+    /**
+     * The name of the custom HTML element (i.e. web component) to render for this control.
+     * The corresponding component must also be returned by 'getCustomWebComponents()' so it gets registered on the page.
+     */
+    componentName: string;
+
+    /**
+     * The type of filter this control implements. Default is 'FilterType.Refiner'.
+     * A 'FilterType.StaticFilter' control provides its own values and is therefore not requested as a refiner/aggregation from the data source.
+     */
+    filterType?: FilterType;
+
+    /**
+     * Renders the builtin AND/OR operator control above the control when the filter allows multiple values. Default is 'false'.
+     */
+    showOperator?: boolean;
+
+    /**
+     * Renders the builtin 'Apply'/'Clear' buttons below the control when the filter allows multiple values. Default is 'false'.
+     */
+    showApplyButtons?: boolean;
+
+    /**
+     * Determines if the 'Multi values' option can be configured for filters using this control. Default is 'true'.
+     */
+    supportsMultiValues?: boolean;
+
+    /**
+     * Determines if the 'Show count' option can be configured for filters using this control. Default is 'true'.
+     */
+    supportsValuesCount?: boolean;
+
+    /**
+     * Determines if the 'Number of values' (i.e. max buckets) option can be configured for filters using this control. Default is 'true'.
+     */
+    supportsMaxBuckets?: boolean;
+}

--- a/search-parts/package.json
+++ b/search-parts/package.json
@@ -31,7 +31,7 @@
         "@microsoft/sp-property-pane": "1.23.0",
         "@microsoft/sp-webpart-base": "1.23.0",
         "@pnp/common": "2.15.0",
-        "@pnp/modern-search-extensibility": "2.0.1",
+        "@pnp/modern-search-extensibility": "2.1.0",
         "@pnp/spfx-controls-react": "3.24.0",
         "@pnp/spfx-property-controls": "3.23.0",
         "@pnp/telemetry-js": "2.0.0",

--- a/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
+++ b/search-parts/src/dataSources/MicrosoftSearchDataSource.ts
@@ -1,4 +1,4 @@
-import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, BuiltinTemplateSlots, IDataContext, ITokenService, FilterBehavior, PagingBehavior, IDataFilter, IDataFilterResult, IDataFilterResultValue, FilterComparisonOperator, FilterConditionOperator, IDataSourceData, SortFieldDirection } from "@pnp/modern-search-extensibility";
+import { BaseDataSource, FilterSortType, FilterSortDirection, ITemplateSlot, BuiltinTemplateSlots, IDataContext, ITokenService, FilterBehavior, PagingBehavior, IDataFilter, IDataFilterResult, IDataFilterResultValue, FilterComparisonOperator, FilterConditionOperator, IDataSourceData, SortFieldDirection, FilterType } from "@pnp/modern-search-extensibility";
 import { IPropertyPaneGroup, PropertyPaneLabel, IPropertyPaneField, PropertyPaneToggle, PropertyPaneHorizontalRule } from "@microsoft/sp-property-pane";
 import { cloneDeep, isEmpty } from '@microsoft/sp-lodash-subset';
 import { MSGraphClientFactory, SPHttpClient } from "@microsoft/sp-http";
@@ -1554,7 +1554,8 @@ export class MicrosoftSearchDataSource extends BaseDataSource<IMicrosoftSearchDa
         this._aggregationFieldAliases.clear();
 
         return dataContext.filters.filtersConfiguration.filter(filterConfig => {
-            return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople;
+            // 'filterType' is only set for filters using a custom filter control from an extensibility library
+            return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople && filterConfig.filterType !== FilterType.StaticFilter;
         }).map(filterConfig => {
             const normalizedFieldName = this.normalizeAggregationFieldName(filterConfig.filterName);
             this._aggregationFieldAliases.set(normalizedFieldName.toLowerCase(), filterConfig.filterName);

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -1,5 +1,5 @@
 ﻿import * as React from 'react';
-import { IDataSourceData, BaseDataSource, ITokenService, ITemplateSlot, IDataFilterResult, IDataFilterResultValue, BuiltinTemplateSlots, FilterBehavior, FilterSortType, FilterSortDirection } from "@pnp/modern-search-extensibility";
+import { IDataSourceData, BaseDataSource, ITokenService, ITemplateSlot, IDataFilterResult, IDataFilterResultValue, BuiltinTemplateSlots, FilterBehavior, FilterSortType, FilterSortDirection, FilterType } from "@pnp/modern-search-extensibility";
 import {
     IPropertyPaneGroup,
     IPropertyPaneDropdownOption,
@@ -1012,7 +1012,8 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
             // Set list of refiners to retrieve
             searchQuery.Refiners = dataContext.filters.filtersConfiguration.filter(filterConfig => {
-                return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople;
+                // 'filterType' is only set for filters using a custom filter control from an extensibility library
+                return filterConfig.selectedTemplate !== BuiltinFilterTemplates.StaticPeople && filterConfig.filterType !== FilterType.StaticFilter;
             }).map(filterConfig => {
 
                 // Special case with Date managed properties

--- a/search-parts/src/helpers/ExtensibilityUsageHelper.ts
+++ b/search-parts/src/helpers/ExtensibilityUsageHelper.ts
@@ -52,6 +52,27 @@ export interface IResultsExtensibilityInput {
 }
 
 /**
+ * Inputs required to evaluate whether a Search Filters Web Part instance uses any
+ * custom extensibility feature.
+ */
+export interface IFiltersExtensibilityInput {
+    selectedLayoutKey: string;
+    filtersConfiguration: { selectedTemplate: string }[];
+    inlineTemplateContent: string;
+    externalTemplateUrl: string;
+    layoutProperties: { [key: string]: any };
+    templateService: ITemplateService;
+
+    /**
+     * Built-in ("out-of-the-box") identifiers, passed in by the caller so this helper does not have
+     * to eagerly import the heavy modules that define them.
+     */
+    builtinLayoutKeys: string[];
+    builtinFilterTemplateKeys: string[];
+    builtinComponentNames: string[];
+}
+
+/**
  * Inputs required to evaluate whether a Search Box Web Part instance uses any
  * custom extensibility feature.
  */
@@ -143,6 +164,65 @@ export class ExtensibilityUsageHelper {
 
         // 7. Custom Handlebars helpers / partials (registerHandlebarsCustomizations). Ensure the
         // out-of-the-box helpers/partials are registered first so custom ones can be told apart.
+        await input.templateService.ensureHandlebarsHelpersLoaded();
+        const handlebars: any = input.templateService.Handlebars;
+        if (!handlebars || typeof handlebars.parse !== "function") {
+            return { usesCustomExtensibility: true, reason: "Handlebars namespace unavailable (conservative)" };
+        }
+
+        const customHandlebars = this.findCustomHandlebars(templates, handlebars);
+        if (customHandlebars) {
+            return { usesCustomExtensibility: true, reason: `custom Handlebars ${customHandlebars}` };
+        }
+
+        return { usesCustomExtensibility: false, reason: "only out-of-the-box features are used" };
+    }
+
+    /**
+     * Evaluates whether a Search Filters Web Part instance uses any custom extensibility feature.
+     */
+    public static async getFiltersUsage(input: IFiltersExtensibilityInput): Promise<IExtensibilityUsageResult> {
+
+        // 1. Custom filter layout (getCustomLayouts)
+        if (input.selectedLayoutKey && input.builtinLayoutKeys.indexOf(input.selectedLayoutKey) === -1) {
+            return { usesCustomExtensibility: true, reason: `custom layout '${input.selectedLayoutKey}'` };
+        }
+
+        // 2. Custom filter control (getCustomFilterControls)
+        const customControl = (input.filtersConfiguration || []).filter(
+            configuration => configuration && configuration.selectedTemplate && input.builtinFilterTemplateKeys.indexOf(configuration.selectedTemplate) === -1
+        )[0];
+
+        if (customControl) {
+            return { usesCustomExtensibility: true, reason: `custom filter control '${customControl.selectedTemplate}'` };
+        }
+
+        // 3. External templates cannot be inspected up front — be conservative and load.
+        if (input.externalTemplateUrl) {
+            return { usesCustomExtensibility: true, reason: "an external template that cannot be inspected" };
+        }
+
+        const templates: string[] = [];
+        const state = { truncated: false };
+
+        if (input.inlineTemplateContent) {
+            templates.push(input.inlineTemplateContent);
+        }
+
+        this.collectStrings(input.layoutProperties, templates, 0, state);
+
+        if (state.truncated) {
+            return { usesCustomExtensibility: true, reason: "a configuration too large to fully inspect" };
+        }
+
+        // 4. Custom web components (getCustomWebComponents) referenced in the template.
+        const oobComponents = new Set((input.builtinComponentNames || []).map(n => (n || "").toLowerCase()));
+        const customComponent = this.findCustomComponent(templates, oobComponents);
+        if (customComponent) {
+            return { usesCustomExtensibility: true, reason: `custom web component '<${customComponent}>'` };
+        }
+
+        // 5. Custom Handlebars helpers / partials (registerHandlebarsCustomizations).
         await input.templateService.ensureHandlebarsHelpersLoaded();
         const handlebars: any = input.templateService.Handlebars;
         if (!handlebars || typeof handlebars.parse !== "function") {

--- a/search-parts/src/helpers/FilterControlHelper.ts
+++ b/search-parts/src/helpers/FilterControlHelper.ts
@@ -1,0 +1,69 @@
+import { FilterType, IFilterControlDefinition } from "@pnp/modern-search-extensibility";
+import { BuiltinFilterTypes } from "../layouts/AvailableTemplates";
+
+/**
+ * Helper resolving information about the control (i.e. 'selectedTemplate') configured for a filter,
+ * regardless of whether it is a builtin control or one provided by an extensibility library.
+ */
+export class FilterControlHelper {
+
+    /**
+     * Returns the custom filter control definition matching a selected template, if any.
+     * @param selectedTemplate the template key configured for the filter
+     * @param customFilterControls the custom filter controls loaded from the extensibility libraries
+     */
+    public static getCustomControl(selectedTemplate: string, customFilterControls: IFilterControlDefinition[]): IFilterControlDefinition {
+
+        if (!selectedTemplate || !customFilterControls || customFilterControls.length === 0) {
+            return undefined;
+        }
+
+        return customFilterControls.filter(control => control && control.key === selectedTemplate)[0];
+    }
+
+    /**
+     * Returns the filter type for a selected template. Custom controls default to 'Refiner' when they don't specify one.
+     * Returns 'undefined' when the template is unknown (ex: the extensibility library is not deployed anymore).
+     * @param selectedTemplate the template key configured for the filter
+     * @param customFilterControls the custom filter controls loaded from the extensibility libraries
+     */
+    public static getFilterType(selectedTemplate: string, customFilterControls: IFilterControlDefinition[]): FilterType {
+
+        const builtinType = BuiltinFilterTypes[selectedTemplate];
+
+        if (builtinType) {
+            return builtinType;
+        }
+
+        const customControl = this.getCustomControl(selectedTemplate, customFilterControls);
+
+        return customControl ? (customControl.filterType || FilterType.Refiner) : undefined;
+    }
+
+    /**
+     * Determines if an option of the filters configuration is supported by the custom control configured for a filter.
+     * Builtin controls (i.e. no matching custom control) are left untouched and always return 'true'.
+     * @param selectedTemplate the template key configured for the filter
+     * @param customFilterControls the custom filter controls loaded from the extensibility libraries
+     * @param option the filters configuration option to check
+     */
+    public static supportsOption(selectedTemplate: string, customFilterControls: IFilterControlDefinition[], option: 'multiValues' | 'valuesCount' | 'maxBuckets'): boolean {
+
+        const customControl = this.getCustomControl(selectedTemplate, customFilterControls);
+
+        if (!customControl) {
+            return true;
+        }
+
+        switch (option) {
+            case 'multiValues':
+                return customControl.supportsMultiValues !== false;
+            case 'valuesCount':
+                return customControl.supportsValuesCount !== false;
+            case 'maxBuckets':
+                return customControl.supportsMaxBuckets !== false;
+            default:
+                return true;
+        }
+    }
+}

--- a/search-parts/src/helpers/FilterControlHelper.ts
+++ b/search-parts/src/helpers/FilterControlHelper.ts
@@ -1,4 +1,4 @@
-import { FilterType, IFilterControlDefinition } from "@pnp/modern-search-extensibility";
+import { FilterConditionOperator, FilterType, IDataFilterConfiguration, IFilterControlDefinition } from "@pnp/modern-search-extensibility";
 import { BuiltinFilterTypes } from "../layouts/AvailableTemplates";
 
 /**
@@ -65,5 +65,62 @@ export class FilterControlHelper {
             default:
                 return true;
         }
+    }
+
+    /**
+     * Returns the filters configuration where the filters using a custom filter control get their resolved filter type
+     * and the options unsupported by their control reset to the default value.
+     *
+     * The property pane only disables the unsupported options, so a value persisted before the custom control was
+     * selected (or before the control opted out from an option) has to be normalized here to make sure everything
+     * relying on the configuration (rendering, connected data sources, ...) sees the effective values.
+     *
+     * @param configurations the filters configuration coming from the property pane
+     * @param customFilterControls the custom filter controls loaded from the extensibility libraries
+     */
+    public static normalizeConfigurations<T extends IDataFilterConfiguration>(configurations: T[], customFilterControls: IFilterControlDefinition[]): T[] {
+
+        if (!configurations || configurations.length === 0 || !customFilterControls || customFilterControls.length === 0) {
+            return configurations;
+        }
+
+        return configurations.map(configuration => this.normalizeConfiguration(configuration, customFilterControls));
+    }
+
+    /**
+     * Normalizes a single filter configuration. Configurations using a builtin control are returned untouched.
+     * @param configuration the filter configuration coming from the property pane
+     * @param customFilterControls the custom filter controls loaded from the extensibility libraries
+     */
+    public static normalizeConfiguration<T extends IDataFilterConfiguration>(configuration: T, customFilterControls: IFilterControlDefinition[]): T {
+
+        const customControl = configuration ? this.getCustomControl(configuration.selectedTemplate, customFilterControls) : undefined;
+
+        if (!customControl) {
+            return configuration;
+        }
+
+        const normalized: T & { showLimitExceededWarning?: boolean } = {
+            ...configuration,
+            filterType: customControl.filterType || FilterType.Refiner
+        };
+
+        if (customControl.supportsMultiValues === false) {
+            // Without multi values, the operator between values is meaningless
+            normalized.isMulti = false;
+            normalized.operator = FilterConditionOperator.AND;
+        }
+
+        if (customControl.supportsValuesCount === false) {
+            normalized.showCount = false;
+        }
+
+        if (customControl.supportsMaxBuckets === false) {
+            // Leaving it empty makes the data sources fall back to their default number of buckets
+            normalized.maxBuckets = undefined;
+            normalized.showLimitExceededWarning = false;
+        }
+
+        return normalized;
     }
 }

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -279,14 +279,16 @@
 											{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 												<div class="filter--value-hierarchical">
 													{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
-													<pnp-filterhierarchical 
-														data-instance-id="{{@root.instanceId}}" 
+													<pnp-filterhierarchical
+														data-instance-id="{{@root.instanceId}}"
 														data-filter="{{JSONstringify filter 2}}"
 														data-selected-filters="{{JSONstringify @root.selectedFilters 2}}"
 														data-theme-variant="{{JSONstringify @root.theme}}"
 													>
 													</pnp-filterhierarchical>
 												</div>
+											{{else}}
+												{{{customFilterControl filter @root.instanceId @root.theme @root.selectedFilters}}}
 											{{/eq}}
 										{{/eq}}	
 										{{/eq}}
@@ -297,6 +299,9 @@
 						</template>
 
 						<template id="collapsible-footer">
+							{{#isCustomFilterControl filter}}
+								{{{customFilterControlFooter filter @root.instanceId @root.theme}}}
+							{{else}}
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
 								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
@@ -321,6 +326,7 @@
 									{{/eq}}
 								{{/eq}}
 							{{/isnt}}
+							{{/isCustomFilterControl}}
 						</template>
 
 					</pnp-collapsible>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -300,14 +300,16 @@
                                                             {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
                                                                 <div class="filter--value-hierarchical">
                                                                     {{{hierarchicalOperator filter @root.instanceId @root.theme}}}
-                                                                    <pnp-filterhierarchical 
-                                                                        data-instance-id="{{@root.instanceId}}" 
+                                                                    <pnp-filterhierarchical
+                                                                        data-instance-id="{{@root.instanceId}}"
                                                                         data-filter="{{JSONstringify filter 2}}"
                                                                         data-selected-filters="{{JSONstringify @root.selectedFilters 2}}"
                                                                         data-theme-variant="{{JSONstringify @root.theme}}"
                                                                     >
                                                                     </pnp-filterhierarchical>
                                                                 </div>
+                                                            {{else}}
+                                                                {{{customFilterControl filter @root.instanceId @root.theme @root.selectedFilters}}}
                                                             {{/eq}}
                                                         {{/eq}}
 														{{/eq}}
@@ -318,6 +320,9 @@
                                         </template>
                 
                                         <template id="collapsible-footer">
+                                            {{#isCustomFilterControl filter}}
+                                                {{{customFilterControlFooter filter @root.instanceId @root.theme}}}
+                                            {{else}}
                                             {{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
                                                 {{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
                                                     {{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
@@ -344,6 +349,7 @@
                                                     {{/isnt}}
                                                 {{/eq}}
                                             {{/isnt}}
+                                            {{/isCustomFilterControl}}
                                         </template>
                 
                                     </pnp-collapsible>

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -266,14 +266,16 @@
 												{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 													<div class="filter--value-hierarchical">
 														{{{hierarchicalOperator filter @root.instanceId @root.theme}}}
-														<pnp-filterhierarchical 
-															data-instance-id="{{@root.instanceId}}" 
+														<pnp-filterhierarchical
+															data-instance-id="{{@root.instanceId}}"
 															data-filter="{{JSONstringify filter 2}}"
 															data-selected-filters="{{JSONstringify @root.selectedFilters 2}}"
 															data-theme-variant="{{JSONstringify @root.theme}}"
 														>
 														</pnp-filterhierarchical>
 													</div>
+												{{else}}
+													{{{customFilterControl filter @root.instanceId @root.theme @root.selectedFilters}}}
 												{{/eq}}
 											{{/eq}}	
 										{{/eq}}
@@ -284,6 +286,9 @@
 						</template>
 
 						<template id="collapsible-footer">
+							{{#isCustomFilterControl filter}}
+								{{{customFilterControlFooter filter @root.instanceId @root.theme}}}
+							{{else}}
 							{{#isnt filter.selectedTemplate 'DateRangeFilterTemplate'}}
 								{{#eq filter.selectedTemplate 'HierarchicalFilterTemplate'}}
 									{{{hierarchicalMultiselect filter @root.instanceId @root.theme}}}
@@ -318,6 +323,7 @@
 									{{/eq}}
 								{{/eq}}
 							{{/isnt}}
+							{{/isCustomFilterControl}}
 						</template>
 
 					</pnp-collapsible>

--- a/search-parts/src/services/templateService/ITemplateService.ts
+++ b/search-parts/src/services/templateService/ITemplateService.ts
@@ -1,6 +1,7 @@
 import {
   IComponentDefinition,
   IExtensibilityLibrary,
+  IFilterControlDefinition,
   LayoutRenderType,
 } from "@pnp/modern-search-extensibility";
 import { IDataResultType } from "../../models/common/IDataResultType";
@@ -16,6 +17,7 @@ export interface ITemplateService {
   TEMPLATE_ID_PREFIX: string;
   Handlebars: typeof Handlebars;
   AdaptiveCardsExtensibilityLibraries: IExtensibilityLibrary[];
+  CustomFilterControls: IFilterControlDefinition[];
   MgtCustomElementHelper: any;
   getTemplateMarkup(templateContent: string): string;
   getPlaceholderMarkup(templateContent: string): string;

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -25,6 +25,7 @@ import { PageContext } from "@microsoft/sp-page-context";
 import {
     IComponentDefinition,
     IExtensibilityLibrary,
+    IFilterControlDefinition,
     IResultTemplates,
     LayoutRenderType,
 } from "@pnp/modern-search-extensibility";
@@ -120,6 +121,19 @@ export class TemplateService implements ITemplateService {
 
     set AdaptiveCardsExtensibilityLibraries(value: IExtensibilityLibrary[]) {
         this._adaptiveCardsExtensibilityLibraries = value;
+    }
+
+    /**
+     * Custom filter controls coming from extensibility libraries, if any
+     */
+    private _customFilterControls: IFilterControlDefinition[] = [];
+
+    get CustomFilterControls(): IFilterControlDefinition[] {
+        return this._customFilterControls;
+    }
+
+    set CustomFilterControls(value: IFilterControlDefinition[]) {
+        this._customFilterControls = value || [];
     }
 
     get TEMPLATE_ID_PREFIX(): string {
@@ -1315,6 +1329,90 @@ export class TemplateService implements ITemplateService {
                 </pnp-filtermultiselect>
             `);
         });
+
+        // Block helper used by the builtin filter layouts to branch on filters rendered by a custom
+        // filter control coming from an extensibility library.
+        // Usage: {{#isCustomFilterControl filter}} custom {{else}} builtin {{/isCustomFilterControl}}
+        const getCustomFilterControls = () => this._customFilterControls;
+        this.Handlebars.registerHelper("isCustomFilterControl", function (this: unknown, filter: any, options: any) {
+            const isCustom = !!TemplateService.getFilterControlDefinition(filter, getCustomFilterControls());
+            return isCustom ? options.fn(this) : options.inverse(this);
+        });
+
+        // Renders the custom filter control registered for a filter, optionally prefixed by the
+        // builtin AND/OR operator control when the control opted in for it.
+        this.Handlebars.registerHelper("customFilterControl", (filter: any, instanceId: string, theme: any, selectedFilters: any) => {
+
+            const definition = TemplateService.getFilterControlDefinition(filter, this._customFilterControls);
+
+            if (!definition) {
+                return "";
+            }
+
+            const serializedTheme = escapeFn(JSON.stringify(theme));
+
+            const operatorMarkup = definition.showOperator && filter.isMulti ? `
+                <div class="filter--option">
+                    <pnp-filteroperator
+                        data-instance-id="${escapeFn(instanceId)}"
+                        data-filter-name="${escapeFn(filter.filterName)}"
+                        data-operator="${escapeFn(filter.operator)}"
+                        data-theme-variant="${serializedTheme}"
+                    ></pnp-filteroperator>
+                </div>
+            ` : "";
+
+            const componentName = escapeFn(definition.componentName);
+
+            return new hb.SafeString(`
+                ${operatorMarkup}
+                <div class="filter--value">
+                    <${componentName}
+                        data-instance-id="${escapeFn(instanceId)}"
+                        data-filter-name="${escapeFn(filter.filterName)}"
+                        data-filter="${escapeFn(JSON.stringify(filter))}"
+                        data-selected-filters="${escapeFn(JSON.stringify(selectedFilters))}"
+                        data-is-multi="${filter.isMulti ? 'true' : 'false'}"
+                        data-show-count="${filter.showCount ? 'true' : 'false'}"
+                        data-operator="${escapeFn(filter.operator)}"
+                        data-theme-variant="${serializedTheme}"
+                    ></${componentName}>
+                </div>
+            `);
+        });
+
+        // Renders the builtin 'Apply'/'Clear' buttons for a custom filter control which opted in for them.
+        this.Handlebars.registerHelper("customFilterControlFooter", (filter: any, instanceId: string, theme: any) => {
+
+            const definition = TemplateService.getFilterControlDefinition(filter, this._customFilterControls);
+
+            if (!definition || !definition.showApplyButtons || !filter.isMulti) {
+                return "";
+            }
+
+            return new hb.SafeString(`
+                <pnp-filtermultiselect
+                    data-instance-id="${escapeFn(instanceId)}"
+                    data-filter-name="${escapeFn(filter.filterName)}"
+                    data-apply-disabled="${filter.canApply ? 'false' : 'true'}"
+                    data-clear-disabled="${filter.canClear ? 'false' : 'true'}"
+                    data-theme-variant="${escapeFn(JSON.stringify(theme))}"
+                >
+                </pnp-filtermultiselect>
+            `);
+        });
+    }
+
+    /**
+     * Resolves the custom filter control definition matching the template selected for a filter, if any.
+     */
+    private static getFilterControlDefinition(filter: any, customFilterControls: IFilterControlDefinition[]): IFilterControlDefinition {
+
+        if (!filter || !filter.selectedTemplate || !customFilterControls || customFilterControls.length === 0) {
+            return undefined;
+        }
+
+        return customFilterControls.filter(control => control && control.key === filter.selectedTemplate && control.componentName)[0];
     }
 
     private async _initAdaptiveCardsResources(): Promise<void> {

--- a/search-parts/src/webparts/searchFilters/ISearchFiltersWebPartProps.ts
+++ b/search-parts/src/webparts/searchFilters/ISearchFiltersWebPartProps.ts
@@ -1,5 +1,6 @@
 import { IBaseWebPartProps } from "../../models/common/IBaseWebPartProps";
 import { IDataFilterConfiguration, FilterConditionOperator } from "@pnp/modern-search-extensibility";
+import { IExtensibilityConfiguration } from "../../models/common/IExtensibilityConfiguration";
 
 export default interface ISearchFiltersWebPartProps extends IBaseWebPartProps {
     
@@ -58,6 +59,11 @@ export default interface ISearchFiltersWebPartProps extends IBaseWebPartProps {
      * The selected vertical fro the Web Part
      */
     selectedVerticalKeys: string[];
+
+    /**
+     * The extensibility configuration to load
+     */
+    extensibilityLibraryConfiguration: IExtensibilityConfiguration[];
 
     /**
      * Filter panel background color

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -27,7 +27,7 @@ import { DynamicDataService } from '../../services/dynamicDataService/DynamicDat
 import { IDynamicDataCallables, IDynamicDataPropertyDefinition } from '@microsoft/sp-dynamic-data';
 import { ComponentType } from '../../common/ComponentType';
 import { IDataFilterSourceData } from '../../models/dynamicData/IDataFilterSourceData';
-import { IDataFilter, ILayoutDefinition, LayoutType, ILayout, FilterConditionOperator, IDataFilterResult, IDataFilterConfiguration, FilterType, IDataFilterResultValue, IComponentDefinition, FilterSortType, FilterSortDirection } from '@pnp/modern-search-extensibility';
+import { IDataFilter, ILayoutDefinition, LayoutType, ILayout, FilterConditionOperator, IDataFilterResult, IDataFilterConfiguration, FilterType, IDataFilterResultValue, IComponentDefinition, FilterSortType, FilterSortDirection, IExtensibilityLibrary, IFilterControlDefinition } from '@pnp/modern-search-extensibility';
 import { AsyncCombo } from '../../controls/PropertyPaneAsyncCombo/components/AsyncCombo';
 import { IAsyncComboProps } from '../../controls/PropertyPaneAsyncCombo/components/IAsyncComboProps';
 import { AvailableLayouts, BuiltinLayoutsKeys } from '../../layouts/AvailableLayouts';
@@ -50,6 +50,11 @@ import { ITaxonomyService } from '../../services/taxonomyService/ITaxonomyServic
 import { TaxonomyService } from '../../services/taxonomyService/TaxonomyService';
 import { Dropdown, IDropdownOption, IDropdownProps } from '@fluentui/react/lib/Dropdown';
 import { TextField } from '@fluentui/react/lib/TextField';
+import { Toggle, IToggleProps } from '@fluentui/react/lib/Toggle';
+import { IExtensibilityConfiguration } from '../../models/common/IExtensibilityConfiguration';
+import { ExtensibilityUsageHelper } from '../../helpers/ExtensibilityUsageHelper';
+import { FilterControlHelper } from '../../helpers/FilterControlHelper';
+import { Constants } from '../../common/Constants';
 
 const LogSource = "SearchFiltersWebPart";
 
@@ -115,6 +120,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     private templateContentToDisplay: string;
 
     /**
+     * The error message to display when the Web Part configuration can't be resolved (ex: a custom layout
+     * coming from an extensibility library which is not available anymore)
+     */
+    private errorMessage: string;
+
+    /**
      * The template service instance
      */
     private templateService: ITemplateService = undefined;
@@ -143,6 +154,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
      * The available web component definitions (not registered yet)
      */
     private availableWebComponentDefinitions: IComponentDefinition<any>[] = [];
+
+    /**
+     * The custom filter control definitions coming from the registered extensibility libraries
+     */
+    private availableFilterControlDefinitions: IFilterControlDefinition[] = [];
 
     /**
      * The available connections as property pane fields
@@ -246,11 +262,14 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         // That's why we need to fetch the licence info before calling this method
         this.ensureDynamicDataSourcesConnection();
 
+        // Load extensions from the registered extensibility libraries (custom layouts, filter controls,
+        // web components and Handlebars customizations). This must happen BEFORE the web components get
+        // registered so custom components are part of the same registration pass.
+        await this.loadExtensions(this.properties.extensibilityLibraryConfiguration);
+
         // Register Web Components in the global page context. We need to do this BEFORE the template processing to avoid race condition.
         // Web components are only defined once.
         // We need to register components here in the case where the Search Results WP is not present on the page
-        const { AvailableComponents } = await import(/* webpackChunkName: 'pnp-modern-search-web-components' */ '../../components/AvailableComponents');
-        this.availableWebComponentDefinitions = AvailableComponents.BuiltinComponents;
         await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
 
         return super.onInit();
@@ -275,20 +294,34 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             return this.renderCompleted();
         }
 
-        // Determine the template content to display
-        // In the case of an external template is selected, the render is done asynchronously waiting for the content to be fetched
-        await this.initTemplate();
+        // Reset the error message every time
+        this.errorMessage = undefined;
 
-        // Re-check disposal after the awaited audience/template work before resolving the layout
-        // instance, which uses this.context (torn down on dispose).
-        if (this._webPartDisposed || !this.context) {
-            return;
+        try {
+
+            // Determine the template content to display
+            // In the case of an external template is selected, the render is done asynchronously waiting for the content to be fetched
+            await this.initTemplate();
+
+            // Re-check disposal after the awaited audience/template work before resolving the layout
+            // instance, which uses this.context (torn down on dispose).
+            if (this._webPartDisposed || !this.context) {
+                return;
+            }
+
+            // Get and initialize layout instance if different (i.e avoid to create a new instance every time)
+            if (this.lastLayoutKey !== this.properties.selectedLayoutKey) {
+                this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions, this.displayMode);
+                this.lastLayoutKey = this.properties.selectedLayoutKey;
+            }
+
+        } catch (error) {
+            // Catch instanciation or wrong definition errors for extensibility scenarios
+            this.errorMessage = error.message ? error.message : error;
         }
 
-        // Get and initialize layout instance if different (i.e avoid to create a new instance every time)
-        if (this.lastLayoutKey !== this.properties.selectedLayoutKey) {
-            this.layout = await LayoutHelper.getLayoutInstance(this.webPartInstanceServiceScope, this.context, this.properties, this.properties.selectedLayoutKey, this.availableLayoutDefinitions, this.displayMode);
-            this.lastLayoutKey = this.properties.selectedLayoutKey;
+        if (this._webPartDisposed || !this.context) {
+            return;
         }
 
         // Refresh the property pane to get layout and data source options.
@@ -317,8 +350,18 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         let renderRootElement: JSX.Element = null;
         let filterResults: IDataFilterResult[] = [];
 
-        // Display the Web Part only if a valid configuration is set
-        if (this.templateContentToDisplay && this.properties.filtersConfiguration.length > 0) {
+        // An extensibility error (ex: a custom layout coming from a library which is not deployed anymore)
+        // prevents any rendering, so surface it instead of silently displaying nothing.
+        if (this.errorMessage) {
+
+            renderRootElement = React.createElement(
+                MessageBar,
+                { messageBarType: MessageBarType.error },
+                this.errorMessage
+            );
+
+        } else if (this.templateContentToDisplay && this.properties.filtersConfiguration.length > 0) {
+            // Display the Web Part only if a valid configuration is set
 
             // Get data from connected sources
             if (this._dataSourceDynamicProperties.length > 0) {
@@ -469,7 +512,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
             case propertyId:
                 return {
-                    filterConfiguration: this.properties.filtersConfiguration,
+                    filterConfiguration: this.getResolvedFiltersConfiguration(),
                     selectedFilters: this._selectedFilters,
                     filterOperator: this.properties.filterOperator,
                     instanceId: this.instanceId,
@@ -479,6 +522,32 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             default:
                 throw new Error('Bad property id');
         }
+    }
+
+    /**
+     * Returns the filters configuration to share with connected Web Parts, resolving the filter type of the
+     * filters using a custom filter control. Connected data sources don't know about the custom controls
+     * registered here, so they rely on that information to skip refiners/aggregations for static filters.
+     */
+    private getResolvedFiltersConfiguration(): IDataFilterConfiguration[] {
+
+        if (this.availableFilterControlDefinitions.length === 0) {
+            return this.properties.filtersConfiguration;
+        }
+
+        return this.properties.filtersConfiguration.map(configuration => {
+
+            const customControl = FilterControlHelper.getCustomControl(configuration.selectedTemplate, this.availableFilterControlDefinitions);
+
+            if (!customControl) {
+                return configuration;
+            }
+
+            return {
+                ...configuration,
+                filterType: customControl.filterType || FilterType.Refiner
+            };
+        });
     }
 
     public onCustomPropertyUpdate(propertyPath: string, newValue: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
@@ -532,6 +601,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     ...this.getPropertyPaneWebPartInfoGroups(),
                     this.getAudienceTargetingPropertyPaneGroup(),
                     {
+                        groupName: commonStrings.PropertyPane.InformationPage.Extensibility.GroupName,
+                        groupFields: this.getExtensibilityFields()
+                    },
+                    {
                         groupName: commonStrings.PropertyPane.InformationPage.ImportExport,
                         groupFields: [this._propertyPanePropertyEditor({
                             webpart: this,
@@ -549,6 +622,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
     protected async onPropertyPaneConfigurationStart() {
         await this.loadPropertyPaneResources();
+
+        // Force the load of the enabled libraries so custom layouts and filter controls are selectable
+        // in the property pane, even if the current configuration doesn't use anything custom yet.
+        await this.loadExtensions(this.properties.extensibilityLibraryConfiguration, true);
+        await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
 
         if (this.groupedTermSets.size === 0) {
             await this._loadTermSets();
@@ -633,6 +711,20 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 this.properties.verticalsDataSourceReference = undefined;
                 this.properties.selectedVerticalKeys = [];
                 this._verticalsSourceData = undefined;
+            }
+        }
+
+        if (propertyPath.localeCompare('extensibilityLibraryConfiguration') === 0) {
+
+            // Remove duplicates if any
+            this.properties.extensibilityLibraryConfiguration = uniqBy(this.properties.extensibilityLibraryConfiguration, 'id');
+
+            await this.loadExtensions(this.properties.extensibilityLibraryConfiguration, true);
+            await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+
+            // The selected layout may come from a library which is not loaded anymore
+            if (this.availableLayoutDefinitions.filter(layout => layout.key === this.properties.selectedLayoutKey).length === 0) {
+                this.properties.selectedLayoutKey = BuiltinLayoutsKeys.Vertical;
             }
         }
 
@@ -835,6 +927,14 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     }
 
     /**
+     * Determines if a filters configuration option is supported by the control selected for a filter.
+     * Builtin controls always support all options, custom controls can opt out from the ones they don't use.
+     */
+    private supportsFilterOption(selectedTemplate: string, option: 'multiValues' | 'valuesCount' | 'maxBuckets'): boolean {
+        return FilterControlHelper.supportsOption(selectedTemplate, this.availableFilterControlDefinitions, option);
+    }
+
+    /**
      * Determines the group fields for filters settings
      */
     private getFilterSettings(): IPropertyPaneField<any>[] {
@@ -934,7 +1034,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                                 key: `${field.id}-${itemId}`,
                                 type: 'number',
                                 value: value ? value.toString() : '',
-                                disabled: item.selectedTemplate === BuiltinFilterTemplates.StaticPeople,
+                                disabled: item.selectedTemplate === BuiltinFilterTemplates.StaticPeople || !this.supportsFilterOption(item.selectedTemplate, 'maxBuckets'),
                                 errorMessage: errorMessage,
                                 onChange: (ev, newValue) => {
                                     const parsedValue = newValue && newValue.trim() !== '' ? parseInt(newValue, 10) : undefined;
@@ -952,7 +1052,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                             return React.createElement("div", { key: `${field.id}-${itemId}` },
                                 React.createElement(Checkbox, {
                                     defaultChecked: item.showLimitExceededWarning ?? false,
-                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval || item.selectedTemplate === BuiltinFilterTemplates.StaticPeople,
+                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval || item.selectedTemplate === BuiltinFilterTemplates.StaticPeople || !this.supportsFilterOption(item.selectedTemplate, 'maxBuckets'),
                                     onChange: (ev, checked: boolean) => {
                                         onUpdate(field.id, checked);
                                     }
@@ -993,7 +1093,14 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                             {
                                 key: BuiltinFilterTemplates.Hierarchical,
                                 text: webPartStrings.PropertyPane.DataFilterCollection.Templates.HierarchicalFilterTemplate
-                            }
+                            },
+                            // Filter controls coming from the registered extensibility libraries
+                            ...this.availableFilterControlDefinitions.map(control => {
+                                return {
+                                    key: control.key,
+                                    text: control.name ? control.name : control.key
+                                };
+                            })
                         ]
                     },
 
@@ -1022,8 +1129,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                         onCustomRender: (field, value, onUpdate, item: IDataFilterConfiguration, itemId) => {
                             return React.createElement("div", { key: `${field.id}-${itemId}` },
                                 React.createElement(Checkbox, {
-                                    defaultChecked: item.selectedTemplate === BuiltinFilterTemplates.DateRange ? false : item.showCount,
-                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange,
+                                    defaultChecked: item.selectedTemplate === BuiltinFilterTemplates.DateRange || !this.supportsFilterOption(item.selectedTemplate, 'valuesCount') ? false : item.showCount,
+                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || !this.supportsFilterOption(item.selectedTemplate, 'valuesCount'),
                                     onChange: (ev, checked: boolean) => {
                                         onUpdate(field.id, checked);
                                     }
@@ -1039,8 +1146,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                         onCustomRender: (field, value, onUpdate, item: IDataFilterConfiguration, itemId) => {
                             return React.createElement("div", { key: `${field.id}-${itemId}` },
                                 React.createElement(Checkbox, {
-                                    defaultChecked: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval ? false : item.isMulti,
-                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval,
+                                    defaultChecked: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval || !this.supportsFilterOption(item.selectedTemplate, 'multiValues') ? false : item.isMulti,
+                                    disabled: item.selectedTemplate === BuiltinFilterTemplates.DateRange || item.selectedTemplate === BuiltinFilterTemplates.DateInterval || !this.supportsFilterOption(item.selectedTemplate, 'multiValues'),
                                     onChange: (ev, checked: boolean) => {
                                         onUpdate(field.id, checked);
                                     }
@@ -1649,8 +1756,15 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
      */
     private async initTemplate(): Promise<void> {
 
-        // Gets the template content according to the selected key
-        const selectedLayoutTemplateContent = this.availableLayoutDefinitions.filter(layout => { return layout.key === this.properties.selectedLayoutKey; })[0].templateContent;
+        // Gets the template content according to the selected key. The matching definition can be missing when
+        // the layout comes from an extensibility library which is not deployed or registered anymore.
+        const selectedLayoutDefinition = this.availableLayoutDefinitions.filter(layout => { return layout.key === this.properties.selectedLayoutKey; })[0];
+
+        if (!selectedLayoutDefinition) {
+            throw new Error(Text.format(commonStrings.General.Extensibility.LayoutDefinitionNotFound, this.properties.selectedLayoutKey));
+        }
+
+        const selectedLayoutTemplateContent = selectedLayoutDefinition.templateContent;
 
         if (this.properties.selectedLayoutKey === BuiltinLayoutsKeys.FiltersCustom) {
 
@@ -1698,6 +1812,168 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         if (this.properties.selectedVerticalKeys === undefined) {
             this.properties.selectedVerticalKeys = [];
         }
+
+        // Seed an example row (disabled by default) so the property pane shows users
+        // where to add their extension manifest IDs. Disabled — it doesn't try to load.
+        this.properties.extensibilityLibraryConfiguration = this.properties.extensibilityLibraryConfiguration ? this.properties.extensibilityLibraryConfiguration : [{
+            name: commonStrings.General.Extensibility.DefaultExtensibilityLibraryName,
+            enabled: false,
+            id: Constants.DEFAULT_EXTENSIBILITY_LIBRARY_COMPONENT_ID
+        }];
+    }
+
+    /**
+     * Loads extensions from the registered extensibility libraries
+     * @param librariesConfiguration the extensibility libraries configured on the Web Part
+     * @param forceLoad loads the libraries even if nothing custom is currently used (i.e. from the property pane, so custom
+     * layouts and filter controls become selectable before anything custom has been applied)
+     */
+    private async loadExtensions(librariesConfiguration: IExtensibilityConfiguration[], forceLoad: boolean = false) {
+
+        const { AvailableComponents } = await import(
+            /* webpackChunkName: 'pnp-modern-search-web-components' */
+            '../../components/AvailableComponents'
+        );
+        this.availableWebComponentDefinitions = AvailableComponents.BuiltinComponents;
+
+        // Only attempt to load extensibility libraries when the Web Part actually uses something provided
+        // by one. This avoids the slow retry/backoff load of a registered-but-undeployed library.
+        let librariesToLoad = librariesConfiguration || [];
+        const enabledCount = librariesToLoad.filter(configuration => configuration.enabled).length;
+
+        if (!forceLoad && enabledCount > 0) {
+            try {
+                const usage = await ExtensibilityUsageHelper.getFiltersUsage({
+                    selectedLayoutKey: this.properties.selectedLayoutKey,
+                    filtersConfiguration: this.properties.filtersConfiguration,
+                    inlineTemplateContent: this.properties.inlineTemplateContent,
+                    externalTemplateUrl: this.properties.externalTemplateUrl,
+                    layoutProperties: this.properties.layoutProperties,
+                    templateService: this.templateService,
+                    builtinLayoutKeys: AvailableLayouts.BuiltinLayouts.map(layout => layout.key),
+                    builtinFilterTemplateKeys: Object.keys(BuiltinFilterTypes),
+                    builtinComponentNames: this.availableWebComponentDefinitions.map(component => component.componentName)
+                });
+
+                if (!usage.usesCustomExtensibility) {
+                    librariesToLoad = [];
+                    const message = `Skipping load of ${enabledCount} enabled extensibility library/libraries — not used by this Web Part (${usage.reason}).`;
+                    Log.verbose(LogSource, message, this.context.serviceScope);
+                    ExtensibilityUsageHelper.debugLog(`[${LogSource}] ${message}`);
+                } else {
+                    const message = `Loading ${enabledCount} enabled extensibility library/libraries — the Web Part uses ${usage.reason}.`;
+                    Log.verbose(LogSource, message, this.context.serviceScope);
+                    ExtensibilityUsageHelper.debugLog(`[${LogSource}] ${message}`);
+                }
+            } catch (error) {
+                // If usage can't be determined, fall back to loading so nothing custom is missed.
+                const details = error instanceof Error ? error.message : String(error);
+                Log.warn(LogSource, `Could not evaluate extensibility usage; loading libraries as a fallback. Details: ${details}`, this.context.serviceScope);
+            }
+        }
+
+        const extensibilityLibraries = await this.extensibilityService.loadExtensibilityLibraries(librariesToLoad);
+
+        // Always start from the builtin definitions so a property pane reload doesn't duplicate entries
+        this.availableLayoutDefinitions = AvailableLayouts.BuiltinLayouts.filter(layout => { return layout.type === LayoutType.Filter; });
+        this.availableFilterControlDefinitions = [];
+
+        extensibilityLibraries.forEach((extensibilityLibrary: IExtensibilityLibrary) => {
+
+            // Add custom filter layouts if any
+            if (extensibilityLibrary.getCustomLayouts) {
+                this.availableLayoutDefinitions = this.availableLayoutDefinitions.concat(
+                    extensibilityLibrary.getCustomLayouts().filter(layout => layout && layout.type === LayoutType.Filter)
+                );
+            }
+
+            // Add custom filter controls if any
+            if (extensibilityLibrary.getCustomFilterControls) {
+                this.availableFilterControlDefinitions = this.availableFilterControlDefinitions.concat(
+                    extensibilityLibrary.getCustomFilterControls().filter(control => control && control.key && control.componentName)
+                );
+            }
+
+            // Add custom web components if any
+            if (extensibilityLibrary.getCustomWebComponents) {
+                this.availableWebComponentDefinitions = this.availableWebComponentDefinitions.concat(extensibilityLibrary.getCustomWebComponents());
+            }
+
+            // Registers Handlebars customizations in the local namespace
+            if (extensibilityLibrary.registerHandlebarsCustomizations) {
+                extensibilityLibrary.registerHandlebarsCustomizations(this.templateService.Handlebars);
+            }
+        });
+
+        // Remove duplicates coming from multiple libraries declaring the same key
+        this.availableLayoutDefinitions = uniqBy(this.availableLayoutDefinitions, 'key');
+        this.availableFilterControlDefinitions = uniqBy(this.availableFilterControlDefinitions, 'key');
+
+        // Make the custom controls available to the Handlebars helpers used by the builtin filter layouts
+        this.templateService.CustomFilterControls = this.availableFilterControlDefinitions;
+    }
+
+    /**
+     * Determines the extensibility libraries configuration fields
+     */
+    private getExtensibilityFields(): IPropertyPaneField<any>[] {
+
+        return [
+            this._propertyFieldCollectionData('extensibilityLibraryConfiguration', {
+                manageBtnLabel: commonStrings.PropertyPane.InformationPage.Extensibility.ManageBtnLabel,
+                key: 'extensibilityLibraryConfiguration',
+                enableSorting: true,
+                panelHeader: webPartStrings.PropertyPane.InformationPage.Extensibility.PanelHeader,
+                panelDescription: webPartStrings.PropertyPane.InformationPage.Extensibility.PanelDescription,
+                label: commonStrings.PropertyPane.InformationPage.Extensibility.FieldLabel,
+                value: this.properties.extensibilityLibraryConfiguration,
+                tableClassName: commonStyles.slotTable,
+                fields: [
+                    {
+                        id: 'name',
+                        title: commonStrings.PropertyPane.InformationPage.Extensibility.Columns.Name,
+                        type: this._customCollectionFieldType.string
+                    },
+                    {
+                        id: 'id',
+                        title: commonStrings.PropertyPane.InformationPage.Extensibility.Columns.Id,
+                        type: this._customCollectionFieldType.string,
+                        onGetErrorMessage: this._validateGuid.bind(this)
+                    },
+                    {
+                        id: 'enabled',
+                        title: commonStrings.PropertyPane.InformationPage.Extensibility.Columns.Enabled,
+                        type: this._customCollectionFieldType.custom,
+                        required: true,
+                        onCustomRender: (field, value, onUpdate, item, itemId) => {
+                            return (
+                                React.createElement("div", null,
+                                    React.createElement(Toggle, {
+                                        key: itemId,
+                                        checked: value,
+                                        offText: commonStrings.General.OffTextLabel,
+                                        onText: commonStrings.General.OnTextLabel,
+                                        onChange: ((evt, checked) => {
+                                            onUpdate(field.id, checked);
+                                        })
+                                    } as IToggleProps)
+                                )
+                            );
+                        }
+                    }
+                ]
+            })
+        ];
+    }
+
+    private _validateGuid(value: string): string {
+        if (value.length > 0) {
+            if (!(/^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$/).test(value)) {
+                return 'Invalid GUID';
+            }
+        }
+
+        return '';
     }
 
     /**
@@ -1820,7 +2096,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         filtersConfiguration.forEach(filterConfiguration => {
 
             const shouldKeepVisibleWhenMissing =
-                BuiltinFilterTypes[filterConfiguration.selectedTemplate] === FilterType.StaticFilter
+                FilterControlHelper.getFilterType(filterConfiguration.selectedTemplate, this.availableFilterControlDefinitions) === FilterType.StaticFilter
                 || filterConfiguration.selectedTemplate === BuiltinFilterTemplates.Hierarchical;
 
             if (shouldKeepVisibleWhenMissing) {

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -363,6 +363,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         } else if (this.templateContentToDisplay && this.properties.filtersConfiguration.length > 0) {
             // Display the Web Part only if a valid configuration is set
 
+            // The options a custom filter control doesn't support are only disabled in the property pane, so render
+            // the filters from the normalized configuration to always use the effective values of the control
+            const resolvedFiltersConfiguration = this.getResolvedFiltersConfiguration();
+
             // Get data from connected sources
             if (this._dataSourceDynamicProperties.length > 0) {
 
@@ -377,7 +381,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             // OR the data results don't contain this filter name. 
             // We create fake entries for those filters to be able to render them in the template
             // We do this by convenience to avoid refactoring the Handlebars templates
-            filterResults = this._initStaticFilters(filterResults, this.properties.filtersConfiguration);
+            filterResults = this._initStaticFilters(filterResults, resolvedFiltersConfiguration);
 
             renderRootElement = React.createElement(
                 React.Suspense,
@@ -387,11 +391,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     {
                         templateContent: this.templateContentToDisplay,
                         availableFilters: filterResults,
-                        filtersConfiguration: this.properties.filtersConfiguration,
+                        filtersConfiguration: resolvedFiltersConfiguration,
                         domElement: this.domElement,
                         instanceId: this.instanceId,
                         selectedLayoutKey: this.properties.selectedLayoutKey,
-                        properties: JSON.parse(JSON.stringify(this.properties)),
+                        properties: JSON.parse(JSON.stringify({ ...this.properties, filtersConfiguration: resolvedFiltersConfiguration })),
                         themeVariant: this._themeVariant,
                         context: this.context,
                         onUpdateFilters: (updatedFilters: IDataFilter[]) => {
@@ -525,29 +529,13 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     }
 
     /**
-     * Returns the filters configuration to share with connected Web Parts, resolving the filter type of the
-     * filters using a custom filter control. Connected data sources don't know about the custom controls
-     * registered here, so they rely on that information to skip refiners/aggregations for static filters.
+     * Returns the effective filters configuration, resolving the filter type of the filters using a custom filter
+     * control and resetting the options their control doesn't support. Connected data sources don't know about the
+     * custom controls registered here, so they rely on the filter type to skip refiners/aggregations for static
+     * filters, and on the normalized options to not apply settings the selected control opted out from.
      */
     private getResolvedFiltersConfiguration(): IDataFilterConfiguration[] {
-
-        if (this.availableFilterControlDefinitions.length === 0) {
-            return this.properties.filtersConfiguration;
-        }
-
-        return this.properties.filtersConfiguration.map(configuration => {
-
-            const customControl = FilterControlHelper.getCustomControl(configuration.selectedTemplate, this.availableFilterControlDefinitions);
-
-            if (!customControl) {
-                return configuration;
-            }
-
-            return {
-                ...configuration,
-                filterType: customControl.filterType || FilterType.Refiner
-            };
-        });
+        return FilterControlHelper.normalizeConfigurations(this.properties.filtersConfiguration, this.availableFilterControlDefinitions);
     }
 
     public onCustomPropertyUpdate(propertyPath: string, newValue: any, changeCallback?: (targetProperty?: string, newValue?: any) => void): void {
@@ -642,7 +630,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
             // Set correct default values according to the template
             const nextConfigurations = newValue as IHierarchicalFilterConfiguration[];
-            this.properties.filtersConfiguration = nextConfigurations.map(configuration => {
+            this.properties.filtersConfiguration = nextConfigurations.map(nextConfiguration => {
+
+                // The options unsupported by a custom filter control are disabled in the property pane, but a value
+                // configured before selecting the control could still be persisted, so reset them here as well
+                const configuration = FilterControlHelper.normalizeConfiguration(nextConfiguration, this.availableFilterControlDefinitions);
+
                 if (configuration.selectedTemplate === BuiltinFilterTemplates.DateRange
                     || configuration.selectedTemplate === BuiltinFilterTemplates.DateInterval) {
                     configuration.isMulti = false;

--- a/search-parts/src/webparts/searchFilters/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchFilters/loc/cs-cz.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Nelze načíst zadanou šablonu. Podrobnosti chyby: '{0}'",
                 FiltersTemplateFieldLabel: "Upravit šablonu filtrů",
                 FiltersTemplatePanelHeader: "Upravit šablonu filtrů"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurujte knihovny rozšiřitelnosti pro načtení při spuštění.",
+                    PanelDescription: "Přidejte/odeberte ID vlastní knihovny rozšiřitelnosti zde. Můžete zadat zobrazený název a rozhodnout, zda by knihovna měla být načtena nebo ne při spuštění. Zde budou načtena pouze vlastní rozvržení filtrů, ovládací prvky filtrů, webové komponenty a Handlebars pomocníci."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/da-dk.js
+++ b/search-parts/src/webparts/searchFilters/loc/da-dk.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Ude af stand til at vise den specifikke skabelon. Fejloplysninger: '{0}'",
                 FiltersTemplateFieldLabel: "Redigér skabelon til filtre",
                 FiltersTemplatePanelHeader: "Redigér skabelon til filtre"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurér extensibility-biblioteker så de indlæser ved opstart.",
+                    PanelDescription: "Tilføj/Fjern ID på dit extensibility-bibliotek her. Du kan specificere et visningsnavn og beslutte, om biblioteket skal indlæses eller ej ved opstart. Kun brugerdefinerede filterlayouts, filterkontroller, web-komponenter og Handlebars-hjælpere vil blive loadet her."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/de-de.js
+++ b/search-parts/src/webparts/searchFilters/loc/de-de.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Kann die angegebene Vorlage nicht auflösen. Fehler Details: '{0}'",
                 FiltersTemplateFieldLabel: "Filter Vorlage bearbeiten",
                 FiltersTemplatePanelHeader: "Filter Vorlage bearbeiten"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Erweiterungsbibliotheken, die beim Start geladen werden, konfigurieren",
+                    PanelDescription: "Hier können Sie die IDs Ihrer benutzerdefinierten Erweiterungsbibliotheken hinzufügen/entfernen. Sie können einen Anzeigenamen angeben und entscheiden, ob die Bibliothek beim Starten geladen werden soll oder nicht. Nur benutzerdefinierte Filterlayouts, Filtersteuerelemente, Webkomponenten und Handlebars-Helfer werden hier geladen."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/en-us.js
+++ b/search-parts/src/webparts/searchFilters/loc/en-us.js
@@ -83,6 +83,12 @@ define([], function () {
                 ErrorTemplateResolve: "Unable to resolve the specified template. Error details: '{0}'",
                 FiltersTemplateFieldLabel: "Edit filters template",
                 FiltersTemplatePanelHeader: "Edit filters template"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configure extensibility libraries to load at startup.",
+                    PanelDescription: "Add/Remove your custom extensibility library IDs here. You can specify a display name and decide if the library should be loaded or not at startup. Only custom filter layouts, filter controls, web components and Handlebars helpers will be loaded here."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/es-es.js
+++ b/search-parts/src/webparts/searchFilters/loc/es-es.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "No se ha podido resolver la plantilla especificada. Detalles del error: '{0}'",
                 FiltersTemplateFieldLabel: "Editar plantilla de filtros",
                 FiltersTemplatePanelHeader: "Editar plantilla de filtros"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configurar las bibliotecas de extensibilidad para que se carguen al inicio.",
+                    PanelDescription: "Añada/elimine sus IDs de bibliotecas de extensibilidad personalizadas aquí. Puede especificar un nombre para mostrar y decidir si la biblioteca debe cargarse o no al inicio. Sólo se cargarán aquí los diseños de filtros, los controles de filtro, los componentes web y los elementos auxiliares de Handlebars personalizados."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchFilters/loc/fi-fi.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Templaatin tunnistaminen ei onnistunut. Virhetiedot: '{0}'",
                 FiltersTemplateFieldLabel: "Muokkaa suodatintemplaattia",
                 FiltersTemplatePanelHeader: "Muokkaa suodatintemplaattia"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konsiguroi laajennuskirjastot ladattavaksi käynnistyksessä.",
+                    PanelDescription: "Lisää/poista mukautetun laajennuskirjastosi ID:t tässä. Voit määrittää näyttönimen ja päättää, ladataanko kirjasto käynnistyksessä. Vain mukautetut suodatintemplaatit, suodatinkontrollit, komponentit ja Handlebar helperit ladataan tässä."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchFilters/loc/fr-fr.js
@@ -83,6 +83,12 @@ define([], function () {
                 ErrorTemplateResolve: "Impossible de résoudre le modèle indiqué. Renseignements sur l'erreur '{0}'",
                 FiltersTemplateFieldLabel: "Modifier le modèle de filtres",
                 FiltersTemplatePanelHeader: "Modifier le modèle de filtres"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configurez les bibliothèques d’extensibilité pour qu’elles soient chargées au démarrage.",
+                    PanelDescription: "Ajoutez ou supprimez vos identifiants personnalisés de la bibliothèque d’extensibilités ici. Vous pouvez préciser un nom d’affichage et décider si la bibliothèque doit être téléchargée ou non au démarrage. Seuls les mises en page de filtres, les contrôles de filtre, les composants Web et les assistants d’expressions entre accolades personnalisés sont chargés ici."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/it-it.js
+++ b/search-parts/src/webparts/searchFilters/loc/it-it.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Impossibile risolvere il modello specificato. Dettagli dell'errore: '{0}'",
                 FiltersTemplateFieldLabel: "Modifica modello di filtri",
                 FiltersTemplatePanelHeader: "Modifica modello di filtri"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configura le librerie di estensibilità da caricare all'avvio.",
+                    PanelDescription: "Aggiungi/Rimuovi qui gli ID della tua libreria di estensibilità personalizzata. Puoi specificare un nome visualizzato e decidere se la libreria deve essere caricata o meno all'avvio. Solo i layout dei filtri, i controlli dei filtri, i componenti web e gli helper Handlebars personalizzati saranno caricati qui."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchFilters/loc/mystrings.d.ts
@@ -82,6 +82,12 @@ declare interface ISearchFiltersWebPartStrings {
             ErrorTemplateResolve: string;
             FiltersTemplateFieldLabel: string;
             FiltersTemplatePanelHeader: string;
+        },
+        InformationPage: {
+            Extensibility: {
+                PanelHeader: string;
+                PanelDescription: string;
+            }
         }
     },
     Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/nb-no.js
+++ b/search-parts/src/webparts/searchFilters/loc/nb-no.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Det går ikke å vise denne malen. Feil: '{0}'",
                 FiltersTemplateFieldLabel: "Rediger filtermal",
                 FiltersTemplatePanelHeader: "Rediger filtermal"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurer utvidelsesbibliotek som skal lastes ved oppstart.",
+                    PanelDescription: "Legg til / fjern ID-en til ditt tilpassede utvidelsesbibliotek her. Du kan angi et visningsnavn og bestemme om biblioteket skal lastes ved oppstart eller ikke. Her lastes kun tilpassede filtermaler, filterkontroller, web-komponenter og Handlebars-hjelpere."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchFilters/loc/nl-nl.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Kan het opgegeven template niet inladen. Foutmelding: '{0}'",
                 FiltersTemplateFieldLabel: "Bewerk filters sjabloon",
                 FiltersTemplatePanelHeader: "Bewerk filters sjabloon"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configureer inladen van uitbreidingsbibliotheken bij opstarten",
+                    PanelDescription: "Beheer hier je aangepaste uitbreidingsbibliotheek ID's. Je kan hier een weergavenaam specificeren en aangeven of de bibliotheek geladen moet worden. Alleen aangepaste filterindelingen, filtercontrols, web componenten en Handlebars helpers worden hier geladen."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchFilters/loc/pl-pl.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Nie można rozwiązać wskazanego szablonu. Szczegóły błędu: '{0}'",
                 FiltersTemplateFieldLabel: "Edytuj filtry szablonu",
                 FiltersTemplatePanelHeader: "Edytuj filtry szablonu"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfiguruj biblioteki rozszerzalności ładowane przy starcie.",
+                    PanelDescription: "Dodaj/Usuń identyfikatory niestandardowych bibliotek rozszerzalności. Wybierz nazwę i zdecyduj czy mają być ładowane przy starcie. Tylko niestandardowe układy filtrów, kontrolki filtrów, komponenty web i Handlebars będą tutaj ładowane."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/pt-br.js
+++ b/search-parts/src/webparts/searchFilters/loc/pt-br.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Não foi possível resolver o modelo especificado. Detalhes do erro: '{0}'",
                 FiltersTemplateFieldLabel: "Modelo de edição de filtros",
                 FiltersTemplatePanelHeader: "Modelo de edição de filtros"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Configurar bibliotecas de extensibilidade para carregar no início.",
+                    PanelDescription: "Adicione/Remove os IDs de suas bibliotecas de extensibilidade aqui. Você pode especificar um nome de exibição e decidir se a biblioteca deve ser carregada ou não no início. Apenas layouts de filtros, controles de filtro, componentes web e funções para marcadores entre chaves customizados serão carregados aqui."
+                }
             }
         },
         Styling: {

--- a/search-parts/src/webparts/searchFilters/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchFilters/loc/sv-SE.js
@@ -81,6 +81,12 @@ define([], function () {
                 ErrorTemplateResolve: "Det går inte att visa den angivna mallen. Felinformation: '{0}'",
                 FiltersTemplateFieldLabel: "Redigera filtermall",
                 FiltersTemplatePanelHeader: "Redigera filtermall"
+            },
+            InformationPage: {
+                Extensibility: {
+                    PanelHeader: "Konfigurera utbyggnadsbibliotek som ska laddas vid start.",
+                    PanelDescription: "Lägg till/ta bort anpassade utbyggnadsbiblioteket-ID:n här. Du kan ange ett visningsnamn och bestämma om biblioteket ska laddas eller ej vid start. Här laddas bara anpassade filterlayouter, filterkontroller, webbkomponenter och styrhjälpmedel."
+                }
             }
         },
         Styling: {


### PR DESCRIPTION
In this PR you can find the extensibility support for the filters web part.

## Same extensibility linking

<img width="748" height="1764" alt="eliostruyf-2026-07-30-10 34 07" src="https://github.com/user-attachments/assets/5efa3c67-44ea-46c5-91c5-de74c993c2a5" />

## Support for custom layouts 

<img width="812" height="1120" alt="eliostruyf-2026-07-30-10 36 06" src="https://github.com/user-attachments/assets/0a49466d-4b87-4489-8062-1bc9d8a3850f" />

## Support for custom filter controls

<img width="3048" height="2624" alt="image" src="https://github.com/user-attachments/assets/050ff194-3971-4444-b22f-db6a31dbe1c1" />

<img width="443" height="299" alt="image" src="https://github.com/user-attachments/assets/750345ca-e0b8-4c0b-895b-eeb6d0985b65" />
