### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_docs:
+        type: boolean
         default: true
         description: 'Publish docs?' 
       
@@ -11,14 +12,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: production
-    if: ${{ github.event.inputs.publish_docs }}
+    if: ${{ inputs.publish_docs }}
     steps:     
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: 3.x
           

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,23 +19,23 @@ jobs:
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             # setup nodejs
             - name: Use Node.js 22
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
                   registry-url: "https://registry.npmjs.org"
             # Setup pnpm for consistent dependency management
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 10.26.0
 
             # cache node modules
             - name: Cache node modules
               id: cache
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: |
                       **/node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
         outputs:
             majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
-            semver: ${{ steps.gitversion.outputs.semver }}
+            semver: ${{ steps.gitversion.outputs.semVer }}
             branchName: ${{ steps.gitversion.outputs.branchName }}
 
         steps:
@@ -36,7 +36,7 @@ jobs:
             - name: Setup GitVersion
               uses: gittools/actions/gitversion/setup@v4.7.0
               with:
-                  versionSpec: "6.0"
+                  versionSpec: "6.2.x"
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v6
@@ -53,6 +53,9 @@ jobs:
               uses: gittools/actions/gitversion/execute@v4.7.0
 
             - name: Build SPFx
+              env:
+                  GITVERSION_MAJORMINORPATCH: ${{ steps.gitversion.outputs.majorMinorPatch }}
+                  GITVERSION_SEMVER: ${{ steps.gitversion.outputs.semVer }}
               run: |
                   pnpm install
                   # Detect build system: heft for SPFx 1.22+, gulp for earlier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,28 +29,28 @@ jobs:
             branchName: ${{ steps.gitversion.outputs.branchName }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
             - name: Setup GitVersion
-              uses: gittools/actions/gitversion/setup@v3.0.0
+              uses: gittools/actions/gitversion/setup@v4.7.0
               with:
                   versionSpec: "6.0"
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 10.26.0
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
 
             - name: Determine Version
               id: gitversion
-              uses: gittools/actions/gitversion/execute@v3.0.0
+              uses: gittools/actions/gitversion/execute@v4.7.0
 
             - name: Build SPFx
               run: |
@@ -69,7 +69,7 @@ jobs:
                   fi
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: pnp-modern-search-parts-v4
                   path: ${{ github.workspace }}/**/*.sppkg
@@ -83,11 +83,11 @@ jobs:
         needs: build
         if: contains(needs.build.outputs['branchName'], 'main')
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
 
             - name: Create GitHub release
               uses: ncipollo/release-action@v1
@@ -104,7 +104,7 @@ jobs:
                   commit: ${{ github.ref_name }}
 
             - name: Setup python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v7
               with:
                   python-version: 3.x
 


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions from Node 20-based releases to Node 24-compatible releases
- update GitVersion actions and use the supported GitVersion.Tool 6.2 line
- type the manual documentation workflow input

## Validation
- workflow YAML parsed locally
- main release build passed through SPFx build and artifact upload

This commit is already present on `main`; this PR synchronizes the workflow changes back to `develop` because direct pushes are blocked by repository rules.