### PR TITLE
Fix People template labels and vertical filter operators

### DIFF
--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -162,8 +162,8 @@ export class TaxonomyHelper {
         const lowerValue = cleanedValue.toLowerCase();
         return lowerValue.startsWith('i:0#')
             || lowerValue.startsWith('c:0')
-            || lowerValue.includes('|membership|')
-            || lowerValue.includes('|federateddirectoryclaimprovider|');
+            || lowerValue === 'membership'
+            || lowerValue === 'federateddirectoryclaimprovider';
     }
 
     private static isUpnLikeSegment(value: string): boolean {

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -153,6 +153,68 @@ export class TaxonomyHelper {
         return firstReadablePart || '';
     }
 
+    private static isClaimsLikeSegment(value: string): boolean {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return false;
+        }
+
+        const lowerValue = cleanedValue.toLowerCase();
+        return lowerValue.startsWith('i:0#')
+            || lowerValue.startsWith('c:0')
+            || lowerValue.includes('|membership|')
+            || lowerValue.includes('|federateddirectoryclaimprovider|');
+    }
+
+    private static isUpnLikeSegment(value: string): boolean {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return false;
+        }
+
+        const extractedEmail = this.extractEmailLikeLabel(cleanedValue);
+        return !!extractedEmail && extractedEmail.toLowerCase() === cleanedValue.toLowerCase();
+    }
+
+    private static scorePeopleDisplaySegment(value: string): number {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        if (!cleanedValue) {
+            return 0;
+        }
+
+        if (this.containsEncodedTokenMarker(cleanedValue)
+            || this.isGuidLikeToken(cleanedValue)
+            || this.isTaxonomyTokenPrefix(cleanedValue)) {
+            return 0;
+        }
+
+        if (this.extractPersonLikeLabel(cleanedValue)) {
+            return 5;
+        }
+
+        if (this.isReadablePlainLabel(cleanedValue)
+            && !this.isUpnLikeSegment(cleanedValue)
+            && !this.isClaimsLikeSegment(cleanedValue)) {
+            return 4;
+        }
+
+        if (this.containsReadableLetter(cleanedValue)
+            && !this.isUpnLikeSegment(cleanedValue)
+            && !this.isClaimsLikeSegment(cleanedValue)) {
+            return 3;
+        }
+
+        if (this.extractClaimsLabel(cleanedValue)) {
+            return 2;
+        }
+
+        if (this.isUpnLikeSegment(cleanedValue) || this.extractEmailLikeLabel(cleanedValue)) {
+            return 1;
+        }
+
+        return 0;
+    }
+
     public static extractPreferredPeopleDisplayLabel(value: string): string {
         const cleanedValue = this.normalizeReadableLabelCandidate(value);
         if (!cleanedValue) {
@@ -165,13 +227,27 @@ export class TaxonomyHelper {
                 return '';
             }
 
-            const preferredSegment = normalizedCandidate
+            const segments = normalizedCandidate
                 .split('|')
-                .map(part => part.trim())
-                .filter(Boolean)
-                .find(part => !!this.extractPersonLikeLabel(part));
+                .map(part => this.normalizeReadableLabelCandidate(part))
+                .filter(Boolean);
 
-            return preferredSegment || this.extractFirstReadablePipeSegment(normalizedCandidate);
+            let bestSegment = '';
+            let bestScore = 0;
+
+            segments.forEach(segment => {
+                const score = this.scorePeopleDisplaySegment(segment);
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestSegment = segment;
+                }
+            });
+
+            if (bestSegment) {
+                return bestSegment;
+            }
+
+            return this.extractFirstReadablePipeSegment(normalizedCandidate);
         };
 
         const preferredRawSegment = getPreferredPipeSegment(cleanedValue);

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -283,18 +283,6 @@
 										{{/isnt}}
 									{{else}}
 										{{#if filter.isMulti}}
-											{{#isnt filter.selectedTemplate 'StaticPeopleTemplate'}}
-											<div class="filter--option">
-												<pnp-filteroperator 
-													data-instance-id="{{@root.instanceId}}"
-													data-filter-name="{{filter.filterName}}" 
-													data-operator="{{filter.operator}}" 
-													data-theme-variant="{{JSONstringify @root.theme}}"
-												></pnp-filteroperator>
-											</div>
-											{{/isnt}}
-										{{/if}}
-										{{#if filter.isMulti}}
 											<pnp-filtermultiselect 
 												data-instance-id="{{@root.instanceId}}" 
 												data-filter-name="{{filter.filterName}}" 

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -719,13 +719,18 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return false;
         }
 
-        const readableRawValue = this.extractReadableLabelFromString(rawValue);
-        if (!readableRawValue) {
+        const preferredValueLabel = this.extractPreferredPeopleValueDisplayName(rawValue);
+        if (!preferredValueLabel) {
             return false;
         }
 
         const readableRawName = this.extractReadableLabelFromString(rawName);
-        return readableRawName === rawName && readableRawValue !== rawValue;
+        const normalizedPreferredValueLabel = TaxonomyHelper.normalizeReadableLabelCandidate(preferredValueLabel).toLowerCase();
+        const normalizedReadableRawName = TaxonomyHelper.normalizeReadableLabelCandidate(readableRawName).toLowerCase();
+        const rawNameLooksLikeIdentityToken = !!TaxonomyHelper.extractEmailLikeLabel(readableRawName)
+            || !!TaxonomyHelper.extractClaimsLabel(readableRawName);
+
+        return rawNameLooksLikeIdentityToken || normalizedPreferredValueLabel !== normalizedReadableRawName;
     }
 
     private extractPreferredPeopleValueDisplayName(rawValue: string): string {

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -727,8 +727,14 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         const readableRawName = this.extractReadableLabelFromString(rawName);
         const normalizedPreferredValueLabel = TaxonomyHelper.normalizeReadableLabelCandidate(preferredValueLabel).toLowerCase();
         const normalizedReadableRawName = TaxonomyHelper.normalizeReadableLabelCandidate(readableRawName).toLowerCase();
-        const rawNameLooksLikeIdentityToken = !!TaxonomyHelper.extractEmailLikeLabel(readableRawName)
-            || !!TaxonomyHelper.extractClaimsLabel(readableRawName);
+        const rawNameCandidates = [rawName, TaxonomyHelper.decodeHexString(rawName)]
+            .map(candidate => TaxonomyHelper.normalizeReadableLabelCandidate(candidate))
+            .filter(Boolean);
+        const rawNameLooksLikeIdentityToken = rawNameCandidates.some(candidate => {
+            const emailLabel = TaxonomyHelper.extractEmailLikeLabel(candidate);
+            return (emailLabel && emailLabel.toLowerCase() === candidate.toLowerCase())
+                || !!TaxonomyHelper.extractClaimsLabel(candidate);
+        });
 
         return rawNameLooksLikeIdentityToken || normalizedPreferredValueLabel !== normalizedReadableRawName;
     }


### PR DESCRIPTION
## Summary

- Prefer display names over UPNs in mixed People values.
- Avoid rendering a duplicate filter operator in the vertical filters layout.

## Validation

- SPFx production build completed successfully.
- TypeScript diagnostics reported no errors.