### PR TITLE
perf: cache external layout templates

### DIFF
--- a/search-parts/package-lock.json
+++ b/search-parts/package-lock.json
@@ -27,7 +27,7 @@
                 "@microsoft/sp-property-pane": "1.23.0",
                 "@microsoft/sp-webpart-base": "1.23.0",
                 "@pnp/common": "2.15.0",
-                "@pnp/modern-search-extensibility": "2.0.1",
+                "@pnp/modern-search-extensibility": "2.1.0",
                 "@pnp/spfx-controls-react": "3.24.0",
                 "@pnp/spfx-property-controls": "3.23.0",
                 "@pnp/telemetry-js": "2.0.0",
@@ -7985,9 +7985,9 @@
             "license": "0BSD"
         },
         "node_modules/@pnp/modern-search-extensibility": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@pnp/modern-search-extensibility/-/modern-search-extensibility-2.0.1.tgz",
-            "integrity": "sha512-Z1RtQb4yZ1ywl6NZrHHZvkn9+HXTBRIz1HsBqUyH5Wp3tprU9dsWkn0KgjBG3lOuGCK8bWQjlZUo9ja3JPuuog==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@pnp/modern-search-extensibility/-/modern-search-extensibility-2.1.0.tgz",
+            "integrity": "sha1-MUxmXp2yWUR9KMAbiSBVN/KmkKw=",
             "license": "MIT",
             "dependencies": {
                 "@webcomponents/custom-elements": "^1.6.0",

--- a/search-parts/pnpm-lock.yaml
+++ b/search-parts/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: 2.15.0
         version: 2.15.0
       '@pnp/modern-search-extensibility':
-        specifier: 2.0.1
-        version: 2.0.1(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
+        specifier: 2.1.0
+        version: 2.1.0(react-dom@17.0.1(react@17.0.1))(react@17.0.1)
       '@pnp/spfx-controls-react':
         specifier: 3.24.0
         version: 3.24.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@microsoft/microsoft-graph-client@3.0.2)(@types/node@25.9.1)(@types/react-dom@17.0.17)(@types/react@17.0.45)(scheduler@0.20.2)
@@ -2209,8 +2209,8 @@ packages:
   '@pnp/logging@2.5.0':
     resolution: {integrity: sha512-SnmMCN6oADjiHKAIR23FfTqXeQZeXPBnWeVfyZAgzJfRn9uEQoUlkyET3jHjl9kkrFOVkiOD1CRI7TWMIxURbA==}
 
-  '@pnp/modern-search-extensibility@2.0.1':
-    resolution: {integrity: sha512-Z1RtQb4yZ1ywl6NZrHHZvkn9+HXTBRIz1HsBqUyH5Wp3tprU9dsWkn0KgjBG3lOuGCK8bWQjlZUo9ja3JPuuog==}
+  '@pnp/modern-search-extensibility@2.1.0':
+    resolution: {integrity: sha1-MUxmXp2yWUR9KMAbiSBVN/KmkKw=}
     engines: {node: '>=22.14.0 < 23.0.0'}
     peerDependencies:
       react: '>=16.8.0'
@@ -10797,7 +10797,7 @@ snapshots:
     dependencies:
       tslib: 2.2.0
 
-  '@pnp/modern-search-extensibility@2.0.1(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
+  '@pnp/modern-search-extensibility@2.1.0(react-dom@17.0.1(react@17.0.1))(react@17.0.1)':
     dependencies:
       '@webcomponents/custom-elements': 1.6.0
       handlebars: 4.7.9

--- a/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
+++ b/search-parts/src/components/DetailsSelectedItemButtonComponent.tsx
@@ -192,7 +192,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
   private _syncOpenPanelWithSelection(): void {
     if (this.state.activePanelMode === "editSelectedItems") {
       if (this._selectedItems.length > 1) {
-        void this._prepareSelectedItemsEditPanel();
+        this._prepareSelectedItemsEditPanel().catch(() => undefined);
       } else {
         this._closeDetailsPanel();
       }
@@ -201,7 +201,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     }
 
     if (this.props.allowMulti === true && this._selectedItems.length > 1) {
-      void this._prepareSelectedItemsEditPanel(true);
+      this._prepareSelectedItemsEditPanel(true).catch(() => undefined);
       return;
     }
 
@@ -238,7 +238,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     }
 
     if (this.props.allowMulti === true && this._selectedItems.length > 1) {
-      void this._prepareSelectedItemsEditPanel(true);
+      this._prepareSelectedItemsEditPanel(true).catch(() => undefined);
       return;
     }
 
@@ -492,7 +492,7 @@ export class DetailsSelectedItemButtonComponent extends React.Component<IDetails
     event.stopPropagation();
 
     if (this.props.allowMulti === true && this._selectedItems.length > 1) {
-      void this._prepareSelectedItemsEditPanel(true);
+      this._prepareSelectedItemsEditPanel(true).catch(() => undefined);
       return;
     }
 

--- a/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
+++ b/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
@@ -1,15 +1,15 @@
-import { FileFormat, ITemplateService } from "../services/templateService/ITemplateService";
-import type {
-    IFiltersExtensibilityInput,
-    IResultsExtensibilityInput
-} from "./ExtensibilityUsageHelper";
-
 jest.mock("@pnp/modern-search-extensibility", () => ({
     LayoutRenderType: {
         Handlebars: "Handlebars",
         AdaptiveCards: "AdaptiveCards"
     }
 }));
+
+import { FileFormat, ITemplateService } from "../services/templateService/ITemplateService";
+import type {
+    IFiltersExtensibilityInput,
+    IResultsExtensibilityInput
+} from "./ExtensibilityUsageHelper";
 
 const { LayoutRenderType } = require("@pnp/modern-search-extensibility") as typeof import("@pnp/modern-search-extensibility");
 const { ExtensibilityUsageHelper } = require("./ExtensibilityUsageHelper") as typeof import("./ExtensibilityUsageHelper");

--- a/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
+++ b/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
@@ -1,0 +1,165 @@
+import { LayoutRenderType } from "@pnp/modern-search-extensibility";
+import { FileFormat, ITemplateService } from "../services/templateService/ITemplateService";
+import {
+    ExtensibilityUsageHelper,
+    IFiltersExtensibilityInput,
+    IResultsExtensibilityInput
+} from "./ExtensibilityUsageHelper";
+
+const createTemplateService = (templateContent: string): ITemplateService => ({
+    getFileContent: jest.fn().mockResolvedValue(templateContent),
+    ensureHandlebarsHelpersLoaded: jest.fn().mockResolvedValue(undefined),
+    Handlebars: {
+        helpers: {},
+        partials: {},
+        parse: jest.fn().mockReturnValue({ type: "Program", body: [] })
+    }
+} as unknown as ITemplateService);
+
+const createResultsInput = (templateService: ITemplateService): IResultsExtensibilityInput => ({
+    dataSourceKey: "builtin-data-source",
+    selectedLayoutKey: "builtin-layout",
+    layoutRenderType: LayoutRenderType.Handlebars,
+    queryModifierConfiguration: [],
+    inlineTemplateContent: "",
+    externalTemplateUrl: "https://contoso.sharepoint.com/template.html",
+    layoutProperties: {},
+    resultTypes: [],
+    templateService,
+    builtinDataSourceKeys: ["builtin-data-source"],
+    builtinLayoutKeys: ["builtin-layout"],
+    builtinComponentNames: []
+});
+
+const createFiltersInput = (templateService: ITemplateService): IFiltersExtensibilityInput => ({
+    selectedLayoutKey: "builtin-layout",
+    filtersConfiguration: [],
+    inlineTemplateContent: "",
+    externalTemplateUrl: "https://contoso.sharepoint.com/filter-template.html",
+    layoutProperties: {},
+    templateService,
+    builtinLayoutKeys: ["builtin-layout"],
+    builtinFilterTemplateKeys: [],
+    builtinComponentNames: []
+});
+
+describe("ExtensibilityUsageHelper external templates", () => {
+    it("skips extensibility libraries when an external template uses only built-in features", async () => {
+        const templateService = createTemplateService("<div>{{Title}}</div>");
+
+        await expect(
+            ExtensibilityUsageHelper.getResultsUsage(createResultsInput(templateService))
+        ).resolves.toEqual({
+            usesCustomExtensibility: false,
+            reason: "only out-of-the-box features are used"
+        });
+
+        expect(templateService.getFileContent).toHaveBeenCalledWith(
+            "https://contoso.sharepoint.com/template.html",
+            FileFormat.Text
+        );
+    });
+
+    it("loads extensibility libraries when an external template uses a custom component", async () => {
+        const templateService = createTemplateService("<contoso-result></contoso-result>");
+
+        await expect(
+            ExtensibilityUsageHelper.getResultsUsage(createResultsInput(templateService))
+        ).resolves.toEqual({
+            usesCustomExtensibility: true,
+            reason: "custom web component '<contoso-result>'"
+        });
+    });
+
+    it("inspects Handlebars result-type external templates", async () => {
+        const templateService = createTemplateService("<contoso-result></contoso-result>");
+        const input = createResultsInput(templateService);
+        input.externalTemplateUrl = "";
+        input.resultTypes = [{
+            externalTemplateUrl: "https://contoso.sharepoint.com/result-type.html"
+        } as any];
+
+        await expect(
+            ExtensibilityUsageHelper.getResultsUsage(input)
+        ).resolves.toEqual({
+            usesCustomExtensibility: true,
+            reason: "custom web component '<contoso-result>'"
+        });
+
+        expect(templateService.getFileContent).toHaveBeenCalledWith(
+            "https://contoso.sharepoint.com/result-type.html",
+            FileFormat.Text
+        );
+    });
+
+    it("loads extensibility libraries conservatively when external template inspection fails", async () => {
+        const templateService = createTemplateService("");
+        (templateService.getFileContent as jest.Mock).mockRejectedValue(new Error("network error"));
+
+        await expect(
+            ExtensibilityUsageHelper.getResultsUsage(createResultsInput(templateService))
+        ).resolves.toEqual({
+            usesCustomExtensibility: true,
+            reason: "an external template that could not be inspected"
+        });
+    });
+
+    it("does not prefetch external templates when inspection is disabled for edit mode", async () => {
+        const templateService = createTemplateService("<div>{{Title}}</div>");
+        const input = createResultsInput(templateService);
+        input.inspectExternalTemplates = false;
+
+        await expect(
+            ExtensibilityUsageHelper.getResultsUsage(input)
+        ).resolves.toEqual({
+            usesCustomExtensibility: true,
+            reason: "external template inspection is disabled"
+        });
+
+        expect(templateService.getFileContent).not.toHaveBeenCalled();
+    });
+
+    it("loads Adaptive Card external templates as JSON for inspection", async () => {
+        const templateService = createTemplateService('{"type":"AdaptiveCard"}');
+        const input = createResultsInput(templateService);
+        input.layoutRenderType = LayoutRenderType.AdaptiveCards;
+
+        await ExtensibilityUsageHelper.getResultsUsage(input);
+
+        expect(templateService.getFileContent).toHaveBeenCalledWith(
+            "https://contoso.sharepoint.com/template.html",
+            FileFormat.Json
+        );
+    });
+
+    it("skips extensibility libraries for built-in external filter templates", async () => {
+        const templateService = createTemplateService("<div>{{filter.displayName}}</div>");
+
+        await expect(
+            ExtensibilityUsageHelper.getFiltersUsage(createFiltersInput(templateService))
+        ).resolves.toEqual({
+            usesCustomExtensibility: false,
+            reason: "only out-of-the-box features are used"
+        });
+
+        expect(templateService.getFileContent).toHaveBeenCalledWith(
+            "https://contoso.sharepoint.com/filter-template.html",
+            FileFormat.Text
+        );
+    });
+
+    it("does not prefetch external filter templates when inspection is disabled for edit mode", async () => {
+        const templateService = createTemplateService("<div>{{filter.displayName}}</div>");
+        const input = createFiltersInput(templateService);
+        input.inspectExternalTemplates = false;
+
+        await expect(
+            ExtensibilityUsageHelper.getFiltersUsage(input)
+        ).resolves.toEqual({
+            usesCustomExtensibility: true,
+            reason: "external template inspection is disabled"
+        });
+
+        expect(templateService.getFileContent).not.toHaveBeenCalled();
+    });
+});

--- a/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
+++ b/search-parts/src/helpers/ExtensibilityUsageHelper.test.ts
@@ -1,10 +1,18 @@
-import { LayoutRenderType } from "@pnp/modern-search-extensibility";
 import { FileFormat, ITemplateService } from "../services/templateService/ITemplateService";
-import {
-    ExtensibilityUsageHelper,
+import type {
     IFiltersExtensibilityInput,
     IResultsExtensibilityInput
 } from "./ExtensibilityUsageHelper";
+
+jest.mock("@pnp/modern-search-extensibility", () => ({
+    LayoutRenderType: {
+        Handlebars: "Handlebars",
+        AdaptiveCards: "AdaptiveCards"
+    }
+}));
+
+const { LayoutRenderType } = require("@pnp/modern-search-extensibility") as typeof import("@pnp/modern-search-extensibility");
+const { ExtensibilityUsageHelper } = require("./ExtensibilityUsageHelper") as typeof import("./ExtensibilityUsageHelper");
 
 const createTemplateService = (templateContent: string): ITemplateService => ({
     getFileContent: jest.fn().mockResolvedValue(templateContent),

--- a/search-parts/src/helpers/ExtensibilityUsageHelper.ts
+++ b/search-parts/src/helpers/ExtensibilityUsageHelper.ts
@@ -1,6 +1,6 @@
 import { LayoutRenderType } from "@pnp/modern-search-extensibility";
 import { IDataResultType } from "../models/common/IDataResultType";
-import { ITemplateService } from "../services/templateService/ITemplateService";
+import { FileFormat, ITemplateService } from "../services/templateService/ITemplateService";
 
 // NOTE: this helper intentionally does not import the built-in layout / data source / component /
 // suggestions modules. Those pull in heavy runtime dependencies (all the web component classes and
@@ -41,6 +41,7 @@ export interface IResultsExtensibilityInput {
     layoutProperties: { [key: string]: any };
     resultTypes: IDataResultType[];
     templateService: ITemplateService;
+    inspectExternalTemplates?: boolean;
 
     /**
      * Built-in ("out-of-the-box") identifiers, passed in by the caller so this helper does not have
@@ -62,6 +63,7 @@ export interface IFiltersExtensibilityInput {
     externalTemplateUrl: string;
     layoutProperties: { [key: string]: any };
     templateService: ITemplateService;
+    inspectExternalTemplates?: boolean;
 
     /**
      * Built-in ("out-of-the-box") identifiers, passed in by the caller so this helper does not have
@@ -132,12 +134,18 @@ export class ExtensibilityUsageHelper {
             return { usesCustomExtensibility: true, reason: "an enabled custom query modifier" };
         }
 
-        // 4. External templates cannot be inspected up front — be conservative and load.
-        if (input.externalTemplateUrl || (input.resultTypes || []).some(rt => rt && rt.externalTemplateUrl)) {
-            return { usesCustomExtensibility: true, reason: "an external template that cannot be inspected" };
+        if (
+            input.inspectExternalTemplates === false
+            && (input.externalTemplateUrl || (input.resultTypes || []).some(resultType => resultType?.externalTemplateUrl))
+        ) {
+            return { usesCustomExtensibility: true, reason: "external template inspection is disabled" };
         }
 
-        const { templates, truncated } = this.collectResultsTemplates(input);
+        const { templates, truncated, externalTemplateError } = await this.collectResultsTemplates(input);
+
+        if (externalTemplateError) {
+            return { usesCustomExtensibility: true, reason: "an external template that could not be inspected" };
+        }
 
         // If the configuration was too large or deeply nested to fully inspect, we can't be certain
         // the templates are free of custom components/helpers — conservatively load (bias to a false
@@ -197,9 +205,8 @@ export class ExtensibilityUsageHelper {
             return { usesCustomExtensibility: true, reason: `custom filter control '${customControl.selectedTemplate}'` };
         }
 
-        // 3. External templates cannot be inspected up front — be conservative and load.
-        if (input.externalTemplateUrl) {
-            return { usesCustomExtensibility: true, reason: "an external template that cannot be inspected" };
+        if (input.inspectExternalTemplates === false && input.externalTemplateUrl) {
+            return { usesCustomExtensibility: true, reason: "external template inspection is disabled" };
         }
 
         const templates: string[] = [];
@@ -207,6 +214,14 @@ export class ExtensibilityUsageHelper {
 
         if (input.inlineTemplateContent) {
             templates.push(input.inlineTemplateContent);
+        }
+
+        if (input.externalTemplateUrl) {
+            try {
+                templates.push(await input.templateService.getFileContent(input.externalTemplateUrl, FileFormat.Text));
+            } catch {
+                return { usesCustomExtensibility: true, reason: "an external template that could not be inspected" };
+            }
         }
 
         this.collectStrings(input.layoutProperties, templates, 0, state);
@@ -274,13 +289,27 @@ export class ExtensibilityUsageHelper {
      * Gathers every inline template / field snippet configured on the Web Part so it can be
      * inspected for custom components, helpers or partials.
      */
-    private static collectResultsTemplates(input: IResultsExtensibilityInput): { templates: string[]; truncated: boolean } {
+    private static async collectResultsTemplates(input: IResultsExtensibilityInput): Promise<{
+        templates: string[];
+        truncated: boolean;
+        externalTemplateError: boolean;
+    }> {
 
         const templates: string[] = [];
         const state = { truncated: false };
+        const externalTemplateRequests: Promise<string>[] = [];
 
         if (input.inlineTemplateContent) {
             templates.push(input.inlineTemplateContent);
+        }
+
+        if (input.externalTemplateUrl) {
+            const fileFormat = input.layoutRenderType === LayoutRenderType.AdaptiveCards
+                ? FileFormat.Json
+                : FileFormat.Text;
+            externalTemplateRequests.push(
+                input.templateService.getFileContent(input.externalTemplateUrl, fileFormat)
+            );
         }
 
         // Column / field templates live under layoutProperties (e.g. Details List columns,
@@ -292,9 +321,19 @@ export class ExtensibilityUsageHelper {
             if (rt && rt.inlineTemplateContent) {
                 templates.push(rt.inlineTemplateContent);
             }
+            if (rt?.externalTemplateUrl) {
+                externalTemplateRequests.push(
+                    input.templateService.getFileContent(rt.externalTemplateUrl, FileFormat.Text)
+                );
+            }
         });
 
-        return { templates, truncated: state.truncated };
+        try {
+            templates.push(...await Promise.all(externalTemplateRequests));
+            return { templates, truncated: state.truncated, externalTemplateError: false };
+        } catch {
+            return { templates, truncated: state.truncated, externalTemplateError: true };
+        }
     }
 
     /**

--- a/search-parts/src/services/templateService/ExpiringPromiseCache.test.ts
+++ b/search-parts/src/services/templateService/ExpiringPromiseCache.test.ts
@@ -66,4 +66,14 @@ describe("ExpiringPromiseCache", () => {
         cache.delete("template");
         await expect(cache.get("template", valueFactory)).resolves.toBe("second");
     });
+
+    it("disables caching when capacity is not positive", async () => {
+        const valueFactory = jest.fn().mockResolvedValue("content");
+        const cache = new ExpiringPromiseCache<string>(60_000, 0);
+
+        await cache.get("template", valueFactory);
+        await cache.get("template", valueFactory);
+
+        expect(valueFactory).toHaveBeenCalledTimes(2);
+    });
 });

--- a/search-parts/src/services/templateService/ExpiringPromiseCache.test.ts
+++ b/search-parts/src/services/templateService/ExpiringPromiseCache.test.ts
@@ -1,0 +1,69 @@
+import { ExpiringPromiseCache } from "./ExpiringPromiseCache";
+
+describe("ExpiringPromiseCache", () => {
+    it("deduplicates in-flight requests and caches successful values", async () => {
+        let resolveValue: (value: string) => void;
+        const pendingValue = new Promise<string>((resolve) => { resolveValue = resolve; });
+        const valueFactory = jest.fn(() => pendingValue);
+        const cache = new ExpiringPromiseCache<string>(60_000, 10);
+
+        const first = cache.get("template", valueFactory);
+        const second = cache.get("template", valueFactory);
+
+        expect(first).toBe(second);
+        await Promise.resolve();
+        expect(valueFactory).toHaveBeenCalledTimes(1);
+
+        resolveValue("content");
+        await expect(first).resolves.toBe("content");
+        await expect(cache.get("template", valueFactory)).resolves.toBe("content");
+        expect(valueFactory).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads successful values after the TTL", async () => {
+        let currentTime = 1_000;
+        const valueFactory = jest.fn()
+            .mockResolvedValueOnce("first")
+            .mockResolvedValueOnce("second");
+        const cache = new ExpiringPromiseCache<string>(60_000, 10, () => currentTime);
+
+        await expect(cache.get("template", valueFactory)).resolves.toBe("first");
+        currentTime += 60_001;
+        await expect(cache.get("template", valueFactory)).resolves.toBe("second");
+        expect(valueFactory).toHaveBeenCalledTimes(2);
+    });
+
+    it("evicts rejected requests so they can be retried", async () => {
+        const valueFactory = jest.fn()
+            .mockRejectedValueOnce(new Error("temporary failure"))
+            .mockResolvedValueOnce("recovered");
+        const cache = new ExpiringPromiseCache<string>(60_000, 10);
+
+        await expect(cache.get("template", valueFactory)).rejects.toThrow("temporary failure");
+        await expect(cache.get("template", valueFactory)).resolves.toBe("recovered");
+        expect(valueFactory).toHaveBeenCalledTimes(2);
+    });
+
+    it("bounds retained entries", async () => {
+        const cache = new ExpiringPromiseCache<string>(60_000, 2);
+        const firstFactory = jest.fn().mockResolvedValue("first");
+
+        await cache.get("first", firstFactory);
+        await cache.get("second", () => Promise.resolve("second"));
+        await cache.get("third", () => Promise.resolve("third"));
+        await cache.get("first", firstFactory);
+
+        expect(firstFactory).toHaveBeenCalledTimes(2);
+    });
+
+    it("allows a cached value to be invalidated", async () => {
+        const valueFactory = jest.fn()
+            .mockResolvedValueOnce("first")
+            .mockResolvedValueOnce("second");
+        const cache = new ExpiringPromiseCache<string>(60_000, 10);
+
+        await expect(cache.get("template", valueFactory)).resolves.toBe("first");
+        cache.delete("template");
+        await expect(cache.get("template", valueFactory)).resolves.toBe("second");
+    });
+});

--- a/search-parts/src/services/templateService/ExpiringPromiseCache.ts
+++ b/search-parts/src/services/templateService/ExpiringPromiseCache.ts
@@ -17,6 +17,10 @@ export class ExpiringPromiseCache<T> {
     ) { }
 
     public get(key: string, valueFactory: () => Promise<T>): Promise<T> {
+        if (this.maxEntries <= 0) {
+            return Promise.resolve().then(valueFactory);
+        }
+
         const currentTime = this.now();
         const cachedEntry = this.entries.get(key);
 

--- a/search-parts/src/services/templateService/ExpiringPromiseCache.ts
+++ b/search-parts/src/services/templateService/ExpiringPromiseCache.ts
@@ -1,0 +1,77 @@
+interface IExpiringPromiseCacheEntry<T> {
+    promise: Promise<T>;
+    expiresAt: number;
+}
+
+/**
+ * Deduplicates in-flight work and temporarily retains successful results.
+ * Rejected promises are evicted immediately so transient failures can be retried.
+ */
+export class ExpiringPromiseCache<T> {
+    private readonly entries: Map<string, IExpiringPromiseCacheEntry<T>> = new Map();
+
+    public constructor(
+        private readonly ttlMs: number,
+        private readonly maxEntries: number,
+        private readonly now: () => number = Date.now
+    ) { }
+
+    public get(key: string, valueFactory: () => Promise<T>): Promise<T> {
+        const currentTime = this.now();
+        const cachedEntry = this.entries.get(key);
+
+        if (cachedEntry && cachedEntry.expiresAt > currentTime) {
+            return cachedEntry.promise;
+        }
+
+        if (cachedEntry) {
+            this.entries.delete(key);
+        }
+
+        this.removeExpiredEntries(currentTime);
+        this.removeOldestEntriesAtCapacity();
+
+        const promise = Promise.resolve().then(valueFactory);
+        const entry: IExpiringPromiseCacheEntry<T> = {
+            promise,
+            // Keep in-flight requests cacheable regardless of network latency.
+            expiresAt: Number.POSITIVE_INFINITY
+        };
+
+        this.entries.set(key, entry);
+
+        promise.then(
+            () => {
+                if (this.entries.get(key) === entry) {
+                    entry.expiresAt = this.now() + this.ttlMs;
+                }
+            },
+            () => {
+                if (this.entries.get(key) === entry) {
+                    this.entries.delete(key);
+                }
+            }
+        );
+
+        return promise;
+    }
+
+    public delete(key: string): void {
+        this.entries.delete(key);
+    }
+
+    private removeExpiredEntries(currentTime: number): void {
+        this.entries.forEach((entry, key) => {
+            if (entry.expiresAt <= currentTime) {
+                this.entries.delete(key);
+            }
+        });
+    }
+
+    private removeOldestEntriesAtCapacity(): void {
+        while (this.entries.size >= this.maxEntries) {
+            const oldestKey = this.entries.keys().next().value as string;
+            this.entries.delete(oldestKey);
+        }
+    }
+}

--- a/search-parts/src/services/templateService/ExpiringSessionStorageCache.test.ts
+++ b/search-parts/src/services/templateService/ExpiringSessionStorageCache.test.ts
@@ -29,6 +29,7 @@ describe("ExpiringSessionStorageCache", () => {
         const cache = new ExpiringSessionStorageCache("templates", 60_000, () => storage);
 
         expect(cache.get("url")).toBeUndefined();
+        expect(storage.removeItem).toHaveBeenCalledWith("templates:url");
     });
 
     it("continues when browser storage is unavailable", () => {

--- a/search-parts/src/services/templateService/ExpiringSessionStorageCache.test.ts
+++ b/search-parts/src/services/templateService/ExpiringSessionStorageCache.test.ts
@@ -1,0 +1,42 @@
+import { ExpiringSessionStorageCache } from "./ExpiringSessionStorageCache";
+
+const createStorage = () => {
+    const values = new Map<string, string>();
+    return {
+        getItem: jest.fn((key: string) => values.get(key) ?? null),
+        setItem: jest.fn((key: string, value: string) => { values.set(key, value); }),
+        removeItem: jest.fn((key: string) => { values.delete(key); })
+    };
+};
+
+describe("ExpiringSessionStorageCache", () => {
+    it("retains content until its TTL expires", () => {
+        let currentTime = 1_000;
+        const storage = createStorage();
+        const cache = new ExpiringSessionStorageCache("templates", 60_000, () => storage, () => currentTime);
+
+        cache.set("url", "content");
+        expect(cache.get("url")).toBe("content");
+
+        currentTime += 60_001;
+        expect(cache.get("url")).toBeUndefined();
+        expect(storage.removeItem).toHaveBeenCalledWith("templates:url");
+    });
+
+    it("ignores malformed entries", () => {
+        const storage = createStorage();
+        storage.setItem("templates:url", "not-json");
+        const cache = new ExpiringSessionStorageCache("templates", 60_000, () => storage);
+
+        expect(cache.get("url")).toBeUndefined();
+    });
+
+    it("continues when browser storage is unavailable", () => {
+        const cache = new ExpiringSessionStorageCache("templates", 60_000, () => {
+            throw new Error("storage disabled");
+        });
+
+        expect(cache.get("url")).toBeUndefined();
+        expect(() => cache.set("url", "content")).not.toThrow();
+    });
+});

--- a/search-parts/src/services/templateService/ExpiringSessionStorageCache.ts
+++ b/search-parts/src/services/templateService/ExpiringSessionStorageCache.ts
@@ -32,12 +32,13 @@ export class ExpiringSessionStorageCache {
                 || typeof entry.expiresAt !== "number"
                 || entry.expiresAt <= this.now()
             ) {
-                this.storageProvider().removeItem(storageKey);
+                this.remove(storageKey);
                 return undefined;
             }
 
             return entry.content;
         } catch {
+            this.remove(storageKey);
             return undefined;
         }
     }
@@ -57,5 +58,13 @@ export class ExpiringSessionStorageCache {
 
     private getStorageKey(key: string): string {
         return `${this.keyPrefix}:${key}`;
+    }
+
+    private remove(storageKey: string): void {
+        try {
+            this.storageProvider().removeItem(storageKey);
+        } catch {
+            // Storage cleanup is best-effort when browser storage is unavailable.
+        }
     }
 }

--- a/search-parts/src/services/templateService/ExpiringSessionStorageCache.ts
+++ b/search-parts/src/services/templateService/ExpiringSessionStorageCache.ts
@@ -1,0 +1,61 @@
+interface IExpiringSessionStorageCacheEntry {
+    content: string;
+    expiresAt: number;
+}
+
+type StorageProvider = () => Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Stores external template content for the lifetime of the browser tab, bounded by a TTL.
+ * Storage access is best-effort because browsers can disable it or reject writes at quota.
+ */
+export class ExpiringSessionStorageCache {
+    public constructor(
+        private readonly keyPrefix: string,
+        private readonly ttlMs: number,
+        private readonly storageProvider: StorageProvider = () => globalThis.sessionStorage,
+        private readonly now: () => number = Date.now
+    ) { }
+
+    public get(key: string): string | undefined {
+        const storageKey = this.getStorageKey(key);
+
+        try {
+            const serializedEntry = this.storageProvider().getItem(storageKey);
+            if (!serializedEntry) {
+                return undefined;
+            }
+
+            const entry = JSON.parse(serializedEntry) as IExpiringSessionStorageCacheEntry;
+            if (
+                typeof entry?.content !== "string"
+                || typeof entry.expiresAt !== "number"
+                || entry.expiresAt <= this.now()
+            ) {
+                this.storageProvider().removeItem(storageKey);
+                return undefined;
+            }
+
+            return entry.content;
+        } catch {
+            return undefined;
+        }
+    }
+
+    public set(key: string, content: string): void {
+        const entry: IExpiringSessionStorageCacheEntry = {
+            content,
+            expiresAt: this.now() + this.ttlMs
+        };
+
+        try {
+            this.storageProvider().setItem(this.getStorageKey(key), JSON.stringify(entry));
+        } catch {
+            // Session storage may be disabled or at quota. The in-memory cache still applies.
+        }
+    }
+
+    private getStorageKey(key: string): string {
+        return `${this.keyPrefix}:${key}`;
+    }
+}

--- a/search-parts/src/services/templateService/ITemplateService.ts
+++ b/search-parts/src/services/templateService/ITemplateService.ts
@@ -21,7 +21,7 @@ export interface ITemplateService {
   MgtCustomElementHelper: any;
   getTemplateMarkup(templateContent: string): string;
   getPlaceholderMarkup(templateContent: string): string;
-  getFileContent(fileUrl: string, fileFormat: FileFormat): Promise<string>;
+  getFileContent(fileUrl: string, fileFormat: FileFormat, bypassCache?: boolean): Promise<string>;
   ensureFileResolves(fileUrl: string): Promise<void>;
   isValidTemplateFile(filePath: string, validExtensions: string[]): boolean;
   processTemplate(
@@ -38,7 +38,7 @@ export interface ITemplateService {
     item: { [key: string]: any },
     context?: ISearchResultsTemplateContext | any
   ): T;
-  registerResultTypes(resultTypes: IDataResultType[]): Promise<void>;
+  registerResultTypes(resultTypes: IDataResultType[], bypassCache?: boolean): Promise<void>;
   ensureHandlebarsHelpersLoaded(): Promise<void>;
   replaceDisambiguatedMgtElementNames(template: Document): Promise<void>;
   legacyStyleParser(style: HTMLStyleElement, elementPrefixId: string): string;

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -667,7 +667,11 @@ export class TemplateService implements ITemplateService {
         fileFormat: FileFormat,
         bypassCache: boolean = false
     ): Promise<string> {
-        const normalizedFileUrl = fileUrl.trim();
+        const normalizedFileUrl = fileUrl?.trim();
+        if (!normalizedFileUrl) {
+            throw new TypeError("fileUrl");
+        }
+
         const userId = this.pageContext?.legacyPageContext?.userId ?? "anonymous";
         const cacheKey = `${userId}:${fileFormat}:${normalizedFileUrl}`;
 

--- a/search-parts/src/services/templateService/TemplateService.ts
+++ b/search-parts/src/services/templateService/TemplateService.ts
@@ -6,7 +6,7 @@ import {
     ServiceKey,
     ServiceScope,
 } from "@microsoft/sp-core-library";
-import { SPHttpClient, SPHttpClientResponse } from "@microsoft/sp-http";
+import { ISPHttpClientOptions, SPHttpClient, SPHttpClientResponse } from "@microsoft/sp-http";
 import * as Handlebars from "handlebars";
 import {
     trimEnd,
@@ -47,9 +47,16 @@ import { getHandlebarsHelpers } from "../../helpers/HandlebarsHelpers";
 import { ServiceScopeHelper } from "../../helpers/ServiceScopeHelper";
 import { DomPurifyHelper } from "../../helpers/DomPurifyHelper";
 import { IAdaptiveCardAction } from "@pnp/modern-search-extensibility";
+import { ExpiringPromiseCache } from "./ExpiringPromiseCache";
+import { ExpiringSessionStorageCache } from "./ExpiringSessionStorageCache";
 
 const TemplateService_ServiceKey = "PnPModernSearchTemplateService";
 const TemplateService_LogSource = "PnPModernSearch:TemplateService";
+const ExternalTemplateCacheKey = "PnPModernSearch:ExternalTemplateCache:v2";
+const ExternalTemplateSessionStorageKey = "PnPModernSearch:ExternalTemplate:v2";
+const ExternalTemplateMemoryCacheTtlMs = 60 * 1000;
+const ExternalTemplateSessionCacheTtlMs = 60 * 60 * 1000;
+const ExternalTemplateCacheMaxEntries = 100;
 
 /**
  * The CSS identifer to load the template markup from a layout html file
@@ -72,6 +79,10 @@ export class TemplateService implements ITemplateService {
     private _adaptiveCardsTemplating;
     private _serializationContext;
     private _extendedHelpersPromise: Promise<void> | null = null;
+    private readonly externalTemplateSessionCache = new ExpiringSessionStorageCache(
+        ExternalTemplateSessionStorageKey,
+        ExternalTemplateSessionCacheTtlMs
+    );
 
     /**
      * The dayjs library reference. Initialized synchronously to the imported
@@ -653,7 +664,53 @@ export class TemplateService implements ITemplateService {
      */
     public async getFileContent(
         fileUrl: string,
-        fileFormat: FileFormat
+        fileFormat: FileFormat,
+        bypassCache: boolean = false
+    ): Promise<string> {
+        const normalizedFileUrl = fileUrl.trim();
+        const userId = this.pageContext?.legacyPageContext?.userId ?? "anonymous";
+        const cacheKey = `${userId}:${fileFormat}:${normalizedFileUrl}`;
+
+        if (bypassCache) {
+            const content = await this.loadFileContent(normalizedFileUrl, fileFormat, true);
+            this.getExternalTemplateCache().delete(cacheKey);
+            this.externalTemplateSessionCache.set(cacheKey, content);
+            return content;
+        }
+
+        return this.getExternalTemplateCache().get(
+            cacheKey,
+            async () => {
+                const sessionContent = this.externalTemplateSessionCache.get(cacheKey);
+                if (sessionContent !== undefined) {
+                    return sessionContent;
+                }
+
+                const content = await this.loadFileContent(normalizedFileUrl, fileFormat);
+                this.externalTemplateSessionCache.set(cacheKey, content);
+                return content;
+            }
+        );
+    }
+
+    private getExternalTemplateCache(): ExpiringPromiseCache<string> {
+        let cache = GlobalSettings.getValue<ExpiringPromiseCache<string>>(ExternalTemplateCacheKey);
+
+        if (!cache) {
+            cache = new ExpiringPromiseCache<string>(
+                ExternalTemplateMemoryCacheTtlMs,
+                ExternalTemplateCacheMaxEntries
+            );
+            GlobalSettings.setValue(ExternalTemplateCacheKey, cache);
+        }
+
+        return cache;
+    }
+
+    private async loadFileContent(
+        fileUrl: string,
+        fileFormat: FileFormat,
+        bypassBrowserCache: boolean = false
     ): Promise<string> {
         let headers: HeadersInit = {
             "X-ClientService-ClientTag": Constants.X_CLIENTSERVICE_CLIENTTAG,
@@ -665,12 +722,15 @@ export class TemplateService implements ITemplateService {
             headers["Accept"] = "application/json";
         }
 
+        const requestOptions: ISPHttpClientOptions = { headers };
+        if (bypassBrowserCache) {
+            requestOptions.cache = "no-store";
+        }
+
         const response: SPHttpClientResponse = await this.spHttpClient.get(
             fileUrl,
             SPHttpClient.configurations.v1,
-            {
-                headers,
-            }
+            requestOptions
         );
 
         if (response.ok) {
@@ -957,13 +1017,14 @@ export class TemplateService implements ITemplateService {
      * @param resultTypes the configured result types from the property pane
      */
     public async registerResultTypes(
-        resultTypes: IDataResultType[]
+        resultTypes: IDataResultType[],
+        bypassCache: boolean = false
     ): Promise<void> {
         await this._ensureExtendedHelpers();
         this.Handlebars.unregisterPartial("resultTypes");
 
         if (resultTypes.length > 0) {
-            let content = await this._buildCondition(resultTypes, resultTypes[0], 0);
+            let content = await this._buildCondition(resultTypes, resultTypes[0], 0, bypassCache);
             let template = this.Handlebars.compile(content);
 
             this.Handlebars.registerPartial("resultTypes", template);
@@ -1135,7 +1196,8 @@ export class TemplateService implements ITemplateService {
     private async _buildCondition(
         resultTypes: IDataResultType[],
         currentResultType: IDataResultType,
-        currentIdx: number
+        currentIdx: number,
+        bypassCache: boolean
     ): Promise<string> {
         let conditionBlockContent;
         let templateContent = currentResultType.inlineTemplateContent;
@@ -1143,7 +1205,8 @@ export class TemplateService implements ITemplateService {
         if (currentResultType.externalTemplateUrl) {
             templateContent = await this.getFileContent(
                 currentResultType.externalTemplateUrl,
-                FileFormat.Text
+                FileFormat.Text,
+                bypassCache
             );
         }
 
@@ -1184,7 +1247,8 @@ export class TemplateService implements ITemplateService {
                 conditionBlockContent = await this._buildCondition(
                     resultTypes,
                     resultTypes[currentIdx + 1],
-                    currentIdx + 1
+                    currentIdx + 1,
+                    bypassCache
                 );
             }
 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -1763,7 +1763,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
             if (this.properties.externalTemplateUrl) {
                 // We do not support filters as adaptive cards
-                this.templateContentToDisplay = await this.templateService.getFileContent(this.properties.externalTemplateUrl, FileFormat.Text);
+                this.templateContentToDisplay = await this.templateService.getFileContent(
+                    this.properties.externalTemplateUrl,
+                    FileFormat.Text,
+                    this.displayMode === DisplayMode.Edit
+                );
             } else {
                 this.templateContentToDisplay = this.properties.inlineTemplateContent ? this.properties.inlineTemplateContent : selectedLayoutTemplateContent;
             }
@@ -1843,6 +1847,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                     externalTemplateUrl: this.properties.externalTemplateUrl,
                     layoutProperties: this.properties.layoutProperties,
                     templateService: this.templateService,
+                    inspectExternalTemplates: this.displayMode !== DisplayMode.Edit,
                     builtinLayoutKeys: AvailableLayouts.BuiltinLayouts.map(layout => layout.key),
                     builtinFilterTemplateKeys: Object.keys(BuiltinFilterTypes),
                     builtinComponentNames: this.availableWebComponentDefinitions.map(component => component.componentName)

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -1184,6 +1184,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     layoutProperties: this.properties.layoutProperties,
                     resultTypes: this.properties.resultTypes,
                     templateService: this.templateService,
+                    inspectExternalTemplates: this.displayMode !== DisplayMode.Edit,
                     builtinDataSourceKeys: AvailableDataSources.BuiltinDataSources.map(d => d.key),
                     builtinLayoutKeys: AvailableLayouts.BuiltinLayouts.map(l => l.key),
                     builtinComponentNames: this.availableWebComponentDefinitions.map(c => c.componentName)
@@ -2070,7 +2071,11 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
             if (this.properties.externalTemplateUrl) {
                 let fileFormat: FileFormat = this.properties.layoutRenderType === LayoutRenderType.AdaptiveCards ? FileFormat.Json : FileFormat.Text;
-                this.templateContentToDisplay = await this.templateService.getFileContent(this.properties.externalTemplateUrl, fileFormat);
+                this.templateContentToDisplay = await this.templateService.getFileContent(
+                    this.properties.externalTemplateUrl,
+                    fileFormat,
+                    this.displayMode === DisplayMode.Edit
+                );
             } else {
                 this.templateContentToDisplay = this.properties.inlineTemplateContent ? this.properties.inlineTemplateContent : selectedLayoutTemplateContent;
             }
@@ -2084,7 +2089,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         // Register result types inside the template      
         if (this.properties.layoutRenderType === LayoutRenderType.Handlebars && this.templateService) {
-            await this.templateService.registerResultTypes(this.properties.resultTypes);
+            await this.templateService.registerResultTypes(
+                this.properties.resultTypes,
+                this.displayMode === DisplayMode.Edit
+            );
 
             // extract all used slot names from result types
             this.resultTypesSlotNames = [];


### PR DESCRIPTION
## Summary
- optimize the **Use an external template URL** feature for Custom Search Results and Search Filters layouts
- deduplicate concurrent requests and retain successful content in memory for 60 seconds
- persist template content in user-scoped `sessionStorage` for one hour, covering page reloads and SPA navigation in the same tab
- in edit mode, skip pre-inspection and always fetch with browser `cache: no-store`; the fresh response replaces cached content for later read mode
- inspect external template content in read mode before loading enabled extensibility libraries, avoiding retry/backoff delays when templates use only built-in features
- cover Handlebars, Adaptive Cards, Search Filters, and external Handlebars result-type templates

## Cache behavior
`SPHttpClient` does not enable its optional SPFx data cache for these calls. It ultimately uses `window.fetch`, so the normal browser HTTP cache may additionally apply when the template host sends suitable response headers. The application cache is therefore deterministic even when SharePoint/CDN headers do not permit useful browser caching.

## Build dependency
- published `@pnp/modern-search-extensibility@2.1.0` through the repository release workflow
- synchronized `package-lock.json` and `pnpm-lock.yaml` from stale 2.0.1 entries to 2.1.0
- adjusted the Jest suite to mock the ESM-only package before loading the CommonJS helper

## Why
External custom layouts were fetched on every web part render (query, paging, sorting, filtering, theme/property changes). In addition, any external template conservatively forced enabled extensibility libraries to load; an unavailable library can add retry delays of 500 ms and 1 s before the template request starts.

## Validation
- full `npm run build` passed
- TypeScript and webpack production build passed
- 17 Jest tests passed
- SharePoint `.sppkg` packaging passed
- frozen pnpm lockfile validation passed
- `git diff --check` passed

No unresolved review threads remain.
