### PR TITLE
fix(details): hide duplicate taxonomy labels in multi-edit pane

### DIFF
--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -666,7 +666,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
                 position: relative;
               }
 
-              .${SELECTED_EDIT_TAXONOMY_PICKER_CLASS} > label {
+              .${SELECTED_EDIT_TAXONOMY_PICKER_CLASS} label {
                 border: 0;
                 clip: rect(0 0 0 0);
                 height: 1px;

--- a/search-parts/src/services/selectedItemsEditService/SelectedItemsEditService.ts
+++ b/search-parts/src/services/selectedItemsEditService/SelectedItemsEditService.ts
@@ -129,15 +129,23 @@ export class SelectedItemsEditService implements ISelectedItemsEditService {
         });
 
         const eligibleScopeKeys = Array.from(new Set(eligibleItems.map((item) => this.getScopeKey(item.webUrl, item.listId))));
-        let commonEditableFields = eligibleScopeKeys.length > 0
+            const commonEditableFields = eligibleScopeKeys.length > 0
             ? this.intersectEditableFields(eligibleScopeKeys.map((scopeKey) => fieldsByScope.get(scopeKey) ?? []))
             : [];
 
         if (eligibleItems.length > 0 && commonEditableFields.length > 0) {
-            commonEditableFields = await this.sortEditableFieldsByContentTypeOrder(commonEditableFields, eligibleItems);
-            const preparedItemValues = await Promise.all(eligibleItems.map(async (item) => this.getItemFieldValues(item, commonEditableFields)));
-            commonEditableFields = this.withAvailableTags(commonEditableFields, preparedItemValues);
-            commonEditableFields = this.withSharedValues(commonEditableFields, preparedItemValues);
+                const sortedEditableFields = await this.sortEditableFieldsByContentTypeOrder(commonEditableFields, eligibleItems);
+                const preparedItemValues = await Promise.all(eligibleItems.map(async (item) => this.getItemFieldValues(item, sortedEditableFields)));
+                const commonEditableFieldsWithTags = this.withAvailableTags(sortedEditableFields, preparedItemValues);
+                const commonEditableFieldsWithSharedValues = this.withSharedValues(commonEditableFieldsWithTags, preparedItemValues);
+
+                return {
+                    eligibleItems,
+                    ineligibleItems,
+                    commonEditableFields: commonEditableFieldsWithSharedValues,
+                    requiresSingleList: listScopes.length > 1,
+                    listScopes,
+                };
         }
 
         return {


### PR DESCRIPTION
## Summary
- update the selected-items taxonomy picker label-hiding selector to match the current rendered DOM
- prevent duplicate visible taxonomy field labels in the multi-edit Details pane
- avoid reassigning selected-item field state across async boundaries in the selected items edit service so the production build passes cleanly
- keep the existing accessibility label in place while hiding the extra visual label

## Validation
- verified in the internal browser debug session on the 4.24x candidate List Items page
- confirmed the taxonomy picker duplicate labels are no longer visibly rendered in the multi-edit pane
- ran \
pm run build\ from \search-parts\ successfully after the selected-items service fix

## Notes
- the taxonomy selector update is a follow-up UI fix to the label handling added in #4908
- the selected-items service change preserves behavior while removing the async reassignment pattern flagged by lint