### PR TITLE
Hide hierarchical terms while refiners load

### DIFF
--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -770,7 +770,7 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
             );
         }
 
-        if (hierarchicalTerms.length === 0) {
+        if (hierarchicalTerms.length === 0 || (this.props.filter?.hideNodesNotInDataSet && this.props.filter?.isAwaitingResultSignals)) {
             return (
                 <div className={styles.filterHierarchical}>
                     <div>{strings.Filters.LoadingMessage}</div>

--- a/search-parts/src/models/dynamicData/IDataResultSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataResultSourceData.ts
@@ -14,6 +14,11 @@ export interface IDataResultSourceData {
     availablefilters: IDataFilterResult[];
 
     /**
+     * Indicates whether the results source is retrieving data.
+     */
+    isLoading?: boolean;
+
+    /**
      * The Hanlebars context available for consumers
      */
     handlebarsContext?: typeof Handlebars;

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -74,6 +74,7 @@ interface IFilterResultWithLimitInfo extends IDataFilterResult {
     configuredMaxBuckets?: number;
     returnedValueCount?: number;
     isEditModeCapApplied?: boolean;
+    isAwaitingResultSignals?: boolean;
 }
 
 /**
@@ -391,7 +392,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             // OR the data results don't contain this filter name. 
             // We create fake entries for those filters to be able to render them in the template
             // We do this by convenience to avoid refactoring the Handlebars templates
-            filterResults = this._initStaticFilters(filterResults, resolvedFiltersConfiguration);
+            const isResultsLoading = this._dataSourceDynamicProperties.some(dynamicProperty => Boolean(DynamicPropertyHelper.tryGetValueSafe(dynamicProperty)?.isLoading));
+            filterResults = this._initStaticFilters(filterResults, resolvedFiltersConfiguration, isResultsLoading);
 
             renderRootElement = React.createElement(
                 React.Suspense,
@@ -2150,9 +2152,9 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
      * Initializes filter results according to 'Static' type filters in the configuration
      * @param filtersConfiguration The current filters configurations
      */
-    private _initStaticFilters(filterResults: IDataFilterResult[], filtersConfiguration: IDataFilterConfiguration[]): IDataFilterResult[] {
+    private _initStaticFilters(filterResults: IDataFilterResult[], filtersConfiguration: IDataFilterConfiguration[], isResultsLoading: boolean = false): IDataFilterResult[] {
 
-        let updatedFilterResults = cloneDeep(filterResults);
+        let updatedFilterResults: IFilterResultWithLimitInfo[] = cloneDeep(filterResults);
 
         // Get the corresponding configuration for this filter
         filtersConfiguration.forEach(filterConfiguration => {
@@ -2167,8 +2169,8 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                 if (filterResults.filter(filterResult => filterResult.filterName === filterConfiguration.filterName).length === 0) {
                     updatedFilterResults.push({
                         filterName: filterConfiguration.filterName,
-                        values: [
-                        ]
+                        values: [],
+                        isAwaitingResultSignals: isResultsLoading && filterConfiguration.selectedTemplate === BuiltinFilterTemplates.Hierarchical
                     });
                 }
             }

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -45,6 +45,7 @@ interface IFilterResultWithLimitInfo extends IDataFilterResult {
     configuredMaxBuckets?: number;
     returnedValueCount?: number;
     isEditModeCapApplied?: boolean;
+    isAwaitingResultSignals?: boolean;
 }
 
 interface IFilterInternalWithWarning extends IDataFilterInternal {
@@ -1265,7 +1266,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         };
     }
 
-    private buildFilterResultInternal(availableFilter: IDataFilterResult, filterConfiguration: IHierarchicalFilterConfiguration, values: IDataFilterValueInternal[], currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number, filterWithLimitInfo: IFilterResultWithLimitInfo, selectionState: { selectedOnce: boolean; hasSelectedValues: boolean; canApply: boolean; canClear: boolean; }): IFilterInternalWithWarning & { termSetId?: string; termGroupId?: string; hierarchicalTerms?: IHierarchicalTerm[]; hideNodesNotInDataSet?: boolean; expandAllNodesByDefault?: boolean } {
+    private buildFilterResultInternal(availableFilter: IDataFilterResult, filterConfiguration: IHierarchicalFilterConfiguration, values: IDataFilterValueInternal[], currentUiFilters: IDataFilterInternal[], selectedFilterIdx: number, filterWithLimitInfo: IFilterResultWithLimitInfo, selectionState: { selectedOnce: boolean; hasSelectedValues: boolean; canApply: boolean; canClear: boolean; }): IFilterInternalWithWarning & { termSetId?: string; termGroupId?: string; hierarchicalTerms?: IHierarchicalTerm[]; hideNodesNotInDataSet?: boolean; expandAllNodesByDefault?: boolean; isAwaitingResultSignals?: boolean } {
         const filterOperator = selectedFilterIdx === -1 ? filterConfiguration.operator : currentUiFilters[selectedFilterIdx].operator;
         const reachedEditModeRefinerCap = this.props.webPartTitleProps?.displayMode === DisplayMode.Edit
             && filterWithLimitInfo.isMaxBucketsExceeded
@@ -1318,7 +1319,8 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             termSetId: filterConfiguration.termSetId,
             termGroupId: filterConfiguration.termGroupId,
             hideNodesNotInDataSet: filterConfiguration.hideNodesNotInDataSet,
-            expandAllNodesByDefault: filterConfiguration.expandAllNodesByDefault
+            expandAllNodesByDefault: filterConfiguration.expandAllNodesByDefault,
+            isAwaitingResultSignals: filterWithLimitInfo.isAwaitingResultSignals
         };
     }
 

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -598,7 +598,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     this._currentDataResultsSourceData = {
                         availableFieldsFromResults: [],
                         availablefilters: [],
-                        isLoading: false
+                        isLoading: false,
+                        selectedItems: []
                     };
 
                     // Remove margin and padding for the empty control zone

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -103,7 +103,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _currentDataResultsSourceData: IDataResultSourceData = {
         availableFieldsFromResults: [],
         availablefilters: [],
-        selectedItems: []
+        selectedItems: [],
+        isLoading: true
     };
 
     /**
@@ -280,6 +281,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
         this._bindHashChange = this._bindHashChange.bind(this);
         this._onDataRetrieved = this._onDataRetrieved.bind(this);
+        this._onDataLoadingChanged = this._onDataLoadingChanged.bind(this);
         this._onItemSelected = this._onItemSelected.bind(this);
         this._updateTitleProperty = this._updateTitleProperty.bind(this);
     }
@@ -510,6 +512,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                 instanceId: instanceId,
                 properties: JSON.parse(JSON.stringify(this.properties)), // Create a copy to avoid unexpected reference value updates from data sources 
                 onDataRetrieved: this._onDataRetrieved,
+                onDataLoadingChanged: this._onDataLoadingChanged,
                 onItemSelected: this._onItemSelected,
                 onNoResultsFound: this._onNoResultsFound.bind(this),
                 pageContext: this.context.pageContext,
@@ -594,7 +597,8 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
                     // Reset data source information
                     this._currentDataResultsSourceData = {
                         availableFieldsFromResults: [],
-                        availablefilters: []
+                        availablefilters: [],
+                        isLoading: false
                     };
 
                     // Remove margin and padding for the empty control zone
@@ -2518,6 +2522,18 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         // Extra call to refresh the property pane in the case where data sources rely on results fields in there configuration (ex: ODataDataSource)
         if (this.context && this.context.propertyPane) {
             this.context.propertyPane.refresh();
+        }
+    }
+
+    private _onDataLoadingChanged(isLoading: boolean): void {
+        if (this._currentDataResultsSourceData.isLoading === isLoading) {
+            return;
+        }
+
+        this._currentDataResultsSourceData.isLoading = isLoading;
+
+        if (this.properties.allowWebPartConnections && this.context?.dynamicDataSourceManager && !this.context.dynamicDataSourceManager.isDisposed) {
+            this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchResults);
         }
     }
 

--- a/search-parts/src/webparts/searchResults/components/ISearchResultsContainerProps.ts
+++ b/search-parts/src/webparts/searchResults/components/ISearchResultsContainerProps.ts
@@ -66,6 +66,11 @@ export interface ISearchResultsContainerProps {
   onDataRetrieved: (availableDataSourceFields: string[], filters?: IDataFilterResult[], pageNumber?: number) => void;
 
   /**
+   * Handler when the data source loading state changes.
+   */
+  onDataLoadingChanged: (isLoading: boolean) => void;
+
+  /**
    * Handler when a item has been selected from results
    */
   onItemSelected: (currentSelectedItems: {[key: string]: any}[]) => void; 

--- a/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
+++ b/search-parts/src/webparts/searchResults/components/SearchResultsContainer.tsx
@@ -263,6 +263,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
      */
     private async getDataFromDataSource(pageNumber: number): Promise<void> {
 
+        this.props.onDataLoadingChanged(true);
         this.setState({
             isLoading: true,
             errorMessage: ''
@@ -309,6 +310,7 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
             }
 
             this.props.onDataRetrieved(this.getAvailableFieldsFromResults(data), availableFilters, pageNumber);
+            this.props.onDataLoadingChanged(false);
 
             // Persist the total items count
             this._totalItemsCount = totalItemsCount;
@@ -324,6 +326,8 @@ export default class SearchResultsContainer extends React.Component<ISearchResul
             this._lastPageNumber = pageNumber;
 
         } catch (error) {
+
+            this.props.onDataLoadingChanged(false);
 
             this.setState({
                 isLoading: false,


### PR DESCRIPTION
## Summary
- Publish the Search Results loading state through dynamic data.
- Keep hierarchical managed-metadata placeholders in a localized loading state while result refiners are pending.
- Retain the existing pruned hierarchy behavior once refiner values arrive.

Fixes #4940

## Validation
- npx tsc --noEmit