### PR TITLE
fix: hide raw taxonomy refiner buckets without localization

### DIFF
--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -45,6 +45,7 @@ import commonStyles from '../styles/Common.module.scss';
 import { PnPClientStorage } from "@pnp/common/storage";
 
 const TAXONOMY_REFINER_REGEX = /((L0|GP0)\|#.?([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}))\|?/;
+const HIDDEN_TAXONOMY_REFINER_VALUE_REGEX = /^(GT0|GP0|GTSet|GPP)\|#/i;
 const EDIT_MODE_REFINER_LIMIT = 100;
 
 export enum BuiltinSourceIds {
@@ -289,7 +290,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
 
     private isHiddenTaxonomyRefinerValueName(valueName: string): boolean {
         const candidate = `${valueName ?? ''}`.trim();
-        return /^(GT0|GP0|GTSet|GPP)\|#/i.test(candidate);
+        return HIDDEN_TAXONOMY_REFINER_VALUE_REGEX.test(candidate);
     }
 
     private logRefinerCounts(dataContext: IDataContext, filters: IDataFilterResult[]): void {

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -260,6 +260,10 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
             promotedResults: results.promotedResults
         };
 
+        if (!this.properties.enableLocalization) {
+            data.filters = this.removeHiddenTaxonomyRefinerValues(data.filters || []);
+        }
+
         this.logRefinerCounts(dataContext, data.filters || []);
 
         // Translates taxonomy refiners and result values by using terms ID if applicable
@@ -274,6 +278,18 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
         this._itemsCount = results.totalRows;
 
         return data;
+    }
+
+    private removeHiddenTaxonomyRefinerValues(filters: IDataFilterResult[]): IDataFilterResult[] {
+        return (filters || []).map((filter) => ({
+            ...filter,
+            values: (filter.values || []).filter((value) => !this.isHiddenTaxonomyRefinerValueName(value?.name))
+        }));
+    }
+
+    private isHiddenTaxonomyRefinerValueName(valueName: string): boolean {
+        const candidate = `${valueName ?? ''}`.trim();
+        return /^(GT0|GP0|GTSet|GPP)\|#/i.test(candidate);
     }
 
     private logRefinerCounts(dataContext: IDataContext, filters: IDataFilterResult[]): void {


### PR DESCRIPTION
Fixes #4904

## Summary
- remove raw taxonomy container buckets from refiner results when localization is disabled
- keep the cleanup in the SharePoint search datasource so `GP0`, `GT0`, `GTSet`, and `GPP` values do not leak into the UI
- preserve the existing localized taxonomy path unchanged

## Testing
- npm run build
- verified live on the Ballerup page against the localhost debug manifests