### PR TITLE
Fix cleared filters remaining applied after vertical switch

### DIFF
--- a/search-parts/src/models/dynamicData/IDataVerticalSourceData.ts
+++ b/search-parts/src/models/dynamicData/IDataVerticalSourceData.ts
@@ -9,6 +9,11 @@ export interface IDataVerticalSourceData {
     selectedVertical: IDataVertical;
 
     /**
+     * Determines whether connected filters are cleared when the selected vertical changes.
+     */
+    clearFiltersOnVerticalChange?: boolean;
+
+    /**
      * The serch verticals configuration. Used to determnine counts for other tabs.
      */
     verticalsConfiguration: IDataVerticalConfiguration[];

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -95,6 +95,34 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
     private _dataSourceDynamicProperties: DynamicProperty<IDataResultSourceData>[] = [];
     private _verticalsSourceData: DynamicProperty<IDataVerticalSourceData>;
     private _selectedFilters: IDataFilter[] = [];
+    private _lastSelectedVerticalKey: string = undefined;
+    private _verticalChangeVersion: number = 0;
+
+    private _resetFiltersForChangedVertical(): boolean {
+        const verticalData = DynamicPropertyHelper.tryGetValueSafe(this._verticalsSourceData);
+        const selectedVerticalKey = verticalData?.selectedVertical?.key;
+
+        if (verticalData?.clearFiltersOnVerticalChange === true && selectedVerticalKey && this._lastSelectedVerticalKey && this._lastSelectedVerticalKey !== selectedVerticalKey) {
+            this._selectedFilters = [];
+            this._verticalChangeVersion++;
+            this._lastSelectedVerticalKey = selectedVerticalKey;
+            return true;
+        }
+
+        if (selectedVerticalKey) {
+            this._lastSelectedVerticalKey = selectedVerticalKey;
+        }
+
+        return false;
+    }
+
+    private _onVerticalsDataChanged = (): void => {
+        if (this._resetFiltersForChangedVertical()) {
+            this.context.dynamicDataSourceManager.notifyPropertyChanged(ComponentType.SearchFilters);
+        }
+
+        this.render();
+    };
 
     /**
      * Dynamically loaded components for property pane
@@ -407,6 +435,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
                         domElement: this.domElement,
                         instanceId: this.instanceId,
                         selectedLayoutKey: this.properties.selectedLayoutKey,
+                        verticalChangeVersion: this._verticalChangeVersion,
                         properties: JSON.parse(JSON.stringify({ ...this.properties, filtersConfiguration: resolvedFiltersConfiguration })),
                         themeVariant: this._themeVariant,
                         context: this.context,
@@ -527,6 +556,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
         switch (propertyId) {
 
             case propertyId:
+                this._resetFiltersForChangedVertical();
                 return {
                     filterConfiguration: this.getResolvedFiltersConfiguration(),
                     selectedFilters: this._selectedFilters,
@@ -2076,11 +2106,11 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
             }
 
             this._verticalsSourceData.setReference(this.properties.verticalsDataSourceReference);
-            this._verticalsSourceData.register(this.render);
+            this._verticalsSourceData.register(this._onVerticalsDataChanged);
 
         } else {
             if (this._verticalsSourceData) {
-                this._verticalsSourceData.unregister(this.render);
+                this._verticalsSourceData.unregister(this._onVerticalsDataChanged);
             }
         }
     }

--- a/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
+++ b/search-parts/src/webparts/searchFilters/SearchFiltersWebPart.ts
@@ -555,7 +555,7 @@ export default class SearchFiltersWebPart extends BaseWebPart<ISearchFiltersWebP
 
         switch (propertyId) {
 
-            case propertyId:
+            case ComponentType.SearchFilters:
                 this._resetFiltersForChangedVertical();
                 return {
                     filterConfiguration: this.getResolvedFiltersConfiguration(),

--- a/search-parts/src/webparts/searchFilters/components/ISearchFiltersContainerProps.ts
+++ b/search-parts/src/webparts/searchFilters/components/ISearchFiltersContainerProps.ts
@@ -39,6 +39,11 @@ export interface ISearchFiltersContainerProps {
   selectedLayoutKey: string;
 
   /**
+   * Incremented when the connected search vertical changes.
+   */
+  verticalChangeVersion: number;
+
+  /**
    * The Web Part properties so they can be used in Handlebars template
    */
   properties: ISearchFiltersWebPartProps;

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -1813,10 +1813,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
         const updatedFilters = (await Promise.all(
             availableFilters.map(availableFilter => this.buildFilterToDisplay(availableFilter, currentUiFilters, filtersConfiguration, debugContext))
-        )).filter(Boolean);
+        )).filter((filter): filter is IDataFilterInternal => Boolean(filter));
 
         const sortStartedAt = performance.now();
-        const sortedFilters = sortBy(updatedFilters.filter(Boolean), 'sortIdx');
+        const sortedFilters = sortBy(updatedFilters, 'sortIdx');
 
         if (debugContext) {
             this.logUpdateStep(debugContext, 'getFiltersToDisplay:beforeSetState', {

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -108,6 +108,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     private _hasAttemptedPeopleDisplayNameLookup: boolean = false;
     private _busyStartedAt: number = 0;
     private _latestDeferredSubmittedFilters: IDataFilter[] | null = null;
+    private _filterUpdateVersion: number = 0;
     private static readonly _DISPLAY_NAME_CACHE_LIMIT = 5000;
     private static readonly _HIERARCHY_CACHE_LIMIT = 64;
     private static readonly _PRUNED_HIERARCHY_CACHE_LIMIT = 256;
@@ -500,6 +501,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     private queueDeferredSubmittedFiltersUpdate(submittedFilters: IDataFilter[], sourceFilterName?: string): void {
+        const filterUpdateVersion = this._filterUpdateVersion;
         this._latestDeferredSubmittedFilters = submittedFilters;
 
         this.beginResultsUpdate(sourceFilterName);
@@ -509,6 +511,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         }
 
         this._deferredSubmittedUpdateTimer = setTimeout(() => {
+            if (filterUpdateVersion !== this._filterUpdateVersion) {
+                return;
+            }
+
             const filtersToUpdate = this._latestDeferredSubmittedFilters;
 
             this._deferredSubmittedUpdateTimer = null;
@@ -524,6 +530,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
     }
 
     private beginResultsUpdate(sourceFilterName?: string, onReady?: () => void): void {
+        const filterUpdateVersion = this._filterUpdateVersion;
         if (this._busyHideTimer) {
             clearTimeout(this._busyHideTimer);
             this._busyHideTimer = null;
@@ -569,16 +576,24 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             isUpdatingResults: true,
             activeBusyFilterName: sourceFilterName || prevState.activeBusyFilterName
         }), () => {
-            if (!onReady) {
+            if (!onReady || filterUpdateVersion !== this._filterUpdateVersion) {
                 return;
             }
 
             if (typeof globalThis.requestAnimationFrame === 'function') {
-                globalThis.requestAnimationFrame(() => onReady());
+                globalThis.requestAnimationFrame(() => {
+                    if (filterUpdateVersion === this._filterUpdateVersion) {
+                        onReady();
+                    }
+                });
                 return;
             }
 
-            setTimeout(() => onReady(), 0);
+            setTimeout(() => {
+                if (filterUpdateVersion === this._filterUpdateVersion) {
+                    onReady();
+                }
+            }, 0);
         });
     }
 
@@ -1716,6 +1731,26 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
     public componentDidUpdate(prevProps: ISearchFiltersContainerProps, prevState: ISearchFiltersContainerState) {
 
+        if (prevProps.verticalChangeVersion !== this.props.verticalChangeVersion) {
+            this._filterUpdateVersion++;
+            if (this._deferredSubmittedUpdateTimer) {
+                clearTimeout(this._deferredSubmittedUpdateTimer);
+                this._deferredSubmittedUpdateTimer = null;
+            }
+            this._latestDeferredSubmittedFilters = null;
+
+            this.setState(prevState => ({
+                currentUiFilters: this.resetSelectedFilterValues(prevState.currentUiFilters),
+                submittedFilters: []
+            }), () => {
+                this.getFiltersToDisplay(this.props.availableFilters, this.state.currentUiFilters, this.props.filtersConfiguration);
+                this.resetFiltersDeepLink();
+                this.props.onUpdateFilters([]);
+            });
+            this.endResultsUpdate();
+            return;
+        }
+
         if (!this._hasAttemptedPeopleDisplayNameLookup && this.hasPeopleTemplateConfigured(this.props.filtersConfiguration)) {
             this.ensurePeopleDisplayNameCacheLoaded().catch(() => {
                 // Ignore People display-name lookup failures and keep raw identities.
@@ -1776,14 +1811,9 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             });
         }
 
-        const updatedFilters: IDataFilterInternal[] = [];
-
-        for (const availableFilter of availableFilters) {
-            const filterResultInternal = await this.buildFilterToDisplay(availableFilter, currentUiFilters, filtersConfiguration, debugContext);
-            if (filterResultInternal) {
-                updatedFilters.push(filterResultInternal);
-            }
-        }
+        const updatedFilters = (await Promise.all(
+            availableFilters.map(availableFilter => this.buildFilterToDisplay(availableFilter, currentUiFilters, filtersConfiguration, debugContext))
+        )).filter(Boolean);
 
         const sortStartedAt = performance.now();
         const sortedFilters = sortBy(updatedFilters.filter(Boolean), 'sortIdx');

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -220,6 +220,7 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
     private _lastSelectedFilters: IDataFilter[] = [];
     private _lastInputQueryText: string = undefined;
     private _lastSelectedVerticalKey: string = undefined;
+    private _filtersToIgnoreAfterVerticalChange: IDataFilter[] = undefined;
 
     /**
      * The default template slots when the data source is instanciated for the first time
@@ -385,8 +386,20 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // Reset page number when switching between verticals (before getDataContext)
             if (this._verticalsConnectionSourceData && this.properties.selectedVerticalKeys.length > 0) {
                 const verticalData = DynamicPropertyHelper.tryGetValueSafe(this._verticalsConnectionSourceData);
-                if (verticalData && verticalData.selectedVertical?.key && this._lastSelectedVerticalKey !== verticalData.selectedVertical.key) {
+                if (verticalData?.clearFiltersOnVerticalChange === true && verticalData.selectedVertical?.key && this._lastSelectedVerticalKey && this._lastSelectedVerticalKey !== verticalData.selectedVertical.key) {
                     this.currentPageNumber = 1;
+                    const filtersSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
+                    this._filtersToIgnoreAfterVerticalChange = filtersSourceData?.selectedFilters;
+                    this._lastSelectedFilters = [];
+
+                    if (filtersSourceData?.instanceId) {
+                        const filterQueryStringParameter = `f_${filtersSourceData.instanceId}`;
+                        const urlWithoutFilters = UrlHelper.removeQueryStringParam(filterQueryStringParameter, globalThis.location.href);
+                        globalThis.history.replaceState({ path: urlWithoutFilters }, '', urlWithoutFilters);
+                    }
+                }
+
+                if (verticalData && verticalData.selectedVertical?.key) {
                     this._lastSelectedVerticalKey = verticalData.selectedVertical.key;
                 }
             }
@@ -2387,7 +2400,14 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
         if (this._filtersConnectionSourceData) {
             const filtersSourceData: IDataFilterSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
             if (filtersSourceData) {
-                const selectedFilters = dataContext.filters.selectedFilters.concat(filtersSourceData.selectedFilters);
+                const filtersWereClearedForVerticalChange = this._filtersToIgnoreAfterVerticalChange
+                    && isEqual(filtersSourceData.selectedFilters, this._filtersToIgnoreAfterVerticalChange);
+
+                if (!filtersWereClearedForVerticalChange) {
+                    this._filtersToIgnoreAfterVerticalChange = undefined;
+                }
+
+                const selectedFilters = dataContext.filters.selectedFilters.concat(filtersWereClearedForVerticalChange ? [] : filtersSourceData.selectedFilters);
 
                 // Reset the page number if filters have been updated by the user
                 if (!isEqual(selectedFilters, this._lastSelectedFilters)) {

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -397,8 +397,9 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
 
                         if (filtersSourceData?.instanceId) {
                             const filterQueryStringParameter = `f_${filtersSourceData.instanceId}`;
-                            const urlWithoutFilters = UrlHelper.removeQueryStringParam(filterQueryStringParameter, globalThis.location.href);
-                            globalThis.history.replaceState({ path: urlWithoutFilters }, '', urlWithoutFilters);
+                            const url = new URL(globalThis.location.href);
+                            url.searchParams.delete(filterQueryStringParameter);
+                            globalThis.history.replaceState({ path: url.toString() }, '', url.toString());
                         }
                     }
                 }

--- a/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
+++ b/search-parts/src/webparts/searchResults/SearchResultsWebPart.ts
@@ -386,16 +386,20 @@ export default class SearchResultsWebPart extends BaseWebPart<ISearchResultsWebP
             // Reset page number when switching between verticals (before getDataContext)
             if (this._verticalsConnectionSourceData && this.properties.selectedVerticalKeys.length > 0) {
                 const verticalData = DynamicPropertyHelper.tryGetValueSafe(this._verticalsConnectionSourceData);
-                if (verticalData?.clearFiltersOnVerticalChange === true && verticalData.selectedVertical?.key && this._lastSelectedVerticalKey && this._lastSelectedVerticalKey !== verticalData.selectedVertical.key) {
+                const hasChangedVertical = verticalData?.selectedVertical?.key && this._lastSelectedVerticalKey && this._lastSelectedVerticalKey !== verticalData.selectedVertical.key;
+                if (hasChangedVertical) {
                     this.currentPageNumber = 1;
-                    const filtersSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
-                    this._filtersToIgnoreAfterVerticalChange = filtersSourceData?.selectedFilters;
-                    this._lastSelectedFilters = [];
 
-                    if (filtersSourceData?.instanceId) {
-                        const filterQueryStringParameter = `f_${filtersSourceData.instanceId}`;
-                        const urlWithoutFilters = UrlHelper.removeQueryStringParam(filterQueryStringParameter, globalThis.location.href);
-                        globalThis.history.replaceState({ path: urlWithoutFilters }, '', urlWithoutFilters);
+                    if (verticalData.clearFiltersOnVerticalChange === true) {
+                        const filtersSourceData = DynamicPropertyHelper.tryGetValueSafe(this._filtersConnectionSourceData);
+                        this._filtersToIgnoreAfterVerticalChange = filtersSourceData?.selectedFilters;
+                        this._lastSelectedFilters = [];
+
+                        if (filtersSourceData?.instanceId) {
+                            const filterQueryStringParameter = `f_${filtersSourceData.instanceId}`;
+                            const urlWithoutFilters = UrlHelper.removeQueryStringParam(filterQueryStringParameter, globalThis.location.href);
+                            globalThis.history.replaceState({ path: urlWithoutFilters }, '', urlWithoutFilters);
+                        }
                     }
                 }
 

--- a/search-parts/src/webparts/searchVerticals/ISearchVerticalsWebPartProps.ts
+++ b/search-parts/src/webparts/searchVerticals/ISearchVerticalsWebPartProps.ts
@@ -19,6 +19,11 @@ export interface ISearchVerticalsWebPartProps extends IBaseWebPartProps {
     defaultVerticalQueryStringParam: string;
 
     /**
+     * Determines whether connected filters are cleared when the selected vertical changes.
+     */
+    clearFiltersOnVerticalChange?: boolean;
+
+    /**
      * Vertical tabs background color
      */
     verticalBackgroundColor?: string;

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.manifest.json
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.manifest.json
@@ -30,7 +30,8 @@
         },
         "officeFabricIconFontName": "Sections",
         "properties": {
-            "documentationLink": "https://microsoft-search.github.io/pnp-modern-search/"
+            "documentationLink": "https://microsoft-search.github.io/pnp-modern-search/",
+            "clearFiltersOnVerticalChange": false
         }
     }]
 }

--- a/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
+++ b/search-parts/src/webparts/searchVerticals/SearchVerticalsWebPart.ts
@@ -7,6 +7,7 @@ import {
     IPropertyPaneField,
     IPropertyPaneGroup,
     PropertyPaneTextField,
+    PropertyPaneToggle,
     PropertyPaneSlider,
     PropertyPaneButton,
     PropertyPaneButtonType
@@ -276,6 +277,7 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
             case ComponentType.SearchVerticals:
                 return {
                     selectedVertical: this._selectedVertical,
+                    clearFiltersOnVerticalChange: this.properties.clearFiltersOnVerticalChange,
                     verticalsConfiguration: this.properties.verticals,
                 } as IDataVerticalSourceData;
 
@@ -523,6 +525,12 @@ export default class DataVerticalsWebPart extends BaseWebPart<ISearchVerticalsWe
                         }
                     }
                 ]
+            }),
+            PropertyPaneToggle('clearFiltersOnVerticalChange', {
+                label: webPartStrings.PropertyPane.Verticals.ClearFiltersOnVerticalChangeLabel,
+                onText: commonStrings.General.OnTextLabel,
+                offText: commonStrings.General.OffTextLabel,
+                checked: this.properties.clearFiltersOnVerticalChange === true
             }),
             PropertyPaneTextField('defaultVerticalQueryStringParam', {
                 label: webPartStrings.PropertyPane.Verticals.DefaultVerticalQueryStringParamLabel,

--- a/search-parts/src/webparts/searchVerticals/loc/cs-cz.js
+++ b/search-parts/src/webparts/searchVerticals/loc/cs-cz.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Konfigurovat vertikály",
           DefaultVerticalQueryStringParamLabel: "Parametr dotazu pro výběr vertikálního panelu jako výchozího",
           DefaultVerticalQueryStringParamDescription: "Porovnání bude provedeno s názvem panelu nebo aktuální URL stránky (pokud je panel hypertextový odkaz)",
+          ClearFiltersOnVerticalChangeLabel: "Vymazat filtry při změně vertikály",
           Fields: {
             TabName: "Název panelu",
             TabValue: "Hodnota panelu",

--- a/search-parts/src/webparts/searchVerticals/loc/da-dk.js
+++ b/search-parts/src/webparts/searchVerticals/loc/da-dk.js
@@ -18,6 +18,7 @@ define([], function() {
         ButtonLabel: "Konfigurér vertikaler",
         DefaultVerticalQueryStringParamLabel: "Query-strengparameter til brug for at vælge en vertikal fane som standard",
         DefaultVerticalQueryStringParamDescription: "Matchningen vil blive udført mod fane-navnet eller den aktuelle side-URL (hvis fanen er et hyperlink)",
+        ClearFiltersOnVerticalChangeLabel: "Ryd filtre ved skift af lodret fane",
         Fields: {
           TabName: "Navn på fane",
           IconName: "Fluent UI ikonnavn",

--- a/search-parts/src/webparts/searchVerticals/loc/de-de.js
+++ b/search-parts/src/webparts/searchVerticals/loc/de-de.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Konfiguriere Vertikale",
           DefaultVerticalQueryStringParamLabel: "Query-String Parameter zur automatischen Auswahl eines Vertikals.",
           DefaultVerticalQueryStringParamDescription: "Der Tab Name oder die derzeitige URL (wenn das Tab ein Hyperlink ist) werden dabei verglichen.",
+          ClearFiltersOnVerticalChangeLabel: "Filter beim Wechsel des Vertikals löschen",
           Fields: {
             TabName: "Tab Name",
             TabValue: "Tab Wert",

--- a/search-parts/src/webparts/searchVerticals/loc/en-us.js
+++ b/search-parts/src/webparts/searchVerticals/loc/en-us.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configure verticals",
           DefaultVerticalQueryStringParamLabel: "Query string parameter to use to select a vertical tab by default",
           DefaultVerticalQueryStringParamDescription: "The match will be done against the tab name or the current page URL (if the tab is an hyperlink)",
+          ClearFiltersOnVerticalChangeLabel: "Clear filters when changing verticals",
           Fields: {
             TabName: "Tab name",
             TabValue: "Tab value",

--- a/search-parts/src/webparts/searchVerticals/loc/es-es.js
+++ b/search-parts/src/webparts/searchVerticals/loc/es-es.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configurar las verticales",
           DefaultVerticalQueryStringParamLabel: "Parámetro de cadena de consulta que se utilizará para seleccionar una pestaña vertical por defecto",
           DefaultVerticalQueryStringParamDescription: "La coincidencia se hará con el nombre de la pestaña o la URL de la página actual (si la pestaña es un hipervínculo)",
+          ClearFiltersOnVerticalChangeLabel: "Borrar filtros al cambiar de vertical",
           Fields: {
             TabName: "Nombre de la pestaña",
             TabValue: "Valor de la pestaña",

--- a/search-parts/src/webparts/searchVerticals/loc/fi-fi.js
+++ b/search-parts/src/webparts/searchVerticals/loc/fi-fi.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Konfiguroi hakuvertikaalit",
           DefaultVerticalQueryStringParamLabel: "URL-osoitteen parametri, jolla määritetään oletuksena valittu vertikaali",
           DefaultVerticalQueryStringParamDescription: "Parametri yhdistetään vertikaalin nimeen tai sivun URL-osoitteeseen, jos vertikaali on linkki",
+          ClearFiltersOnVerticalChangeLabel: "Tyhjennä suodattimet vertikaalia vaihdettaessa",
           Fields: {
             TabName: "Vertikaalin nimi",
             TabValue: "Vertikaalin arvo",

--- a/search-parts/src/webparts/searchVerticals/loc/fr-fr.js
+++ b/search-parts/src/webparts/searchVerticals/loc/fr-fr.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configurer les verticales",
           DefaultVerticalQueryStringParamLabel: "Paramètre de requête à utiliser pour sélectionner un onglet vertical par défaut",
           DefaultVerticalQueryStringParamDescription: "La correspondance sera faite avec le nom de l'onglet ou l'URL de la page actuelle (si l'onglet est un lien hypertexte)",
+          ClearFiltersOnVerticalChangeLabel: "Effacer les filtres lors du changement de verticale",
           Fields: {
             TabName: "Nom de l'onglet",
             TabValue: "Valeur de l'onglet",

--- a/search-parts/src/webparts/searchVerticals/loc/it-it.js
+++ b/search-parts/src/webparts/searchVerticals/loc/it-it.js
@@ -18,6 +18,7 @@ define([], function () {
                 ButtonLabel: "Configura verticali",
                 DefaultVerticalQueryStringParamLabel: "Parametro della stringa di query da utilizzare per selezionare una scheda verticale per impostazione predefinita",
                 DefaultVerticalQueryStringParamDescription: "La corrispondenza verrà fatta con il nome della scheda o l'URL della pagina corrente (se la scheda è un hyperlink)",
+                ClearFiltersOnVerticalChangeLabel: "Cancella i filtri quando si cambia verticale",
                 Fields: {
                     TabName: "Nome scheda",
                     TabValue: "Valore scheda",

--- a/search-parts/src/webparts/searchVerticals/loc/mystrings.d.ts
+++ b/search-parts/src/webparts/searchVerticals/loc/mystrings.d.ts
@@ -17,6 +17,7 @@ declare interface ISearchVerticalsWebPartStrings {
       ButtonLabel: string;
       DefaultVerticalQueryStringParamLabel: string;
       DefaultVerticalQueryStringParamDescription: string;
+      ClearFiltersOnVerticalChangeLabel: string;
       Fields: {
         TabName: string;
         TabValue: string;

--- a/search-parts/src/webparts/searchVerticals/loc/nb-no.js
+++ b/search-parts/src/webparts/searchVerticals/loc/nb-no.js
@@ -18,6 +18,7 @@ define([], function() {
                 ButtonLabel: "Konfigurer vertikaler",
                 DefaultVerticalQueryStringParamLabel: "Spørringsstrengparameter for å velge en vertikal fane som standard",
                 DefaultVerticalQueryStringParamDescription: "Sammenligningen vil bli utført mot fane-navnet eller gjeldende side-URL (hvis fanen er en hyperkobling)",
+                ClearFiltersOnVerticalChangeLabel: "Fjern filtre når vertikal endres",
                 Fields: {
                     TabName: "Fane",
                     IconName: "Fluent UI ikonnavn",

--- a/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
+++ b/search-parts/src/webparts/searchVerticals/loc/nl-nl.js
@@ -18,6 +18,7 @@ define([], function() {
                 ButtonLabel: "Configureer zoekverticalen",
                 DefaultVerticalQueryStringParamLabel: "Querystring-parameter om te gebruiken om standaard een verticale tab te selecteren",
                 DefaultVerticalQueryStringParamDescription: "De overeenkomst wordt gemaakt met de tabnaam of de huidige paginakoppeling (als de tab een hyperlink is)",
+                ClearFiltersOnVerticalChangeLabel: "Filters wissen bij het wijzigen van de verticale tab",
                 Fields: {
                     TabName: "Tab naam",
                     IconName: "Fluent UI icoon naam",

--- a/search-parts/src/webparts/searchVerticals/loc/pl-pl.js
+++ b/search-parts/src/webparts/searchVerticals/loc/pl-pl.js
@@ -18,6 +18,7 @@ define([], function() {
                     ButtonLabel: "Konfiguruj wertykały",
                     DefaultVerticalQueryStringParamLabel: "Parametr ciągu zapytań do użycia do wybrania zakładki wertykalnej domyślnie",
                     DefaultVerticalQueryStringParamDescription: "Dopasowanie zostanie wykonane do nazwy karty lub bieżącego adresu URL strony (jeśli karta jest hiperłączem)",
+                    ClearFiltersOnVerticalChangeLabel: "Wyczyść filtry przy zmianie wertykalnej",
                     Fields: {
                         TabName: "Nazwa karty",
                         IconName: "Nazwa ikony Fluent UI",

--- a/search-parts/src/webparts/searchVerticals/loc/pt-br.js
+++ b/search-parts/src/webparts/searchVerticals/loc/pt-br.js
@@ -18,6 +18,7 @@ define([], function() {
           ButtonLabel: "Configurar verticais",
           DefaultVerticalQueryStringParamLabel: "Parâmetro da <i>query string</i> a ser usado para selecionar a aba da vertical por padrão",
           DefaultVerticalQueryStringParamDescription: "A correspondência será feita com o nome da guia ou a URL da página atual (se a guia for um hiperlink)",
+          ClearFiltersOnVerticalChangeLabel: "Limpar filtros ao alterar a vertical",
           Fields: {
             TabName: "Nome da aba",
             TabValue: "Valor da aba",

--- a/search-parts/src/webparts/searchVerticals/loc/sv-SE.js
+++ b/search-parts/src/webparts/searchVerticals/loc/sv-SE.js
@@ -18,6 +18,7 @@ define([], function() {
                 ButtonLabel: "Konfigurera",
                 DefaultVerticalQueryStringParamLabel: "Frågesträngsparameter att använda för att välja en vertikal flik som standard",
                 DefaultVerticalQueryStringParamDescription: "Matchningen kommer att göras mot fliknamnet eller den aktuella sidans URL (om fliken är en hyperlänk)",
+                ClearFiltersOnVerticalChangeLabel: "Rensa filter när vertikal ändras",
                 Fields: {
                     TabName: "Fliknamn",
                     IconName: "Fluent UI Fabric ikonnamn",


### PR DESCRIPTION
Fixes #3701. The change clears the prior filter snapshot and deep-link parameter on an enabled vertical switch, and adds an opt-in Search Verticals setting that defaults to off for compatibility. The setting is published through dynamic data and honored by Search Results and Search Filters. Refiner display models now build concurrently, and the new setting is translated for all supported Search Verticals locales. Validation: npm run build from search-parts.