### PR TITLE
fix: restore people template display names

### DIFF
--- a/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
@@ -320,28 +320,38 @@ export class FilterCheckBoxList extends React.Component<IFilterCheckBoxListProps
         return value.count === undefined ? '' : `${value.count}`;
     }
 
-    private _getDisplayLabel(value: IFilterCheckBoxListValue): string {
-        const preferredDisplayLabel = value.displayLabel?.trim();
-        const rawName = `${value.name ?? ''}`;
-        const rawValue = `${value.value ?? ''}`;
-        const resolvedValueLabel = rawValue ? TaxonomyHelper.resolveDisplayLabel(rawValue) : '';
-        const resolvedNameLabel = rawName ? TaxonomyHelper.resolveDisplayLabel(rawName) : '';
-        const nameLooksLikeEmail = !!TaxonomyHelper.extractEmailLikeLabel(rawName);
-        const shouldPreferValueLabel = !preferredDisplayLabel
-            && !!resolvedValueLabel
-            && resolvedValueLabel !== rawValue
-            && (!resolvedNameLabel || resolvedNameLabel === rawName)
-            && nameLooksLikeEmail;
-        const rawLabel = preferredDisplayLabel
-            || (shouldPreferValueLabel ? rawValue : '')
-            || rawName
-            || rawValue;
-
-        if (!this._displayLabels.has(rawLabel)) {
-            this._displayLabels.set(rawLabel, TaxonomyHelper.resolveDisplayLabel(rawLabel));
+    private _resolveDisplayLabel(label: string): string {
+        if (!label) {
+            return '';
         }
 
-        return this._displayLabels.get(rawLabel);
+        if (!this._displayLabels.has(label)) {
+            this._displayLabels.set(label, TaxonomyHelper.resolveDisplayLabel(label));
+        }
+
+        return this._displayLabels.get(label) ?? label;
+    }
+
+    private _getDisplayLabel(value: IFilterCheckBoxListValue): string {
+        const preferredDisplayLabel = value.displayLabel?.trim();
+        if (preferredDisplayLabel) {
+            return this._resolveDisplayLabel(preferredDisplayLabel);
+        }
+
+        const rawName = `${value.name ?? ''}`;
+        const rawValue = `${value.value ?? ''}`;
+        const nameLooksLikeEmail = !!TaxonomyHelper.extractEmailLikeLabel(rawName);
+        if (nameLooksLikeEmail && rawValue) {
+            const resolvedValueLabel = this._resolveDisplayLabel(rawValue);
+            if (resolvedValueLabel && resolvedValueLabel !== rawValue) {
+                const resolvedNameLabel = rawName ? this._resolveDisplayLabel(rawName) : '';
+                if (!resolvedNameLabel || resolvedNameLabel === rawName) {
+                    return resolvedValueLabel;
+                }
+            }
+        }
+
+        return this._resolveDisplayLabel(rawName || rawValue);
     }
 
     private _getValueTitle(value: IFilterCheckBoxListValue, label: string): string {

--- a/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
@@ -19,6 +19,11 @@ export interface IFilterCheckBoxListValue {
     name: string;
 
     /**
+     * An optional display label already normalized by the template.
+     */
+    displayLabel?: string;
+
+    /**
      * The value to use when selected
      */
     value: string;
@@ -316,7 +321,21 @@ export class FilterCheckBoxList extends React.Component<IFilterCheckBoxListProps
     }
 
     private _getDisplayLabel(value: IFilterCheckBoxListValue): string {
-        const rawLabel = `${value.name ?? value.value ?? ''}`;
+        const preferredDisplayLabel = value.displayLabel?.trim();
+        const rawName = `${value.name ?? ''}`;
+        const rawValue = `${value.value ?? ''}`;
+        const resolvedValueLabel = rawValue ? TaxonomyHelper.resolveDisplayLabel(rawValue) : '';
+        const resolvedNameLabel = rawName ? TaxonomyHelper.resolveDisplayLabel(rawName) : '';
+        const nameLooksLikeEmail = !!TaxonomyHelper.extractEmailLikeLabel(rawName);
+        const shouldPreferValueLabel = !preferredDisplayLabel
+            && !!resolvedValueLabel
+            && resolvedValueLabel !== rawValue
+            && (!resolvedNameLabel || resolvedNameLabel === rawName)
+            && nameLooksLikeEmail;
+        const rawLabel = preferredDisplayLabel
+            || (shouldPreferValueLabel ? rawValue : '')
+            || rawName
+            || rawValue;
 
         if (!this._displayLabels.has(rawLabel)) {
             this._displayLabels.set(rawLabel, TaxonomyHelper.resolveDisplayLabel(rawLabel));
@@ -366,6 +385,7 @@ export class FilterCheckBoxListWebComponent extends BaseWebComponent {
         this.querySelectorAll('option').forEach((htmlOption: HTMLOptionElement) => {
             values.push({
                 name: htmlOption.text,
+                displayLabel: htmlOption.dataset.displayLabel,
                 value: htmlOption.value,
                 selected: this.toBoolean(htmlOption.getAttribute('data-selected')),
                 disabled: this.toBoolean(htmlOption.getAttribute('data-disabled')),

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -176,7 +176,7 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
     }
 
     private readonly onRenderSelectedItem = (props: { item: ITag; index: number }): JSX.Element => {
-        const itemName = this.getDisplayName(`${props.item.name ?? ''}`);
+        const itemName = this.getDisplayName(`${props.item.name ?? ''}`, `${props.item.key ?? ''}`);
 
         return <li
             className={styles.tagItem}
@@ -212,7 +212,7 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
     }
 
     private readonly onRenderSuggestionItem = (itemProps: ITag): JSX.Element => {
-        return <span>{this.getDisplayName(itemProps.name)}</span>;
+        return <span>{this.getDisplayName(itemProps.name, `${itemProps.key ?? ''}`)}</span>;
     }
 
     public componentDidUpdate(prevProps: IFilterSearchBoxProps): void {
@@ -257,7 +257,7 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
         return values.map(filterValue => {
             return {
                 key: `${filterValue?.value ?? ''}`,
-                name: this.getDisplayName(filterValue?.name ?? filterValue?.value)
+                name: this.getDisplayName(`${filterValue?.name ?? filterValue?.value ?? ''}`, `${filterValue?.value ?? ''}`)
             };
         });
     }
@@ -271,7 +271,27 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
         return (this.props.filter as any)?.selectedTemplate === 'PeopleTemplate';
     }
 
-    private readonly getDisplayName = (rawName: string): string => {
+    private readonly getPreferredPeopleValueLabel = (rawValue: string): string => {
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const readablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (readablePipeSegment) {
+            return readablePipeSegment;
+        }
+
+        const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
+        const decodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (decodedPipeSegment) {
+            return decodedPipeSegment;
+        }
+
+        return '';
+    }
+
+    private readonly getDisplayName = (rawName: string, rawValue?: string): string => {
         if (!this.isPeopleTemplate()) {
             return `${rawName ?? ''}`;
         }
@@ -308,6 +328,11 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
 
             return '';
         };
+
+        const preferredValueLabel = this.getPreferredPeopleValueLabel(`${rawValue ?? ''}`);
+        if (preferredValueLabel) {
+            return preferredValueLabel;
+        }
 
         const readableRawName = extractReadableLabel(rawName);
         if (readableRawName) {

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -6,6 +6,8 @@ import styles from './SelectedFiltersComponent.module.scss';
 import * as strings from 'CommonStrings';
 import { Log } from '@microsoft/sp-core-library';
 import { DateHelper } from '../../helpers/DateHelper';
+import { TaxonomyHelper } from '../../helpers/TaxonomyHelper';
+import { BuiltinFilterTemplates } from '../../layouts/AvailableTemplates';
 import { TestConstants } from '../../common/Constants';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 const SelectedFilters_LogSource = "PnPModernSearch:SelectedFiltersComponent";
@@ -80,11 +82,15 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
                     filterName = currentFilterConfig[0].displayValue ? currentFilterConfig[0].displayValue : filterName;
                 }
 
+                const selectedTemplate = currentFilterConfig.length === 1 ? currentFilterConfig[0].selectedTemplate : undefined;
+
                 const uniqueDisplayValues: Array<{ displayValue: string; operator: FilterComparisonOperator }> = [];
                 const seenDisplayValues = new Set<string>();
 
                 filter.values.forEach(value => {
-                    let displayValue = this.props.dayjs && this.props.dayjs(value.value).isValid() ? this.props.dayjs(value.value).format('LL') : value.name;
+                    let displayValue = this.props.dayjs && this.props.dayjs(value.value).isValid()
+                        ? this.props.dayjs(value.value).format('LL')
+                        : this.resolveDisplayValue(value.name, value.value, selectedTemplate);
 
                     // For taxonomy filters (GPP/GP0 tokens), extract the label if name is not set
                     if (!displayValue || displayValue.indexOf("GPP|#") === 0 || displayValue.indexOf("GP0|#") === 0) {
@@ -226,6 +232,45 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
         }
 
         return null;
+    }
+
+    private resolveDisplayValue(name: string, value: string, selectedTemplate?: string): string {
+        const rawName = `${name ?? ''}`.trim();
+        const rawValue = `${value ?? ''}`.trim();
+
+        if (selectedTemplate === BuiltinFilterTemplates.People) {
+            const displayNameFromValue = this.extractPeopleDisplayValue(rawValue);
+            if (displayNameFromValue) {
+                return displayNameFromValue;
+            }
+        }
+
+        return rawName || rawValue;
+    }
+
+    private extractPeopleDisplayValue(rawValue: string): string {
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const readablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (readablePipeSegment) {
+            return readablePipeSegment;
+        }
+
+        const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
+        const decodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (decodedPipeSegment) {
+            return decodedPipeSegment;
+        }
+
+        const claimsLabel = TaxonomyHelper.extractClaimsLabel(decodedValue || cleanedValue);
+        if (claimsLabel) {
+            return claimsLabel;
+        }
+
+        return '';
     }
 
     private getConditionOperatorString(operator: FilterConditionOperator): string {

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -193,7 +193,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-												<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+												<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -215,7 +215,7 @@
                                                             data-show-count="{{filter.showCount}}"
                                                         >
                                                             {{#each filter.values}}
-                                                                <option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+                                                                <option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
                                                             {{/each}}
                                                         </pnp-filtercheckboxlist>
                                                     </div>

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -178,7 +178,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-												<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+												<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -74,6 +74,12 @@ interface IUpdateDebugContext {
     lastMarkAt: number;
 }
 
+interface IGraphUserEntity {
+    displayName?: string;
+    mail?: string;
+    userPrincipalName?: string;
+}
+
 export default class SearchFiltersContainer extends React.Component<ISearchFiltersContainerProps, ISearchFiltersContainerState> {
 
     private readonly componentRef: React.RefObject<any>;
@@ -98,6 +104,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private _busyPrimeTimer: ReturnType<typeof setTimeout> | null = null;
     private _busyCursorAutoHideTimer: ReturnType<typeof setTimeout> | null = null;
     private _isMounted: boolean = false;
+    private _hasAttemptedPeopleDisplayNameLookup: boolean = false;
     private _busyStartedAt: number = 0;
     private _latestDeferredSubmittedFilters: IDataFilter[] | null = null;
     private static readonly _DISPLAY_NAME_CACHE_LIMIT = 5000;
@@ -108,6 +115,18 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private static readonly _MAX_BUSY_DURATION_MS = 10000;
     private static readonly _BUSY_PRIME_TIMEOUT_MS = 1500;
     private static readonly _GLOBAL_BUSY_CURSOR_STYLE_ID = 'pnp-modern-search-busy-cursor-style';
+    private static readonly _GRAPH_PAGE_SIZE = 200;
+    private static readonly _MAX_INITIAL_GRAPH_USERS = 2000;
+    private static _tenantPeopleDisplayNameCache: Map<string, string> | null = null;
+    private static _tenantPeopleDisplayNameLoadingPromise: Promise<Map<string, string>> | null = null;
+
+    private static setTenantPeopleDisplayNameCache(cache: Map<string, string> | null): void {
+        SearchFiltersContainer._tenantPeopleDisplayNameCache = cache;
+    }
+
+    private static setTenantPeopleDisplayNameLoadingPromise(promise: Promise<Map<string, string>> | null): void {
+        SearchFiltersContainer._tenantPeopleDisplayNameLoadingPromise = promise;
+    }
 
     public constructor(props: ISearchFiltersContainerProps) {
 
@@ -261,6 +280,125 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         cache.set(key, value);
+    }
+
+    private hasPeopleTemplateConfigured(filtersConfiguration: IDataFilterConfiguration[] = this.props.filtersConfiguration): boolean {
+        return (filtersConfiguration || []).some(filter => filter.selectedTemplate === BuiltinFilterTemplates.People);
+    }
+
+    private applyTenantPeopleDisplayNameCache(cache: Map<string, string>): boolean {
+        let cacheChanged = false;
+
+        cache.forEach((displayName, normalizedIdentity) => {
+            if (!displayName || !normalizedIdentity) {
+                return;
+            }
+
+            if (this._peopleDisplayNameByValue.get(normalizedIdentity) !== displayName) {
+                this.setDisplayNameCacheEntry(this._peopleDisplayNameByValue, normalizedIdentity, displayName);
+                cacheChanged = true;
+            }
+
+            if (this._peopleDisplayNameByName.get(normalizedIdentity) !== displayName) {
+                this.setDisplayNameCacheEntry(this._peopleDisplayNameByName, normalizedIdentity, displayName);
+                cacheChanged = true;
+            }
+        });
+
+        return cacheChanged;
+    }
+
+    private async loadTenantPeopleDisplayNameCache(): Promise<Map<string, string>> {
+        const msGraphClientFactory = this.props.context?.msGraphClientFactory;
+        if (!msGraphClientFactory) {
+            return new Map<string, string>();
+        }
+
+        const client = await msGraphClientFactory.getClient('3');
+        const displayNameCache = new Map<string, string>();
+        let users: IGraphUserEntity[] = [];
+        let response = await client
+            .api('/users')
+            .version('v1.0')
+            .select('displayName,mail,userPrincipalName')
+            .top(SearchFiltersContainer._GRAPH_PAGE_SIZE)
+            .get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
+
+        users = users.concat(Array.isArray(response?.value) ? response.value : []);
+        if (users.length > SearchFiltersContainer._MAX_INITIAL_GRAPH_USERS) {
+            users = users.slice(0, SearchFiltersContainer._MAX_INITIAL_GRAPH_USERS);
+        }
+
+        let nextLink = response?.['@odata.nextLink'];
+        let pageCount = 1;
+
+        while (nextLink && pageCount < 100 && users.length < SearchFiltersContainer._MAX_INITIAL_GRAPH_USERS) {
+            response = await client.api(nextLink).get() as { value?: IGraphUserEntity[]; '@odata.nextLink'?: string };
+            users = users.concat(Array.isArray(response?.value) ? response.value : []);
+
+            if (users.length > SearchFiltersContainer._MAX_INITIAL_GRAPH_USERS) {
+                users = users.slice(0, SearchFiltersContainer._MAX_INITIAL_GRAPH_USERS);
+            }
+
+            nextLink = response?.['@odata.nextLink'];
+            pageCount++;
+        }
+
+        users.forEach(user => {
+            const displayName = `${user.displayName || ''}`.trim();
+            if (!displayName) {
+                return;
+            }
+
+            const normalizedMail = this.normalizeDisplayCacheKey(user.mail);
+            const normalizedUserPrincipalName = this.normalizeDisplayCacheKey(user.userPrincipalName);
+
+            if (normalizedMail) {
+                displayNameCache.set(normalizedMail, displayName);
+            }
+
+            if (normalizedUserPrincipalName) {
+                displayNameCache.set(normalizedUserPrincipalName, displayName);
+            }
+        });
+
+        return displayNameCache;
+    }
+
+    private async ensurePeopleDisplayNameCacheLoaded(): Promise<void> {
+        if (this._hasAttemptedPeopleDisplayNameLookup || !this.hasPeopleTemplateConfigured()) {
+            return;
+        }
+
+        this._hasAttemptedPeopleDisplayNameLookup = true;
+
+        const existingCache = SearchFiltersContainer._tenantPeopleDisplayNameCache;
+        if (existingCache) {
+            const cacheChanged = this.applyTenantPeopleDisplayNameCache(existingCache);
+            if (cacheChanged && this._isMounted) {
+                this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);
+            }
+            return;
+        }
+
+        const loadingPromise = SearchFiltersContainer._tenantPeopleDisplayNameLoadingPromise ?? this.loadTenantPeopleDisplayNameCache();
+        SearchFiltersContainer.setTenantPeopleDisplayNameLoadingPromise(loadingPromise);
+
+        try {
+            const tenantPeopleDisplayNameCache = await loadingPromise;
+            SearchFiltersContainer.setTenantPeopleDisplayNameCache(tenantPeopleDisplayNameCache);
+
+            const cacheChanged = this.applyTenantPeopleDisplayNameCache(tenantPeopleDisplayNameCache);
+            if (cacheChanged && this._isMounted) {
+                this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);
+            }
+        } catch {
+            // Ignore People display-name lookup failures and keep raw identities.
+        } finally {
+            if (SearchFiltersContainer._tenantPeopleDisplayNameLoadingPromise === loadingPromise) {
+                SearchFiltersContainer.setTenantPeopleDisplayNameLoadingPromise(null);
+            }
+        }
     }
 
     private getHierarchyCacheKey(filterName: string, termSetId: string, termGroupId: string): string {
@@ -487,7 +625,46 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         });
     }
 
-    private resolveFilterDisplayName(name: string, value: string): string {
+    private shouldPreferPeopleValueDisplayName(rawName: string, rawValue: string, selectedTemplate?: string): boolean {
+        if (selectedTemplate !== BuiltinFilterTemplates.People) {
+            return false;
+        }
+
+        const readableRawValue = this.extractReadableLabelFromString(rawValue);
+        if (!readableRawValue) {
+            return false;
+        }
+
+        const readableRawName = this.extractReadableLabelFromString(rawName);
+        return readableRawName === rawName && readableRawValue !== rawValue;
+    }
+
+    private extractPreferredPeopleValueDisplayName(rawValue: string): string {
+        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (firstReadablePipeSegment) {
+            return firstReadablePipeSegment;
+        }
+
+        const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
+        const readableDecodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (readableDecodedPipeSegment) {
+            return readableDecodedPipeSegment;
+        }
+
+        const readableCleanedValue = this.extractReadableLabelFromString(cleanedValue);
+        if (readableCleanedValue) {
+            return readableCleanedValue;
+        }
+
+        return this.extractReadableLabelFromString(decodedValue);
+    }
+
+    private resolveFilterDisplayName(name: string, value: string, selectedTemplate?: string): string {
         const rawName = `${name ?? ''}`;
         const rawValue = `${value ?? ''}`;
         const cacheKey = `${this.normalizeDisplayCacheKey(rawName)}::${this.normalizeDisplayCacheKey(rawValue)}`;
@@ -507,6 +684,21 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         if (resolvedFromPeopleNameCache) {
             this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, resolvedFromPeopleNameCache);
             return resolvedFromPeopleNameCache;
+        }
+
+        if (this.shouldPreferPeopleValueDisplayName(rawName, rawValue, selectedTemplate)) {
+            const readableRawValue = this.extractPreferredPeopleValueDisplayName(rawValue);
+            if (readableRawValue) {
+                this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableRawValue);
+                return readableRawValue;
+            }
+
+            const decodedValue = TaxonomyHelper.decodeHexString(rawValue);
+            const readableDecodedValue = this.extractPreferredPeopleValueDisplayName(decodedValue);
+            if (readableDecodedValue) {
+                this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, readableDecodedValue);
+                return readableDecodedValue;
+            }
         }
 
         const readableRawName = this.extractReadableLabelFromString(rawName);
@@ -867,7 +1059,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
     private mergeAvailableValueWithSelection(availableValue: IDataFilterResultValue, selectedFilterValues: IDataFilterValueInternal[], selectedValueIndexByRaw: Map<string, number>, selectedTemplate?: string): IDataFilterValueInternal {
         const filterValueInternal: IDataFilterValueInternal = {
-            name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`),
+            name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`, selectedTemplate),
             selected: false,
             selectedOnce: false,
             disabled: false,
@@ -887,7 +1079,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         const updatedValue = selectedFilterValues[valueIdx];
         updatedValue.count = availableValue.count;
 
-        const resolvedAvailableName = this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`);
+        const resolvedAvailableName = this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`, selectedTemplate);
         const currentNameIsToken = this.isTokenDisplayName(updatedValue.name);
         const availableNameIsToken = this.isTokenDisplayName(availableValue.name);
 
@@ -910,7 +1102,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return availableFilter.values.map(availableValue => {
             if (selectedFilterIdx === -1) {
                 return {
-                    name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`),
+                    name: this.resolveFilterDisplayName(availableValue.name, `${availableValue.value}`, filterConfiguration.selectedTemplate),
                     selected: false,
                     selectedOnce: false,
                     disabled: false,
@@ -1169,10 +1361,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         return filterResultInternal;
     }
 
-    private buildFilterValueInternal(filterValue: IDataFilterValueInfo): IDataFilterValueInternal {
+    private buildFilterValueInternal(filterValue: IDataFilterValueInfo, selectedTemplate?: string): IDataFilterValueInternal {
         return {
             selected: filterValue.selected,
-            name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`),
+            name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`, selectedTemplate),
             value: filterValue.value,
             operator: filterValue.operator,
             selectedOnce: true
@@ -1183,7 +1375,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         const filterValuesInternal: IDataFilterValueInternal[] = filterInfo.filterValues.map(filterValue => {
             return {
                 selected: filterValue.selected,
-                name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`),
+                name: this.resolveFilterDisplayName(`${filterValue.name ?? ''}`, `${filterValue.value ?? ''}`, filterConfiguration.selectedTemplate),
                 value: filterValue.value,
                 selectedOnce: true
             };
@@ -1220,7 +1412,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         filterInfo.filterValues.forEach(filterValue => {
-            const filterValueInternal = this.buildFilterValueInternal(filterValue);
+            const filterValueInternal = this.buildFilterValueInternal(filterValue, filterConfiguration.selectedTemplate);
             const valueIdx = updatedUiFilters[filterIdx].values.findIndex(value => value.value === filterValue.value);
 
             if (valueIdx === -1) {
@@ -1417,10 +1609,20 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             this.getFiltersToDisplay(this.props.availableFilters, [], this.props.filtersConfiguration);
         }
 
+        this.ensurePeopleDisplayNameCacheLoaded().catch(() => {
+            // Ignore People display-name lookup failures and keep raw identities.
+        });
+
         this._handleQueryStringChange();
     }
 
     public componentDidUpdate(prevProps: ISearchFiltersContainerProps, prevState: ISearchFiltersContainerState) {
+
+        if (!this._hasAttemptedPeopleDisplayNameLookup && this.hasPeopleTemplateConfigured(this.props.filtersConfiguration)) {
+            this.ensurePeopleDisplayNameCacheLoaded().catch(() => {
+                // Ignore People display-name lookup failures and keep raw identities.
+            });
+        }
 
         const availableFiltersChanged = !isEqual(prevProps.availableFilters, this.props.availableFilters);
         const currentUiFiltersChanged = !isEqual(prevState.currentUiFilters, this.state.currentUiFilters) && prevState.currentUiFilters.length > 0;

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -305,6 +305,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             }
         });
 
+        if (cacheChanged) {
+            this._resolvedDisplayNameCache.clear();
+        }
+
         return cacheChanged;
     }
 


### PR DESCRIPTION
Fixes #4897

## Summary
- restore PeopleTemplate-specific display labels when the built-in checkbox list renderer is used
- prefer decoded people display names across filter rows, selected filter summaries, and selected pills in the filter search box
- keep the performance refactor from #4894 while preserving friendly person labels in the built-in layouts

## Testing
- npm run build