### PR TITLE
Preserve filter counts for pending selections

### DIFF
--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -1517,7 +1517,8 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
                 return;
             }
 
-            updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { values: { [valueIdx]: { $set: filterValueInternal } } } });
+            const existingValue = updatedUiFilters[filterIdx].values[valueIdx];
+            updatedUiFilters = update(updatedUiFilters, { [filterIdx]: { values: { [valueIdx]: { $set: { ...filterValueInternal, count: existingValue.count } } } } });
         });
 
         return updatedUiFilters;


### PR DESCRIPTION
## Summary
- Retain the last result-derived count when a pending filter selection updates UI state.
- Keep category counts visible when closing and reopening the filter panel before applying.
- Allow normal aggregation refreshes to replace counts after filters are applied.

Fixes #4941

## Validation
- npx tsc --noEmit