### PR TITLE
Fix multi-select Details errors when comparing list items

### DIFF
--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -22,6 +22,7 @@ const DETAILS_PANEL_RIGHT_OFFSET = 32;
 const HEX_COLOR_REGEXP = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 const RGB_COLOR_REGEXP = /^rgba?\((\d+),\s*(\d+),\s*(\d+)/i;
 const RESET_RESULTS_SELECTION_EVENT = "resetResultsSelection";
+const SELECTED_EDIT_TAXONOMY_PICKER_CLASS = "pnp-modern-search-selected-edit-taxonomy-picker";
 const LazyTaxonomyPicker = React.lazy(() =>
   import(
     /* webpackChunkName: "pnp-modern-search-taxonomy-picker" */ "@pnp/spfx-controls-react/lib/TaxonomyPicker"
@@ -660,6 +661,23 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
 
         {!this.state.isSelectedItemsEditLoading && !this.state.selectedItemsEditErrorMessage && fields.length > 0 && (
           <>
+            <style>{`
+              .${SELECTED_EDIT_TAXONOMY_PICKER_CLASS} {
+                position: relative;
+              }
+
+              .${SELECTED_EDIT_TAXONOMY_PICKER_CLASS} > label {
+                border: 0;
+                clip: rect(0 0 0 0);
+                height: 1px;
+                margin: -1px;
+                overflow: hidden;
+                padding: 0;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
+              }
+            `}</style>
             <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>{strings.Layouts.DetailsList.SelectedItemsEditFieldLabel}</div>
             <div style={{ overflowY: "auto", minHeight: 0, border: "1px solid #edebe9", borderRadius: 2, background: "#fff" }}>
               {fields.map((field, index) => {
@@ -815,21 +833,23 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     }
 
     return (
-      <React.Suspense fallback={<Spinner size={SpinnerSize.small} />}>
-        <LazyTaxonomyPicker
-          label={field.title}
-          panelTitle={field.title}
-          placeholder={strings.General.TagPickerStrings.SearchPlaceholder}
-          allowMultipleSelections={field.allowMultipleValues !== false}
-          termsetNameOrID={field.termSetId}
-          isTermSetSelectable={false}
-          context={webPartContext as any}
-          initialValues={this._getSelectedEditTaxonomyTerms(this._getSelectedEditFieldValue(field), field.termSetId)}
-          onChange={(nextSelectedItems?: IPickerTerms) => {
-            this._setSelectedEditFieldValue(field, (nextSelectedItems as ISelectedEditTag[]) ?? []);
-          }}
-        />
-      </React.Suspense>
+      <div className={SELECTED_EDIT_TAXONOMY_PICKER_CLASS}>
+        <React.Suspense fallback={<Spinner size={SpinnerSize.small} />}>
+          <LazyTaxonomyPicker
+            label={field.title}
+            panelTitle={field.title}
+            placeholder={strings.General.TagPickerStrings.SearchPlaceholder}
+            allowMultipleSelections={field.allowMultipleValues !== false}
+            termsetNameOrID={field.termSetId}
+            isTermSetSelectable={false}
+            context={webPartContext as any}
+            initialValues={this._getSelectedEditTaxonomyTerms(this._getSelectedEditFieldValue(field), field.termSetId)}
+            onChange={(nextSelectedItems?: IPickerTerms) => {
+              this._setSelectedEditFieldValue(field, (nextSelectedItems as ISelectedEditTag[]) ?? []);
+            }}
+          />
+        </React.Suspense>
+      </div>
     );
   }
 

--- a/search-parts/src/dataSources/SharePointSearchDataSource.ts
+++ b/search-parts/src/dataSources/SharePointSearchDataSource.ts
@@ -776,6 +776,7 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
                 'AuthorOWSUSER',
                 'owstaxidmetadataalltagsinfo',
                 'Created',
+                'ListItemID',
                 'UniqueID',
                 'NormSiteID',
                 'NormWebID',
@@ -1140,7 +1141,12 @@ export class SharePointSearchDataSource extends BaseDataSource<ISharePointSearch
             searchQuery.SortList = this._convertToSortList(this.properties.sortList.filter(sort => sort.isDefaultSort));
         }
 
-        searchQuery.SelectProperties = this.properties.selectedProperties.filter(a => a); // Fix to remove null values;
+        const selectProperties = Array.from(new Set([
+            ...this.properties.selectedProperties.filter(Boolean),
+            'ListItemID',
+        ]));
+
+        searchQuery.SelectProperties = selectProperties;
 
         // Audience targeting
         if (this.properties.enableAudienceTargeting) {

--- a/search-parts/src/models/search/ISharePointSearchResults.ts
+++ b/search-parts/src/models/search/ISharePointSearchResults.ts
@@ -11,6 +11,7 @@ export interface ISharePointSearchResult {
     AuthorOWSUSER?: string;
     owstaxidmetadataalltagsinfo?: string;
     Created?: string;
+    ListItemID?: string;
     UniqueID?: string;
     NormSiteID?: string;
     NormWebID?: string;

--- a/search-parts/src/services/selectedItemsEditService/SelectedItemsEditService.ts
+++ b/search-parts/src/services/selectedItemsEditService/SelectedItemsEditService.ts
@@ -40,6 +40,14 @@ interface IPreparedItemValues {
     values: Record<string, unknown>;
 }
 
+interface IContentTypeFieldOrderEntry {
+    StringId?: string;
+    FieldLinks?: Array<{
+        Name?: string;
+        Hidden?: boolean;
+    }>;
+}
+
 export class SelectedItemsEditService implements ISelectedItemsEditService {
 
     public static readonly ServiceKey: ServiceKey<ISelectedItemsEditService> = ServiceKey.create(SelectedItemsEditServiceKey, SelectedItemsEditService);
@@ -47,6 +55,7 @@ export class SelectedItemsEditService implements ISelectedItemsEditService {
     private pageContext: PageContext;
     private spHttpClient: SPHttpClient;
     private readonly fieldCache = new Map<string, Promise<IEditableFieldDescriptor[]>>();
+    private readonly contentTypeFieldOrderCache = new Map<string, Promise<string[]>>();
 
     constructor(private readonly serviceScope: ServiceScope) {
         serviceScope.whenFinished(() => {
@@ -125,6 +134,7 @@ export class SelectedItemsEditService implements ISelectedItemsEditService {
             : [];
 
         if (eligibleItems.length > 0 && commonEditableFields.length > 0) {
+            commonEditableFields = await this.sortEditableFieldsByContentTypeOrder(commonEditableFields, eligibleItems);
             const preparedItemValues = await Promise.all(eligibleItems.map(async (item) => this.getItemFieldValues(item, commonEditableFields)));
             commonEditableFields = this.withAvailableTags(commonEditableFields, preparedItemValues);
             commonEditableFields = this.withSharedValues(commonEditableFields, preparedItemValues);
@@ -608,6 +618,82 @@ export class SelectedItemsEditService implements ISelectedItemsEditService {
         });
 
         return Array.from(tagsByKey.values()).sort((left, right) => left.name.localeCompare(right.name));
+    }
+
+    private async sortEditableFieldsByContentTypeOrder(fields: IEditableFieldDescriptor[], eligibleItems: ISelectedSharePointItemRef[]): Promise<IEditableFieldDescriptor[]> {
+        if (fields.length <= 1 || eligibleItems.length === 0) {
+            return fields;
+        }
+
+        const primaryItem = eligibleItems.find((item) => !!item.contentTypeId) ?? eligibleItems[0];
+
+        if (!primaryItem?.contentTypeId) {
+            return fields;
+        }
+
+        const orderedFieldNames = await this.getContentTypeFieldOrder(primaryItem.webUrl, primaryItem.listId, primaryItem.contentTypeId);
+
+        if (orderedFieldNames.length === 0) {
+            return fields;
+        }
+
+        const fieldOrderByName = new Map<string, number>();
+        orderedFieldNames.forEach((fieldName, index) => {
+            if (!fieldOrderByName.has(fieldName)) {
+                fieldOrderByName.set(fieldName, index);
+            }
+        });
+
+        return [...fields].sort((left, right) => {
+            const leftOrder = fieldOrderByName.get(left.internalName) ?? Number.MAX_SAFE_INTEGER;
+            const rightOrder = fieldOrderByName.get(right.internalName) ?? Number.MAX_SAFE_INTEGER;
+
+            if (leftOrder !== rightOrder) {
+                return leftOrder - rightOrder;
+            }
+
+            return left.title.localeCompare(right.title);
+        });
+    }
+
+    private async getContentTypeFieldOrder(webUrl: string, listId: string, contentTypeId: string): Promise<string[]> {
+        const cacheKey = `${this.getScopeKey(webUrl, listId)}::${contentTypeId.toLowerCase()}`;
+
+        if (!this.contentTypeFieldOrderCache.has(cacheKey)) {
+            this.contentTypeFieldOrderCache.set(cacheKey, this.fetchContentTypeFieldOrder(webUrl, listId, contentTypeId));
+        }
+
+        return this.contentTypeFieldOrderCache.get(cacheKey)!;
+    }
+
+    private async fetchContentTypeFieldOrder(webUrl: string, listId: string, contentTypeId: string): Promise<string[]> {
+        try {
+            const endpoint = `${webUrl.replace(/\/$/, '')}/_api/web/lists/GetById('${this.normalizeGuid(listId)}')/ContentTypes?$select=StringId,Name&$expand=FieldLinks`;
+            const response = await this.spHttpClient.get(endpoint, SPHttpClient.configurations.v1);
+
+            if (!response.ok) {
+                return [];
+            }
+
+            const payload = await response.json();
+            const contentTypes = (payload?.value ?? []) as IContentTypeFieldOrderEntry[];
+            const normalizedContentTypeId = `${contentTypeId ?? ''}`.toLowerCase();
+            const matchingContentType = contentTypes.find((contentType) => `${contentType?.StringId ?? ''}`.toLowerCase() === normalizedContentTypeId)
+                ?? contentTypes
+                    .filter((contentType) => normalizedContentTypeId.startsWith(`${contentType?.StringId ?? ''}`.toLowerCase()))
+                    .sort((left, right) => (`${right?.StringId ?? ''}`.length - `${left?.StringId ?? ''}`.length))[0];
+
+            if (!matchingContentType?.FieldLinks?.length) {
+                return [];
+            }
+
+            return matchingContentType.FieldLinks
+                .filter((fieldLink) => !!fieldLink?.Name && fieldLink.Hidden !== true)
+                .map((fieldLink) => `${fieldLink.Name}`);
+        } catch (error) {
+            Log.warn(LogSource, `Failed to resolve content type field order for '${contentTypeId}'. Falling back to default field ordering. ${(error as Error)?.message ?? ''}`, this.serviceScope);
+            return [];
+        }
     }
 
     private addTaxonomyTagsFromRawValue(rawValue: unknown, tagsByKey: Map<string, { key: string; name: string }>): void {


### PR DESCRIPTION
## Summary
- always request `ListItemID` for SharePoint search results, including existing web part instances with saved selected properties
- use `ListItemID`-backed metadata so multi-select Details resolves editable list items correctly
- order the multi-edit fields by the list content type `FieldLinks` order instead of alphabetical title order
- remove duplicate visible taxonomy field labels in the multi-edit pane

## Validation
- verified in the internal browser debug session on the 4.24x candidate List Items page
- confirmed SharePoint search requests now include `ListItemID`
- confirmed the multi-select Details pane changed from "None of the selected items can be edited" to `2 / 2 selected items can be edited`
- confirmed the rendered multi-edit field order matches the visible subset of the selected content type field order

## Notes
- the repository still has unrelated existing TypeScript watch errors outside this change set