### PR TITLE
Fix People refiner pills showing UPN instead of display name

### DIFF
--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -272,33 +272,7 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
     }
 
     private readonly getPreferredPeopleValueLabel = (rawValue: string): string => {
-        const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
-        if (!cleanedValue) {
-            return '';
-        }
-
-        const preferredReadablePipeSegment = cleanedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (preferredReadablePipeSegment) {
-            return preferredReadablePipeSegment;
-        }
-
-        const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const preferredDecodedPipeSegment = decodedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (preferredDecodedPipeSegment) {
-            return preferredDecodedPipeSegment;
-        }
-
-        return '';
+        return TaxonomyHelper.extractPreferredPeopleDisplayLabel(rawValue);
     }
 
     private readonly getDisplayName = (rawName: string, rawValue?: string): string => {

--- a/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterSearchBoxComponent.tsx
@@ -277,15 +277,25 @@ export class FilterSearchBox extends React.Component<IFilterSearchBoxProps, IFil
             return '';
         }
 
-        const readablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (readablePipeSegment) {
-            return readablePipeSegment;
+        const preferredReadablePipeSegment = cleanedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (preferredReadablePipeSegment) {
+            return preferredReadablePipeSegment;
         }
 
         const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const decodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (decodedPipeSegment) {
-            return decodedPipeSegment;
+        const preferredDecodedPipeSegment = decodedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (preferredDecodedPipeSegment) {
+            return preferredDecodedPipeSegment;
         }
 
         return '';

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -249,31 +249,13 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
     }
 
     private extractPeopleDisplayValue(rawValue: string): string {
+        const preferredDisplayLabel = TaxonomyHelper.extractPreferredPeopleDisplayLabel(rawValue);
+        if (preferredDisplayLabel) {
+            return preferredDisplayLabel;
+        }
+
         const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
-        if (!cleanedValue) {
-            return '';
-        }
-
-        const preferredReadablePipeSegment = cleanedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (preferredReadablePipeSegment) {
-            return preferredReadablePipeSegment;
-        }
-
         const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const preferredDecodedPipeSegment = decodedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (preferredDecodedPipeSegment) {
-            return preferredDecodedPipeSegment;
-        }
 
         const claimsLabel = TaxonomyHelper.extractClaimsLabel(decodedValue || cleanedValue);
         if (claimsLabel) {

--- a/search-parts/src/components/filters/SelectedFiltersComponent.tsx
+++ b/search-parts/src/components/filters/SelectedFiltersComponent.tsx
@@ -254,15 +254,25 @@ export class SelectedFiltersComponent extends React.Component<ISelectedFiltersPr
             return '';
         }
 
-        const readablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (readablePipeSegment) {
-            return readablePipeSegment;
+        const preferredReadablePipeSegment = cleanedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (preferredReadablePipeSegment) {
+            return preferredReadablePipeSegment;
         }
 
         const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const decodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (decodedPipeSegment) {
-            return decodedPipeSegment;
+        const preferredDecodedPipeSegment = decodedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (preferredDecodedPipeSegment) {
+            return preferredDecodedPipeSegment;
         }
 
         const claimsLabel = TaxonomyHelper.extractClaimsLabel(decodedValue || cleanedValue);

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -117,8 +117,16 @@ export class TaxonomyHelper {
             return '';
         }
 
-        const personLikeLabelMatch = /^([A-Za-z][A-Za-z'-]*(?:\s+[A-Za-z][A-Za-z'-]*)+)$/.exec(cleanedValue);
-        return personLikeLabelMatch?.[1]?.trim() || '';
+        const wordSegment = "[\\p{L}\\p{M}][\\p{L}\\p{M}.'’-]*";
+        const displayNamePattern = new RegExp(`^(${wordSegment}(?:\\s+${wordSegment})+)$`, 'u');
+        const displayNameMatch = displayNamePattern.exec(cleanedValue);
+        if (displayNameMatch?.[1]) {
+            return displayNameMatch[1].trim();
+        }
+
+        const commaNamePattern = new RegExp(`^(${wordSegment}(?:\\s+${wordSegment})*,\\s*${wordSegment}(?:\\s+${wordSegment})*)$`, 'u');
+        const commaNameMatch = commaNamePattern.exec(cleanedValue);
+        return commaNameMatch?.[1]?.trim() || '';
     }
 
     public static extractEmailLikeLabel(value: string): string {
@@ -143,6 +151,36 @@ export class TaxonomyHelper {
             && !this.isTaxonomyTokenPrefix(part)
             && !this.isGuidLikeToken(part));
         return firstReadablePart || '';
+    }
+
+    public static extractPreferredPeopleDisplayLabel(value: string): string {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return '';
+        }
+
+        const getPreferredPipeSegment = (candidateValue: string): string => {
+            const normalizedCandidate = this.normalizeReadableLabelCandidate(candidateValue);
+            if (!normalizedCandidate) {
+                return '';
+            }
+
+            const preferredSegment = normalizedCandidate
+                .split('|')
+                .map(part => part.trim())
+                .filter(Boolean)
+                .find(part => !!this.extractPersonLikeLabel(part));
+
+            return preferredSegment || this.extractFirstReadablePipeSegment(normalizedCandidate);
+        };
+
+        const preferredRawSegment = getPreferredPipeSegment(cleanedValue);
+        if (preferredRawSegment) {
+            return preferredRawSegment;
+        }
+
+        const decodedValue = this.decodeHexString(cleanedValue);
+        return getPreferredPipeSegment(decodedValue);
     }
 
     /**

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -734,15 +734,25 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return '';
         }
 
-        const firstReadablePipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (firstReadablePipeSegment) {
-            return firstReadablePipeSegment;
+        const preferredReadablePipeSegment = cleanedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
+        if (preferredReadablePipeSegment) {
+            return preferredReadablePipeSegment;
         }
 
         const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const readableDecodedPipeSegment = TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (readableDecodedPipeSegment) {
-            return readableDecodedPipeSegment;
+        const preferredDecodedPipeSegment = decodedValue
+            .split('|')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
+            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
+        if (preferredDecodedPipeSegment) {
+            return preferredDecodedPipeSegment;
         }
 
         const readableCleanedValue = this.extractReadableLabelFromString(cleanedValue);

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -729,31 +729,13 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     private extractPreferredPeopleValueDisplayName(rawValue: string): string {
+        const preferredDisplayLabel = TaxonomyHelper.extractPreferredPeopleDisplayLabel(rawValue);
+        if (preferredDisplayLabel) {
+            return preferredDisplayLabel;
+        }
+
         const cleanedValue = TaxonomyHelper.normalizeReadableLabelCandidate(rawValue);
-        if (!cleanedValue) {
-            return '';
-        }
-
-        const preferredReadablePipeSegment = cleanedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(cleanedValue);
-        if (preferredReadablePipeSegment) {
-            return preferredReadablePipeSegment;
-        }
-
         const decodedValue = TaxonomyHelper.decodeHexString(cleanedValue);
-        const preferredDecodedPipeSegment = decodedValue
-            .split('|')
-            .map(part => part.trim())
-            .filter(Boolean)
-            .find(part => !!TaxonomyHelper.extractPersonLikeLabel(part))
-            || TaxonomyHelper.extractFirstReadablePipeSegment(decodedValue);
-        if (preferredDecodedPipeSegment) {
-            return preferredDecodedPipeSegment;
-        }
 
         const readableCleanedValue = this.extractReadableLabelFromString(cleanedValue);
         if (readableCleanedValue) {


### PR DESCRIPTION
## Summary
This PR fixes People refiner labels so display names are shown instead of UPN/email values in all relevant UI paths.

## Changes
- Prefer person-like name segments over first readable pipe segment in People label resolution for filters container.
- Apply the same People label preference logic in selected filter summary rendering.
- Apply the same People label preference logic in in-filter selected pills/tags (search box tag picker).

## Validation
- Built successfully with 
pm run build in search-parts.
- Verified the previous UPN display issue paths now resolve to display names.