### PR TITLE
Allow odopen: links so templates can open files in desktop client apps

### DIFF
--- a/search-parts/src/common/Constants.ts
+++ b/search-parts/src/common/Constants.ts
@@ -18,7 +18,7 @@ export class Constants {
     /**
      * The regular expression to sanitize URIs with DomPurify
      */
-    public static readonly ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|file|tel|callto|msteams|rcapp|im|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
+    public static readonly ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|file|tel|callto|msteams|odopen|rcapp|im|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
 
     /**
      * Page-wide GlobalSettings key holding a monotonically increasing id that is bumped every time a

--- a/search-parts/src/common/Constants.ts
+++ b/search-parts/src/common/Constants.ts
@@ -18,7 +18,7 @@ export class Constants {
     /**
      * The regular expression to sanitize URIs with DomPurify
      */
-    public static readonly ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|file|tel|callto|msteams|odopen|rcapp|im|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
+    public static readonly ALLOWED_URI_REGEXP = /^(?:(?:https?|ftps?|mailto|file|tel|callto|msteams|odopen|rcapp|im|cid|xmpp|xxx|ms-\w+):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i;
 
     /**
      * Page-wide GlobalSettings key holding a monotonically increasing id that is bumped every time a


### PR DESCRIPTION
## Problem
`ALLOWED_URI_REGEXP` doesn't include `odopen`, so the `href` is stripped from
`odopen:` links in result templates and the link is dead. That rules out
handing a result off to its desktop client app — in my case `.eml`/`.msg`
results that need the Outlook client:

```handlebars
{{#contains "['eml','msg']" (slot item @root.slots.FileType)}}
    <a href="odopen://openFile/?fileId={{replace (slot item @root.slots.ItemId) '-' '%2D'}}&siteId=%7B{{replace (slot item @root.slots.SiteId) '-' '%2D'}}%7D&listId=%7B{{replace (slot item @root.slots.ListId) '-' '%2D'}}%7D&userEmail={{replace (replace (getPageContext "user.email") '@' '%40') '.' '%2E'}}&userId={{getPageContext "aadInfo.userId"}}&webUrl={{replace (replace (replace (replace item.SPWebUrl ':' '%3A') '/' '%2F') '.' '%2E') '_' '%5F'}}&fileName={{replace (slot item @root.slots.Title) ' ' '%20'}}%2E{{slot item @root.slots.FileType}}" data-interception="off" title="{{slot item @root.slots.Title}}">{{slot item @root.slots.Title}}</a>
{{else}}
```

`odopen:` is the protocol SharePoint itself uses for "Open in app".

## Solution
Added `odopen` to `Constants.ALLOWED_URI,
`callto` and `rcapp`. One scheme added; `javascript:` and `data:` still blocked.