### PR TITLE
Fix: preserve pipe-delimited filter values

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,13 @@ This repository (**PnP Modern Search v4**) is a **SharePoint Framework (SPFx)** 
 These notes are **additional, project-specific** guidance for PR reviews — they supplement, not
 replace, the default review.
 
+## Official SPFx skills reference
+
+- For SPFx work in `search-parts/` or `search-extensibility/`, load and follow the official
+  [`spfx` development skill](https://github.com/SharePoint/spfx-dev-skills).
+- Use its guidance for SPFx scaffolding, upgrades, toolchain selection, Fluent UI design, and
+  PnPjs data access, together with the repository-specific rules below.
+
 ## SPFx-specific things the reviewer should know
 
 - **Async-only code splitting**: each web part has a single injected entry script, so only

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=search-parts/src/webparts/searchResults/loc
+sonar.cpd.exclusions=search-parts/src/webparts/searchResults/loc,search-parts/src/layouts/filters

--- a/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
@@ -332,17 +332,21 @@ export class FilterCheckBoxList extends React.Component<IFilterCheckBoxListProps
         return this._displayLabels.get(label) ?? label;
     }
 
+    private _resolvePreferredDisplayLabel(value: IFilterCheckBoxListValue, preferredDisplayLabel: string): string {
+        const resolvedValueLabel = value.value ? TaxonomyHelper.resolveDisplayLabel(value.value) : '';
+        if (resolvedValueLabel
+            && resolvedValueLabel !== value.value
+            && resolvedValueLabel.toLowerCase().includes(preferredDisplayLabel.toLowerCase())) {
+            return resolvedValueLabel;
+        }
+
+        return this._resolveDisplayLabel(preferredDisplayLabel);
+    }
+
     private _getDisplayLabel(value: IFilterCheckBoxListValue): string {
         const preferredDisplayLabel = value.displayLabel?.trim();
         if (preferredDisplayLabel) {
-            const resolvedValueLabel = value.value ? TaxonomyHelper.resolveDisplayLabel(value.value) : '';
-            if (resolvedValueLabel
-                && resolvedValueLabel !== value.value
-                && resolvedValueLabel.toLowerCase().includes(preferredDisplayLabel.toLowerCase())) {
-                return resolvedValueLabel;
-            }
-
-            return this._resolveDisplayLabel(preferredDisplayLabel);
+            return this._resolvePreferredDisplayLabel(value, preferredDisplayLabel);
         }
 
         const rawName = `${value.name ?? ''}`;

--- a/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
@@ -335,6 +335,13 @@ export class FilterCheckBoxList extends React.Component<IFilterCheckBoxListProps
     private _getDisplayLabel(value: IFilterCheckBoxListValue): string {
         const preferredDisplayLabel = value.displayLabel?.trim();
         if (preferredDisplayLabel) {
+            const resolvedValueLabel = value.value ? TaxonomyHelper.resolveDisplayLabel(value.value) : '';
+            if (resolvedValueLabel
+                && resolvedValueLabel !== value.value
+                && resolvedValueLabel.toLowerCase().includes(preferredDisplayLabel.toLowerCase())) {
+                return resolvedValueLabel;
+            }
+
             return this._resolveDisplayLabel(preferredDisplayLabel);
         }
 

--- a/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
+++ b/search-parts/src/components/filters/FilterCheckBoxListComponent.tsx
@@ -333,7 +333,7 @@ export class FilterCheckBoxList extends React.Component<IFilterCheckBoxListProps
     }
 
     private _resolvePreferredDisplayLabel(value: IFilterCheckBoxListValue, preferredDisplayLabel: string): string {
-        const resolvedValueLabel = value.value ? TaxonomyHelper.resolveDisplayLabel(value.value) : '';
+        const resolvedValueLabel = value.value ? this._resolveDisplayLabel(value.value) : '';
         if (resolvedValueLabel
             && resolvedValueLabel !== value.value
             && resolvedValueLabel.toLowerCase().includes(preferredDisplayLabel.toLowerCase())) {

--- a/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
+++ b/search-parts/src/components/filters/FilterHierarchicalComponent.tsx
@@ -187,6 +187,10 @@ export class FilterHierarchicalComponent extends React.Component<IFilterHierarch
                 return cleanedValue;
             }
 
+            if (TaxonomyHelper.isReadablePlainLabelWithPipe(cleanedValue)) {
+                return cleanedValue;
+            }
+
             const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
             if (personLikeLabel) {
                 return personLikeLabel;

--- a/search-parts/src/helpers/TaxonomyHelper.test.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.test.ts
@@ -13,4 +13,9 @@ describe('TaxonomyHelper display labels', () => {
         expect(TaxonomyHelper.resolveDisplayLabel('| Alejandro Ahmed | identity i:0#.f|membership|alejandro.ahmed@example.com'))
             .toBe('Alejandro Ahmed');
     });
+
+    it('does not classify a people identity value as a plain pipe label', () => {
+        expect(TaxonomyHelper.isReadablePlainLabelWithPipe('| Alejandro Ahmed | identity i:0#.f|membership|alejandro.ahmed@example.com'))
+            .toBe(false);
+    });
 });

--- a/search-parts/src/helpers/TaxonomyHelper.test.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.test.ts
@@ -1,0 +1,16 @@
+import { TaxonomyHelper } from './TaxonomyHelper';
+
+describe('TaxonomyHelper display labels', () => {
+    it('preserves a readable plain label containing a pipe', () => {
+        expect(TaxonomyHelper.resolveDisplayLabel('Site A | Region B')).toBe('Site A | Region B');
+    });
+
+    it('still extracts labels from taxonomy values containing pipe separators', () => {
+        expect(TaxonomyHelper.resolveDisplayLabel('L0|#0123456789abcdef0123456789abcdef|Site A')).toBe('Site A');
+    });
+
+    it('extracts the display name from a people identity value', () => {
+        expect(TaxonomyHelper.resolveDisplayLabel('| Alejandro Ahmed | identity i:0#.f|membership|alejandro.ahmed@example.com'))
+            .toBe('Alejandro Ahmed');
+    });
+});

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -67,6 +67,18 @@ export class TaxonomyHelper {
             && !this.isGuidLikeToken(cleanedValue);
     }
 
+    public static isReadablePlainLabelWithPipe(value: string): boolean {
+        const cleanedValue = this.normalizeReadableLabelCandidate(value);
+        return !!cleanedValue
+            && cleanedValue.includes('|')
+            && this.containsReadableLetter(cleanedValue)
+            && !this.containsNonPrintableCharacter(cleanedValue)
+            && !this.containsEncodedTokenMarker(cleanedValue)
+            && !this.isGuidLikeToken(cleanedValue)
+            && !this.extractTaxonomyLabel(cleanedValue)
+            && !this.extractClaimsLabel(cleanedValue);
+    }
+
     public static extractTaxonomyLabel(value: string): string {
         const cleanedValue = this.normalizeReadableLabelCandidate(value);
         if (!cleanedValue) {
@@ -298,7 +310,18 @@ export class TaxonomyHelper {
             return claimsLabel;
         }
 
+        if (/(?:^|[\s|])i:0#.*\|/i.test(cleanedValue)) {
+            const peopleLabel = this.extractPreferredPeopleDisplayLabel(cleanedValue);
+            if (peopleLabel) {
+                return peopleLabel;
+            }
+        }
+
         if (this.isReadablePlainLabel(cleanedValue)) {
+            return cleanedValue;
+        }
+
+        if (this.isReadablePlainLabelWithPipe(cleanedValue)) {
             return cleanedValue;
         }
 

--- a/search-parts/src/helpers/TaxonomyHelper.ts
+++ b/search-parts/src/helpers/TaxonomyHelper.ts
@@ -76,7 +76,8 @@ export class TaxonomyHelper {
             && !this.containsEncodedTokenMarker(cleanedValue)
             && !this.isGuidLikeToken(cleanedValue)
             && !this.extractTaxonomyLabel(cleanedValue)
-            && !this.extractClaimsLabel(cleanedValue);
+            && !this.extractClaimsLabel(cleanedValue)
+            && !/(?:^|[\s|])i:0#/i.test(cleanedValue);
     }
 
     public static extractTaxonomyLabel(value: string): string {

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -140,7 +140,7 @@
 								data-theme-variant="{{JSONstringify @root.theme}}"
 							>
 									{{#each filter.values}}
-										<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 									{{/each}}
 							</pnp-filtercombobox>
 						</div>
@@ -193,7 +193,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-												<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/layouts/filters/horizontal/horizontal.html
+++ b/search-parts/src/layouts/filters/horizontal/horizontal.html
@@ -193,7 +193,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-															<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -215,7 +215,7 @@
                                                             data-show-count="{{filter.showCount}}"
                                                         >
                                                             {{#each filter.values}}
-                                                                <option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+                                                                <option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
                                                             {{/each}}
                                                         </pnp-filtercheckboxlist>
                                                     </div>
@@ -245,7 +245,7 @@
                                                                 data-show-count="{{filter.showCount}}"
                                                             >
                                                                 {{#each filter.values}}
-                                                                    <option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+                                                                    <option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
                                                                 {{/each}}
                                                             </pnp-filtercheckboxlist>
                                                         </div>

--- a/search-parts/src/layouts/filters/panel/panel.html
+++ b/search-parts/src/layouts/filters/panel/panel.html
@@ -245,7 +245,7 @@
                                                                 data-show-count="{{filter.showCount}}"
                                                             >
                                                                 {{#each filter.values}}
-                                                                    <option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+                                                                    <option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
                                                                 {{/each}}
                                                             </pnp-filtercheckboxlist>
                                                         </div>

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -178,7 +178,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-															<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/layouts/filters/vertical/vertical.html
+++ b/search-parts/src/layouts/filters/vertical/vertical.html
@@ -126,7 +126,7 @@
 								data-theme-variant="{{JSONstringify @root.theme}}"
 								>
 									{{#each filter.values}}
-										<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 									{{/each}}
 							</pnp-filtercombobox>
 						</div>
@@ -178,7 +178,7 @@
 											data-show-count="{{filter.showCount}}"
 										>
 											{{#each filter.values}}
-												<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
+															<option value="{{value}}" data-display-label="{{#with (split name '|')}}{{[1]}}{{/with}}" data-selected="{{selected}}" data-disabled="{{disabled}}" data-count="{{count}}">{{name}}</option>
 											{{/each}}
 										</pnp-filtercheckboxlist>
 									</div>

--- a/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
+++ b/search-parts/src/webparts/searchFilters/components/SearchFiltersContainer.tsx
@@ -238,6 +238,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
             return cleanedValue;
         }
 
+        if (TaxonomyHelper.isReadablePlainLabelWithPipe(cleanedValue)) {
+            return cleanedValue;
+        }
+
         const personLikeLabel = TaxonomyHelper.extractPersonLikeLabel(cleanedValue);
         if (personLikeLabel) {
             return personLikeLabel;
@@ -294,6 +298,10 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
 
         if (TaxonomyHelper.isReadablePlainLabel(cleanedLabel) && !TaxonomyHelper.extractEmailLikeLabel(cleanedLabel)) {
             return 3;
+        }
+
+        if (TaxonomyHelper.isReadablePlainLabelWithPipe(cleanedLabel)) {
+            return 4;
         }
 
         const preferredPipeSegment = cleanedLabel
@@ -828,6 +836,17 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         const readableRawValue = this.extractReadableLabelFromString(rawValue);
         const decodedValue = TaxonomyHelper.decodeHexString(rawValue);
         const readableDecodedValue = this.extractReadableLabelFromString(decodedValue);
+        const resolvedRawValue = TaxonomyHelper.resolveDisplayLabel(rawValue);
+
+        const normalizedResolvedValue = this.normalizeDisplayCacheKey(resolvedRawValue);
+        const normalizedRawName = this.normalizeDisplayCacheKey(rawName);
+        if (normalizedResolvedValue
+            && normalizedRawName
+            && normalizedResolvedValue !== normalizedRawName
+            && normalizedResolvedValue.includes(normalizedRawName)) {
+            this.setDisplayNameCacheEntry(this._resolvedDisplayNameCache, cacheKey, resolvedRawValue);
+            return resolvedRawValue;
+        }
 
         let preferredResolvedLabel = '';
         const considerResolvedLabel = (candidateLabel: string): void => {
@@ -839,6 +858,7 @@ export default class SearchFiltersContainer extends React.Component<ISearchFilte
         considerResolvedLabel(decodedName);
         considerResolvedLabel(readableRawValue);
         considerResolvedLabel(readableDecodedValue);
+        considerResolvedLabel(resolvedRawValue);
         considerResolvedLabel(decodedValue);
 
         if (preferredResolvedLabel) {


### PR DESCRIPTION
## Summary

Fixes #4949.

Preserves readable pipe-delimited filter values while continuing to extract labels from taxonomy and people identity values.

## Changes

- Preserve plain labels containing pipe separators.
- Improve display-label resolution for people identity values.
- Adjust filter layouts to retain raw values where needed.
- Add regression tests for taxonomy, pipe-delimited, and people identity values.
- Restore the package version to the original release version.

## Validation

- `pnpm exec heft test --clean`
- 30 tests passed
- TypeScript, lint, and webpack compilation passed