### PR TITLE
Fix filter controls on dark section backgrounds

### DIFF
--- a/search-parts/src/components/filters/FilterComboBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterComboBoxComponent.tsx
@@ -182,7 +182,11 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                                             <ComboBox 
                                                 theme={theme}
                                                 calloutProps={{
-                                                    backgroundColor: surfaceColor
+                                                    styles: {
+                                                        calloutMain: {
+                                                            backgroundColor: surfaceColor
+                                                        }
+                                                    }
                                                 }}
                                                 comboBoxOptionStyles={{
                                                     root: {
@@ -252,7 +256,7 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                                     theme={theme}
                                     styles={{
                                         root: {
-                                            color: '#ffffff',
+                                            color: textColor,
                                             cursor: 'pointer'
                                         }
                                     }}

--- a/search-parts/src/components/filters/FilterComboBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterComboBoxComponent.tsx
@@ -147,8 +147,8 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
 
         let options = this.state.options;
         const theme = (this.props.themeVariant as ITheme) || getTheme();
-        const surfaceColor = this.props.themeVariant?.semanticColors?.bodyBackground ?? '#ffffff';
-        const textColor = this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
+        const surfaceColor = theme.semanticColors.bodyBackground ?? '#ffffff';
+        const textColor = theme.semanticColors.inputText ?? '#323130';
 
         let foundValuesCount = 0;
         // Filter the current collection by the search value
@@ -260,6 +260,9 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                                             cursor: 'pointer'
                                         }
                                     }}
+                                    role='button'
+                                    tabIndex={0}
+                                    aria-label={strings.Filters.ClearAllFiltersButtonLabel}
                                     onClick={() => {
                                         
                                         if (!this.props.isMulti) {
@@ -276,6 +279,12 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                                             }
                                         } else {
                                             this._clearFilters();
+                                        }
+                                    }}
+                                    onKeyDown={(event) => {
+                                        if (event.key === 'Enter' || event.key === ' ') {
+                                            event.preventDefault();
+                                            (event.currentTarget as HTMLElement).click();
                                         }
                                     }}>
                                 </Icon>

--- a/search-parts/src/components/filters/FilterComboBoxComponent.tsx
+++ b/search-parts/src/components/filters/FilterComboBoxComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseWebComponent, IDataFilterValueInfo, ExtensibilityConstants, IDataFilterInfo, FilterConditionOperator } from '@pnp/modern-search-extensibility';
 import * as ReactDOM from 'react-dom';
-import { IComboBoxOption, Label, Icon, SelectableOptionMenuItemType, ComboBox, IComboBox, Fabric } from '@fluentui/react';
+import { IComboBoxOption, Label, Icon, SelectableOptionMenuItemType, ComboBox, IComboBox, Fabric, ITheme, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import update from 'immutability-helper';
 import styles from './FilterComboBoxComponent.module.scss';
@@ -146,6 +146,9 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
     public render() {
 
         let options = this.state.options;
+        const theme = (this.props.themeVariant as ITheme) || getTheme();
+        const surfaceColor = this.props.themeVariant?.semanticColors?.bodyBackground ?? '#ffffff';
+        const textColor = this.props.themeVariant?.semanticColors?.inputText ?? '#323130';
 
         let foundValuesCount = 0;
         // Filter the current collection by the search value
@@ -175,8 +178,25 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
         }
 
         let renderIcon: JSX.Element = null;
-        let renderCombo: JSX.Element =  <Fabric>
+        let renderCombo: JSX.Element =  <Fabric theme={theme}>
                                             <ComboBox 
+                                                theme={theme}
+                                                calloutProps={{
+                                                    backgroundColor: surfaceColor
+                                                }}
+                                                comboBoxOptionStyles={{
+                                                    root: {
+                                                        backgroundColor: surfaceColor,
+                                                        color: theme.semanticColors.bodyText
+                                                    },
+                                                    rootHovered: {
+                                                        backgroundColor: theme.semanticColors.listItemBackgroundHovered,
+                                                        color: theme.semanticColors.bodyText
+                                                    },
+                                                    optionText: {
+                                                        color: theme.semanticColors.bodyText
+                                                    }
+                                                }}
                                                 allowFreeform={true}
                                                 text={this.state.searchValue ? this.state.searchValue : this.props.defaultOptions.filter(option => option.selected).map(option => option.text).join(',')}
                                                 componentRef={this.comboRef}
@@ -206,10 +226,13 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
                                                         width: '90%'
                                                     },
                                                     optionsContainerWrapper: {
-                                                        overflow: 'hidden'
+                                                        overflow: 'hidden',
+                                                        backgroundColor: surfaceColor,
+                                                        color: theme.semanticColors.bodyText
                                                     },
                                                     input: {
-                                                        backgroundColor: 'inherit'
+                                                        backgroundColor: 'inherit',
+                                                        color: textColor
                                                     },
                                                     header:{
                                                         height: '100%'
@@ -226,6 +249,13 @@ export class FilterComboBox extends React.Component<IFilterComboBoxProps, IFilte
             renderIcon =    <Label>
                                 <Icon
                                     iconName='ClearFilter' 
+                                    theme={theme}
+                                    styles={{
+                                        root: {
+                                            color: '#ffffff',
+                                            cursor: 'pointer'
+                                        }
+                                    }}
                                     onClick={() => {
                                         
                                         if (!this.props.isMulti) {

--- a/search-parts/src/components/filters/FilterMultiComponent.tsx
+++ b/search-parts/src/components/filters/FilterMultiComponent.tsx
@@ -69,18 +69,34 @@ export class FilterMulti extends React.Component<IFilterMultiProps, IFilterMulti
     }
 
     public render() {
+        const theme = (this.props.themeVariant as ITheme) || getTheme();
+
         return <div className={styles.filterMultiActions}>
             <PrimaryButton
                 className={styles.applyBtn}
                 disabled={this.props.applyDisabled}
-                theme={(this.props.themeVariant as ITheme) || getTheme()}
+                theme={theme}
+                styles={{
+                    root: {
+                        backgroundColor: theme.semanticColors.primaryButtonBackground,
+                        borderColor: theme.semanticColors.primaryButtonBackground,
+                        color: theme.semanticColors.primaryButtonText
+                    }
+                }}
                 onClick={this._applyFilters}>
                 {strings.Filters.ApplyAllFiltersButtonLabel}
             </PrimaryButton>
             <DefaultButton
                 className={styles.clearBtn}
-                theme={(this.props.themeVariant as ITheme) || getTheme()}
+                theme={theme}
                 disabled={this.props.clearDisabled}
+                styles={{
+                    root: {
+                        backgroundColor: theme.semanticColors.buttonBackground,
+                        borderColor: theme.semanticColors.buttonBorder,
+                        color: theme.semanticColors.buttonText
+                    }
+                }}
                 onClick={this._clearFilters}>
                 {strings.Filters.ClearAllFiltersButtonLabel}
             </DefaultButton>

--- a/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
+++ b/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
@@ -65,9 +65,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
     
     public render() {
         const theme = (this.props.themeVariant as ITheme) || getTheme();
-        const textColor = this.props.themeVariant?.isInverted
-            ? this.props.themeVariant?.semanticColors?.bodyText ?? '#ffffff'
-            : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130';
+        const textColor = theme.semanticColors.bodyText ?? '#323130';
 
         let renderOperators: JSX.Element =  <ChoiceGroup tabIndex={0}
                                                 theme={theme}
@@ -98,7 +96,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                             },
                                                             'label.is-checked span.ms-ChoiceFieldLabel, label.is-checked:hover, label.is-checked span.ms-ChoiceFieldLabel:hover': {
                                                                 fontWeight: 700,
-                                                                color: this.props.themeVariant ? this.props.themeVariant.palette.themePrimary : '#005a9e'
+                                                                color: theme.palette.themePrimary
                                                             },
                                                             'label span.ms-ChoiceFieldLabel, label span.ms-ChoiceFieldLabel:hover': {
                                                                 color: textColor

--- a/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
+++ b/search-parts/src/components/filters/FilterValueOperatorComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { BaseWebComponent, ExtensibilityConstants, FilterConditionOperator } from "@pnp/modern-search-extensibility";
 import * as ReactDOM from "react-dom";
-import { ChoiceGroup, Icon } from '@fluentui/react';
+import { ChoiceGroup, Icon, ITheme, getTheme } from '@fluentui/react';
 import { IReadonlyTheme } from '@microsoft/sp-component-base';
 import * as commonStrings from 'CommonStrings';
 import styles from "./FilterValueOperatorComponent.module.scss";
@@ -64,8 +64,13 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
     }
     
     public render() {
+        const theme = (this.props.themeVariant as ITheme) || getTheme();
+        const textColor = this.props.themeVariant?.isInverted
+            ? this.props.themeVariant?.semanticColors?.bodyText ?? '#ffffff'
+            : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130';
 
         let renderOperators: JSX.Element =  <ChoiceGroup tabIndex={0}
+                                                theme={theme}
                                                 styles={{
                                                     flexContainer: {
                                                         display: 'flex',
@@ -83,7 +88,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                             '.ms-ChoiceField + .ms-ChoiceField::before': {
                                                                 content: '"/"',
                                                                 padding: '0 4px',
-                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
+                                                                color: textColor
                                                             },
                                                             'label::before, label::after': {
                                                                 display: 'none',
@@ -96,7 +101,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                                                 color: this.props.themeVariant ? this.props.themeVariant.palette.themePrimary : '#005a9e'
                                                             },
                                                             'label span.ms-ChoiceFieldLabel, label span.ms-ChoiceFieldLabel:hover': {
-                                                                color: this.props.themeVariant?.isInverted ? '#fff' : this.props.themeVariant?.semanticColors?.bodyText ?? '#323130'
+                                                                color: textColor
                                                             }
                                                         }
                                                     }
@@ -121,7 +126,7 @@ export class FilterValueOperator extends React.Component<IFilterValueOperatorPro
                                             />;
 
         return  <div className={styles.filterValueOperator}>
-                    <Icon iconName="FilterSettings" title={commonStrings.Filters.UseValuesOperators}/>
+                    <Icon iconName="FilterSettings" title={commonStrings.Filters.UseValuesOperators} styles={{ root: { color: textColor } }}/>
                     {renderOperators}
                 </div>;
     }


### PR DESCRIPTION
## Summary
- apply SharePoint/Fluent theme styling to ComboBox menus and filter controls
- preserve the section background for the main ComboBox input
- improve dropdown option contrast and clear-filter icon visibility on dark backgrounds

## Validation
- 
px heft test --clean --production
- 31 Jest tests passed

Fixes #4929