### PR TITLE
Fix Search Filters extensibility inheritance

### DIFF
--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -45,6 +45,8 @@ Each Web Part type in the solution supports several extensions or no extension a
 | **Search box** | <ul><li>Custom suggestions providers.</li></ul>
 | **Search Verticals** | None.
 
+For backward compatibility, a Search Filters Web Part with its extensibility configuration left at the disabled default inherits enabled libraries from connected Search Results Web Parts. As soon as libraries are configured explicitly on Search Filters, that configuration takes precedence.
+
 ### Context and data available to each extension type
 
 Different extension types receive different runtime context. This table summarises **what each extension can access** so you don't have to dig through each individual doc page.

--- a/search-parts/src/helpers/ExtensibilityConfigurationHelper.test.ts
+++ b/search-parts/src/helpers/ExtensibilityConfigurationHelper.test.ts
@@ -1,0 +1,68 @@
+import { Constants } from "../common/Constants";
+import { IExtensibilityConfiguration } from "../models/common/IExtensibilityConfiguration";
+import { ExtensibilityConfigurationHelper } from "./ExtensibilityConfigurationHelper";
+
+const configuration = (id: string, enabled: boolean, name: string = id): IExtensibilityConfiguration => ({
+    id,
+    enabled,
+    name
+});
+
+const defaultFiltersConfiguration = (): IExtensibilityConfiguration[] => [
+    configuration(Constants.DEFAULT_EXTENSIBILITY_LIBRARY_COMPONENT_ID, false, "Default")
+];
+
+describe("ExtensibilityConfigurationHelper", () => {
+    it("inherits enabled Search Results libraries for an untouched Filters configuration", () => {
+        const inherited = [
+            configuration("11111111-1111-1111-1111-111111111111", true),
+            configuration("22222222-2222-2222-2222-222222222222", false)
+        ];
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(
+            defaultFiltersConfiguration(),
+            inherited
+        )).toEqual([inherited[0]]);
+    });
+
+    it("keeps an explicit Filters configuration instead of inheriting", () => {
+        const own = [configuration("33333333-3333-3333-3333-333333333333", true)];
+        const inherited = [configuration("11111111-1111-1111-1111-111111111111", true)];
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(own, inherited)).toBe(own);
+    });
+
+    it("treats a disabled custom Filters entry as explicit", () => {
+        const own = [configuration("33333333-3333-3333-3333-333333333333", false)];
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(
+            own,
+            [configuration("11111111-1111-1111-1111-111111111111", true)]
+        )).toBe(own);
+    });
+
+    it("treats an empty Filters configuration as explicitly loading no libraries", () => {
+        const own: IExtensibilityConfiguration[] = [];
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(
+            own,
+            [configuration("11111111-1111-1111-1111-111111111111", true)]
+        )).toBe(own);
+    });
+
+    it("deduplicates inherited IDs case-insensitively and ignores braces", () => {
+        const first = configuration("{AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA}", true, "First");
+        const duplicate = configuration("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", true, "Duplicate");
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(defaultFiltersConfiguration(), [first, duplicate])).toEqual([first]);
+    });
+
+    it("retains the default placeholder when no enabled library can be inherited", () => {
+        const own = defaultFiltersConfiguration();
+
+        expect(ExtensibilityConfigurationHelper.resolveFiltersConfiguration(
+            own,
+            [configuration("11111111-1111-1111-1111-111111111111", false)]
+        )).toBe(own);
+    });
+});

--- a/search-parts/src/helpers/ExtensibilityConfigurationHelper.ts
+++ b/search-parts/src/helpers/ExtensibilityConfigurationHelper.ts
@@ -38,7 +38,7 @@ export class ExtensibilityConfigurationHelper {
     public static getConfigurationKey(configuration: IExtensibilityConfiguration[]): string {
         return (configuration || [])
             .map(item => `${this.normalizeId(item?.id)}:${item?.enabled === true}`)
-            .sort()
+            .sort((left, right) => left.localeCompare(right))
             .join("|");
     }
 

--- a/search-parts/src/helpers/ExtensibilityConfigurationHelper.ts
+++ b/search-parts/src/helpers/ExtensibilityConfigurationHelper.ts
@@ -1,0 +1,58 @@
+import { Constants } from "../common/Constants";
+import { IExtensibilityConfiguration } from "../models/common/IExtensibilityConfiguration";
+
+/**
+ * Resolves the extensibility configuration used by Web Parts while preserving
+ * compatibility with configurations saved before Search Filters had its own setting.
+ */
+export class ExtensibilityConfigurationHelper {
+
+    /**
+     * Uses connected Search Results libraries only while the Search Filters configuration
+     * is still its untouched, disabled default placeholder. Any explicit Filters entry wins.
+     */
+    public static resolveFiltersConfiguration(
+        filtersConfiguration: IExtensibilityConfiguration[],
+        connectedResultsConfigurations: IExtensibilityConfiguration[]
+    ): IExtensibilityConfiguration[] {
+
+        const ownConfiguration = filtersConfiguration || [];
+        if (!this.isDefaultFiltersConfiguration(ownConfiguration)) {
+            return ownConfiguration;
+        }
+
+        const inheritedById = new Map<string, IExtensibilityConfiguration>();
+        (connectedResultsConfigurations || [])
+            .filter(configuration => configuration?.enabled && !!configuration.id)
+            .forEach(configuration => {
+                const id = this.normalizeId(configuration.id);
+                if (!inheritedById.has(id)) {
+                    inheritedById.set(id, { ...configuration });
+                }
+            });
+
+        return inheritedById.size > 0 ? Array.from(inheritedById.values()) : ownConfiguration;
+    }
+
+    /** Creates a stable identity for runtime configuration reload checks. */
+    public static getConfigurationKey(configuration: IExtensibilityConfiguration[]): string {
+        return (configuration || [])
+            .map(item => `${this.normalizeId(item?.id)}:${item?.enabled === true}`)
+            .sort()
+            .join("|");
+    }
+
+    private static isDefaultFiltersConfiguration(configuration: IExtensibilityConfiguration[]): boolean {
+        if (configuration.length !== 1) {
+            return false;
+        }
+
+        const item = configuration[0];
+        return item?.enabled !== true
+            && this.normalizeId(item?.id) === this.normalizeId(Constants.DEFAULT_EXTENSIBILITY_LIBRARY_COMPONENT_ID);
+    }
+
+    private static normalizeId(id: string): string {
+        return (id || "").replace(/[{}]/g, "").toLowerCase();
+    }
+}

--- a/search-parts/src/helpers/HandlebarsCustomizationTracker.test.ts
+++ b/search-parts/src/helpers/HandlebarsCustomizationTracker.test.ts
@@ -1,0 +1,72 @@
+import { HandlebarsCustomizationTracker, IHandlebarsRegistry } from "./HandlebarsCustomizationTracker";
+
+const createRegistry = (): IHandlebarsRegistry => {
+    const registry: IHandlebarsRegistry = {
+        helpers: {},
+        partials: {},
+        registerHelper: (name, helper) => { registry.helpers[name] = helper; },
+        unregisterHelper: name => { delete registry.helpers[name]; },
+        registerPartial: (name, partial) => { registry.partials[name] = partial; },
+        unregisterPartial: name => { delete registry.partials[name]; }
+    };
+    return registry;
+};
+
+describe("HandlebarsCustomizationTracker", () => {
+    it("unregisters helpers and partials added by a library", () => {
+        const registry = createRegistry();
+        const tracker = new HandlebarsCustomizationTracker();
+
+        tracker.register(registry, () => {
+            registry.registerHelper("customHelper", () => "custom");
+            registry.registerPartial("customPartial", "custom");
+        });
+        tracker.reset(registry);
+
+        expect(registry.helpers.customHelper).toBeUndefined();
+        expect(registry.partials.customPartial).toBeUndefined();
+    });
+
+    it("restores built-in registrations overridden by a library", () => {
+        const registry = createRegistry();
+        const originalHelper = () => "built-in";
+        registry.registerHelper("helper", originalHelper);
+        registry.registerPartial("partial", "built-in");
+        const tracker = new HandlebarsCustomizationTracker();
+
+        tracker.register(registry, () => {
+            registry.registerHelper("helper", () => "custom");
+            registry.registerPartial("partial", "custom");
+        });
+        tracker.reset(registry);
+
+        expect(registry.helpers.helper).toBe(originalHelper);
+        expect(registry.partials.partial).toBe("built-in");
+    });
+
+    it("preserves the original state across multiple library registrations", () => {
+        const registry = createRegistry();
+        const originalHelper = () => "built-in";
+        registry.registerHelper("helper", originalHelper);
+        const tracker = new HandlebarsCustomizationTracker();
+
+        tracker.register(registry, () => registry.registerHelper("helper", () => "first"));
+        tracker.register(registry, () => registry.registerHelper("helper", () => "second"));
+        tracker.reset(registry);
+
+        expect(registry.helpers.helper).toBe(originalHelper);
+    });
+
+    it("can be reset repeatedly without removing restored registrations", () => {
+        const registry = createRegistry();
+        const tracker = new HandlebarsCustomizationTracker();
+        registry.registerHelper("builtIn", () => "built-in");
+
+        tracker.register(registry, () => registry.registerHelper("custom", () => "custom"));
+        tracker.reset(registry);
+        tracker.reset(registry);
+
+        expect(registry.helpers.builtIn).toBeDefined();
+        expect(registry.helpers.custom).toBeUndefined();
+    });
+});

--- a/search-parts/src/helpers/HandlebarsCustomizationTracker.ts
+++ b/search-parts/src/helpers/HandlebarsCustomizationTracker.ts
@@ -20,14 +20,14 @@ export class HandlebarsCustomizationTracker {
 
     /** Runs a library registration and records every helper/partial it changes. */
     public register(handlebars: IHandlebarsRegistry, registration: () => void): void {
-        const helpersBefore = { ...(handlebars.helpers || {}) };
-        const partialsBefore = { ...(handlebars.partials || {}) };
+        const helpersBefore = { ...handlebars.helpers };
+        const partialsBefore = { ...handlebars.partials };
 
         try {
             registration();
         } finally {
-            this.recordChanges(this.originalHelpers, helpersBefore, handlebars.helpers || {});
-            this.recordChanges(this.originalPartials, partialsBefore, handlebars.partials || {});
+            this.recordChanges(this.originalHelpers, helpersBefore, handlebars.helpers);
+            this.recordChanges(this.originalPartials, partialsBefore, handlebars.partials);
         }
     }
 
@@ -54,7 +54,7 @@ export class HandlebarsCustomizationTracker {
         names.forEach(name => {
             if (before[name] !== after[name] && !originals.has(name)) {
                 originals.set(name, {
-                    existed: Object.prototype.hasOwnProperty.call(before, name),
+                    existed: name in before,
                     value: before[name]
                 });
             }

--- a/search-parts/src/helpers/HandlebarsCustomizationTracker.ts
+++ b/search-parts/src/helpers/HandlebarsCustomizationTracker.ts
@@ -1,0 +1,78 @@
+interface IHandlebarsRegistrationState {
+    existed: boolean;
+    value: any;
+}
+
+export interface IHandlebarsRegistry {
+    helpers: { [name: string]: any };
+    partials: { [name: string]: any };
+    registerHelper(name: string, helper: any): void;
+    unregisterHelper(name: string): void;
+    registerPartial(name: string, partial: any): void;
+    unregisterPartial(name: string): void;
+}
+
+/** Tracks and restores Handlebars registrations made by extensibility libraries. */
+export class HandlebarsCustomizationTracker {
+
+    private readonly originalHelpers = new Map<string, IHandlebarsRegistrationState>();
+    private readonly originalPartials = new Map<string, IHandlebarsRegistrationState>();
+
+    /** Runs a library registration and records every helper/partial it changes. */
+    public register(handlebars: IHandlebarsRegistry, registration: () => void): void {
+        const helpersBefore = { ...(handlebars.helpers || {}) };
+        const partialsBefore = { ...(handlebars.partials || {}) };
+
+        try {
+            registration();
+        } finally {
+            this.recordChanges(this.originalHelpers, helpersBefore, handlebars.helpers || {});
+            this.recordChanges(this.originalPartials, partialsBefore, handlebars.partials || {});
+        }
+    }
+
+    /** Restores the registry to its state before the tracked library registrations. */
+    public reset(handlebars: IHandlebarsRegistry): void {
+        this.restoreRegistrations(
+            this.originalHelpers,
+            handlebars.registerHelper.bind(handlebars),
+            handlebars.unregisterHelper.bind(handlebars)
+        );
+        this.restoreRegistrations(
+            this.originalPartials,
+            handlebars.registerPartial.bind(handlebars),
+            handlebars.unregisterPartial.bind(handlebars)
+        );
+    }
+
+    private recordChanges(
+        originals: Map<string, IHandlebarsRegistrationState>,
+        before: { [name: string]: any },
+        after: { [name: string]: any }
+    ): void {
+        const names = new Set([...Object.keys(before), ...Object.keys(after)]);
+        names.forEach(name => {
+            if (before[name] !== after[name] && !originals.has(name)) {
+                originals.set(name, {
+                    existed: Object.prototype.hasOwnProperty.call(before, name),
+                    value: before[name]
+                });
+            }
+        });
+    }
+
+    private restoreRegistrations(
+        originals: Map<string, IHandlebarsRegistrationState>,
+        register: (name: string, value: any) => void,
+        unregister: (name: string) => void
+    ): void {
+        originals.forEach((original, name) => {
+            if (original.existed) {
+                register(name, original.value);
+            } else {
+                unregister(name);
+            }
+        });
+        originals.clear();
+    }
+}

--- a/search-parts/src/models/dynamicData/IDataResultSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataResultSourceData.ts
@@ -1,4 +1,5 @@
 import { IDataFilterResult } from "@pnp/modern-search-extensibility";
+import { IExtensibilityConfiguration } from "../common/IExtensibilityConfiguration";
 
 export interface IDataResultSourceData {
 
@@ -31,4 +32,11 @@ export interface IDataResultSourceData {
      * The filter data source reference this results web part is connected to (used for bidirectional connection validation)
      */
     connectedFilterSourceReference?: string;
+
+    /**
+     * Enabled extensibility libraries configured on this Search Results Web Part.
+     * Search Filters instances saved before they had their own extensibility setting
+     * can inherit these through their existing dynamic-data connection.
+     */
+    extensibilityLibraryConfiguration?: IExtensibilityConfiguration[];
 }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -1848,7 +1848,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         this.extensionsLoadingPromise = (async () => {
             await this.loadExtensions(effectiveConfiguration, forceLoad);
-            await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+            const instanceId = this.tryGetInstanceId();
+            if (instanceId) {
+                await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, instanceId);
+            } else {
+                Log.verbose(LogSource, "Skipping web component registration because the instance ID is unavailable.", this.context?.serviceScope);
+            }
             this.loadedExtensibilityConfigurationKey = configurationKey;
         })();
 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -56,6 +56,7 @@ import { ExtensibilityUsageHelper } from '../../helpers/ExtensibilityUsageHelper
 import { FilterControlHelper } from '../../helpers/FilterControlHelper';
 import { Constants } from '../../common/Constants';
 import { ExtensibilityConfigurationHelper } from '../../helpers/ExtensibilityConfigurationHelper';
+import { HandlebarsCustomizationTracker } from '../../helpers/HandlebarsCustomizationTracker';
 
 const LogSource = "SearchFiltersWebPart";
 
@@ -166,6 +167,9 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
     /** Prevents concurrent reloads when dynamic-data callbacks re-enter render. */
     private extensionsLoadingPromise: Promise<void>;
+
+    /** Restores helpers/partials when the effective library configuration changes. */
+    private readonly handlebarsCustomizationTracker = new HandlebarsCustomizationTracker();
 
     /**
      * The available connections as property pane fields
@@ -1828,7 +1832,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
      * configuration wins; otherwise enabled libraries are inherited from connected Results Web Parts.
      */
     private async ensureExtensionsLoaded(forceLoad: boolean = false): Promise<void> {
-        if (this.extensionsLoadingPromise) {
+        if (this.extensionsLoadingPromise !== undefined) {
             await this.extensionsLoadingPromise;
         }
 
@@ -1836,6 +1840,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         const configurationKey = ExtensibilityConfigurationHelper.getConfigurationKey(effectiveConfiguration);
         if (!forceLoad && configurationKey === this.loadedExtensibilityConfigurationKey) {
             return;
+        }
+
+        if (configurationKey !== this.loadedExtensibilityConfigurationKey) {
+            this.handlebarsCustomizationTracker.reset(this.templateService.Handlebars);
         }
 
         this.extensionsLoadingPromise = (async () => {
@@ -1947,7 +1955,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
             // Registers Handlebars customizations in the local namespace
             if (extensibilityLibrary.registerHandlebarsCustomizations) {
-                extensibilityLibrary.registerHandlebarsCustomizations(this.templateService.Handlebars);
+                this.handlebarsCustomizationTracker.register(
+                    this.templateService.Handlebars,
+                    () => extensibilityLibrary.registerHandlebarsCustomizations(this.templateService.Handlebars)
+                );
             }
         });
 

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -55,6 +55,7 @@ import { IExtensibilityConfiguration } from '../../models/common/IExtensibilityC
 import { ExtensibilityUsageHelper } from '../../helpers/ExtensibilityUsageHelper';
 import { FilterControlHelper } from '../../helpers/FilterControlHelper';
 import { Constants } from '../../common/Constants';
+import { ExtensibilityConfigurationHelper } from '../../helpers/ExtensibilityConfigurationHelper';
 
 const LogSource = "SearchFiltersWebPart";
 
@@ -159,6 +160,12 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
      * The custom filter control definitions coming from the registered extensibility libraries
      */
     private availableFilterControlDefinitions: IFilterControlDefinition[] = [];
+
+    /** Stable identity of the effective own/inherited extensibility configuration. */
+    private loadedExtensibilityConfigurationKey: string;
+
+    /** Prevents concurrent reloads when dynamic-data callbacks re-enter render. */
+    private extensionsLoadingPromise: Promise<void>;
 
     /**
      * The available connections as property pane fields
@@ -265,12 +272,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         // Load extensions from the registered extensibility libraries (custom layouts, filter controls,
         // web components and Handlebars customizations). This must happen BEFORE the web components get
         // registered so custom components are part of the same registration pass.
-        await this.loadExtensions(this.properties.extensibilityLibraryConfiguration);
-
-        // Register Web Components in the global page context. We need to do this BEFORE the template processing to avoid race condition.
-        // Web components are only defined once.
-        // We need to register components here in the case where the Search Results WP is not present on the page
-        await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+        await this.ensureExtensionsLoaded();
 
         return super.onInit();
     }
@@ -298,6 +300,10 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         this.errorMessage = undefined;
 
         try {
+
+            // A connected Search Results Web Part may become available after this Web Part initialized.
+            // Re-resolve the effective configuration so legacy pages can inherit its libraries.
+            await this.ensureExtensionsLoaded();
 
             // Determine the template content to display
             // In the case of an external template is selected, the render is done asynchronously waiting for the content to be fetched
@@ -613,8 +619,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         // Force the load of the enabled libraries so custom layouts and filter controls are selectable
         // in the property pane, even if the current configuration doesn't use anything custom yet.
-        await this.loadExtensions(this.properties.extensibilityLibraryConfiguration, true);
-        await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+        await this.ensureExtensionsLoaded(true);
 
         if (this.groupedTermSets.size === 0) {
             await this._loadTermSets();
@@ -712,8 +717,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             // Remove duplicates if any
             this.properties.extensibilityLibraryConfiguration = uniqBy(this.properties.extensibilityLibraryConfiguration, 'id');
 
-            await this.loadExtensions(this.properties.extensibilityLibraryConfiguration, true);
-            await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+            await this.ensureExtensionsLoaded(true);
 
             // The selected layout may come from a library which is not loaded anymore
             if (this.availableLayoutDefinitions.filter(layout => layout.key === this.properties.selectedLayoutKey).length === 0) {
@@ -1817,6 +1821,50 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             enabled: false,
             id: Constants.DEFAULT_EXTENSIBILITY_LIBRARY_COMPONENT_ID
         }];
+    }
+
+    /**
+     * Loads extensions when the effective configuration changes. Explicit Search Filters
+     * configuration wins; otherwise enabled libraries are inherited from connected Results Web Parts.
+     */
+    private async ensureExtensionsLoaded(forceLoad: boolean = false): Promise<void> {
+        if (this.extensionsLoadingPromise) {
+            await this.extensionsLoadingPromise;
+        }
+
+        const effectiveConfiguration = this.getEffectiveExtensibilityLibraryConfiguration();
+        const configurationKey = ExtensibilityConfigurationHelper.getConfigurationKey(effectiveConfiguration);
+        if (!forceLoad && configurationKey === this.loadedExtensibilityConfigurationKey) {
+            return;
+        }
+
+        this.extensionsLoadingPromise = (async () => {
+            await this.loadExtensions(effectiveConfiguration, forceLoad);
+            await this.templateService.registerWebComponents(this.availableWebComponentDefinitions, this.instanceId);
+            this.loadedExtensibilityConfigurationKey = configurationKey;
+        })();
+
+        try {
+            await this.extensionsLoadingPromise;
+        } finally {
+            this.extensionsLoadingPromise = undefined;
+        }
+    }
+
+    private getEffectiveExtensibilityLibraryConfiguration(): IExtensibilityConfiguration[] {
+        const connectedResultsConfigurations: IExtensibilityConfiguration[] = [];
+
+        this._dataSourceDynamicProperties.forEach(dynamicProperty => {
+            const sourceData = DynamicPropertyHelper.tryGetValueSafe(dynamicProperty);
+            if (sourceData?.extensibilityLibraryConfiguration) {
+                connectedResultsConfigurations.push(...sourceData.extensibilityLibraryConfiguration);
+            }
+        });
+
+        return ExtensibilityConfigurationHelper.resolveFiltersConfiguration(
+            this.properties.extensibilityLibraryConfiguration,
+            connectedResultsConfigurations
+        );
     }
 
     /**

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -435,6 +435,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 this._currentDataResultsSourceData.handlebarsContext = this.templateService.Handlebars;
                 this._currentDataResultsSourceData.totalCount = this.dataSource?.getItemCount();
                 this._currentDataResultsSourceData.connectedFilterSourceReference = this.properties.filtersDataSourceReference;
+                this._currentDataResultsSourceData.extensibilityLibraryConfiguration = (this.properties.extensibilityLibraryConfiguration || [])
+                    .filter(configuration => configuration.enabled)
+                    .map(configuration => ({ ...configuration }));
 
                 return this._currentDataResultsSourceData;
 
@@ -1007,6 +1010,10 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             this.extensionsLoaded = false;
 
             await this.loadExtensions(cleanConfiguration, true);
+
+            if (this.properties.allowWebPartConnections && this.context?.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
+                this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchResults);
+            }
         }
 
         if (this.properties.queryTextSource === QueryTextSource.StaticValue || !this.properties.useDefaultQueryText || !this.properties.useInputQueryText) {


### PR DESCRIPTION
## Summary
- restore the documented pre-4.23.3 behavior where Search Filters can use libraries configured on connected Search Results web parts
- inherit enabled Results libraries only while the Filters extensibility configuration remains the untouched disabled default
- keep explicit Search Filters configuration authoritative, including an intentionally empty configuration
- reload inherited configuration safely when connected Results sources initialize or change
- document the backward-compatibility behavior

## Regression
PR #4871 optimized extensibility loading by inspecting only the Search Results configuration. That caused Results to skip libraries used exclusively by a connected Search Filters template, although this scenario was explicitly documented as supported. First-class Filter-owned configuration added later does not migrate existing Results library IDs.

## Validation
- 23 Jest tests passed, including 6 new precedence/inheritance tests
- `npm run build` passed and generated the SPFx package
- MkDocs build passed; only pre-existing broken-link warnings remain

Fixes #4883